### PR TITLE
fix: password placeholder

### DIFF
--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -142,10 +142,7 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Get
 		baseURL = *req.BaseURL
 	}
 
-	apiKey := existing.ApiKey
-	if req.APIKey != nil {
-		apiKey = *req.APIKey
-	}
+	apiKey := resolveUpdatedAPIKey(existing.ApiKey, req.APIKey)
 
 	metadata := existing.Metadata
 	if req.Metadata != nil {
@@ -252,4 +249,16 @@ func maskAPIKey(apiKey string) string {
 		return strings.Repeat("*", len(apiKey))
 	}
 	return apiKey[:8] + strings.Repeat("*", len(apiKey)-8)
+}
+
+// resolveUpdatedAPIKey keeps the original key when the request value matches the masked version.
+// This prevents masked placeholder values from overwriting the real stored credential.
+func resolveUpdatedAPIKey(existing string, updated *string) string {
+	if updated == nil {
+		return existing
+	}
+	if *updated == maskAPIKey(existing) {
+		return existing
+	}
+	return *updated
 }

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1,0 +1,40 @@
+package providers
+
+import "testing"
+
+func TestResolveUpdatedAPIKey(t *testing.T) {
+	t.Parallel()
+
+	existing := "sk-1234567890abcdef"
+	masked := maskAPIKey(existing)
+
+	t.Run("nil update keeps existing", func(t *testing.T) {
+		t.Parallel()
+		if got := resolveUpdatedAPIKey(existing, nil); got != existing {
+			t.Fatalf("expected existing key, got %q", got)
+		}
+	})
+
+	t.Run("masked update keeps existing", func(t *testing.T) {
+		t.Parallel()
+		if got := resolveUpdatedAPIKey(existing, &masked); got != existing {
+			t.Fatalf("expected existing key, got %q", got)
+		}
+	})
+
+	t.Run("new key replaces existing", func(t *testing.T) {
+		t.Parallel()
+		next := "sk-new-secret"
+		if got := resolveUpdatedAPIKey(existing, &next); got != next {
+			t.Fatalf("expected new key, got %q", got)
+		}
+	})
+
+	t.Run("empty update clears key", func(t *testing.T) {
+		t.Parallel()
+		empty := ""
+		if got := resolveUpdatedAPIKey(existing, &empty); got != empty {
+			t.Fatalf("expected empty key, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
这个 PR 修复了 Provider 配置页的一个数据覆盖问题。此前在 WebUI 里只修改其他字段并保存时，masked 的 API Key（***）也会被提交，导致后端把真实 Key 覆盖掉

修复后：只有用户明确输入新 API Key 时才更新；未修改 API Key 时不会回传masked 值。这样可保证更新其他配置时，已有 API Key 不会丢失