### PR TITLE
chore(mise): update setup completion message

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -57,5 +57,5 @@ depends = [
   "//:pnpm-install",
   "//:go-install",
 ]
-run = "echo '✓ Setup complete! Next: Copy config.toml.example to config.toml and configure, then run: mise run dev:web'"
+run = "echo '✓ Setup complete! Next: Copy config.toml.example to config.toml and configure, then run: mise run dev'"
 


### PR DESCRIPTION
## Summary
Fixes a misleading hint in the `mise` setup task.

## Changes
- Updated the success message of the `setup` task in `mise.toml` to recommend running `mise run dev` (the full environment) instead of the non-existent `dev:web` command.