### PR TITLE
fix(web): configure development proxy and update port documentation

### DIFF
--- a/docs/docs/guide/configuration.md
+++ b/docs/docs/guide/configuration.md
@@ -13,7 +13,7 @@
 
 - `QDRANT_URL` - Qdrant 连接字符串（默认：http://localhost:6333）
 - `REDIS_URL` - Redis 连接字符串（默认：redis://localhost:6379）
-- `API_PORT` - API 服务端口（默认：7002）
+- `API_PORT` - API 服务端口（默认：8080）
 
 ## 模型配置
 

--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -71,7 +71,7 @@ pnpm run db:push
 pnpm run api:dev
 ```
 
-API 服务将在 `http://localhost:7002` 启动。
+API 服务将在 `http://localhost:8080` 启动。
 
 ## 下一步
 

--- a/packages/web/src/utils/request.ts
+++ b/packages/web/src/utils/request.ts
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 const router=useRouter()
 export default (function () {
   const axiosInstance = axios.create({
-    baseURL:'http://localhost:7002/'
+    baseURL: '/api'
   })
 
   axiosInstance.interceptors.response.use((response) => {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -16,10 +16,24 @@ export default defineConfig({
   server: {
     port,
     host: '0.0.0.0',
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, "")
+      }
+    },
   },
   preview: {
     port,
     host: '0.0.0.0',
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, "")
+      }
+    },
     allowedHosts: true,
   },
   resolve: {


### PR DESCRIPTION
## Summary
Fixes the issue where the frontend was unable to communicate with the backend during development due to port mismatch and CORS restrictions.

## Changes
- **Vite Proxy**: Configured a proxy in `vite.config.ts` to forward `/api` requests to `http://localhost:8080`. This resolves CORS issues in the development environment without adding CORS middleware to the Go backend.
- **Request Utility**: Updated `request.ts` to use the relative `/api` path as the base URL.
- **Documentation**: Updated `getting-started.md` and `configuration.md` to reflect the actual default API port (8080) instead of the outdated 7002.