### PR TITLE
improvement(mcp): make CNI binary & data path configurable

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -28,6 +28,8 @@ image = "docker.io/library/memoh-mcp:dev"
 snapshotter = "overlayfs"
 data_root = "data"
 data_mount = "/data"
+cni_bin_dir = "/opt/cni/bin"
+cni_conf_dir = "/etc/cni/net.d"
 
 ## Postgres configuration
 [postgres]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ const (
 	DefaultMCPImage         = "docker.io/library/memoh-mcp:latest"
 	DefaultDataRoot         = "data"
 	DefaultDataMount        = "/data"
+	DefaultCNIBinaryDir    = "/opt/cni/bin"
+	DefaultCNIConfigDir    = "/etc/cni/net.d"
 	DefaultJWTExpiresIn     = "24h"
 	DefaultPGHost           = "127.0.0.1"
 	DefaultPGPort           = 5432
@@ -63,10 +65,12 @@ type ContainerdConfig struct {
 }
 
 type MCPConfig struct {
-	Image       string `toml:"image"`
-	Snapshotter string `toml:"snapshotter"`
-	DataRoot    string `toml:"data_root"`
-	DataMount   string `toml:"data_mount"`
+	Image        string `toml:"image"`
+	Snapshotter  string `toml:"snapshotter"`
+	DataRoot     string `toml:"data_root"`
+	DataMount    string `toml:"data_mount"`
+	CNIBinaryDir string `toml:"cni_bin_dir"`
+	CNIConfigDir string `toml:"cni_conf_dir"`
 }
 
 type PostgresConfig struct {
@@ -124,9 +128,11 @@ func Load(path string) (Config, error) {
 			Namespace:  DefaultNamespace,
 		},
 		MCP: MCPConfig{
-			Image:     DefaultMCPImage,
-			DataRoot:  DefaultDataRoot,
-			DataMount: DefaultDataMount,
+			Image:        DefaultMCPImage,
+			DataRoot:     DefaultDataRoot,
+			DataMount:    DefaultDataMount,
+			CNIBinaryDir: DefaultCNIBinaryDir,
+			CNIConfigDir: DefaultCNIConfigDir,
 		},
 		Postgres: PostgresConfig{
 			Host:     DefaultPGHost,

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -174,7 +174,7 @@ func (m *Manager) Start(ctx context.Context, botID string) error {
 	if err != nil {
 		return err
 	}
-	if err := ctr.SetupNetwork(ctx, task, m.containerID(botID)); err != nil {
+	if err := ctr.SetupNetwork(ctx, task, m.containerID(botID), m.cfg.CNIBinaryDir, m.cfg.CNIConfigDir); err != nil {
 		if stopErr := m.service.StopTask(ctx, m.containerID(botID), &ctr.StopTaskOptions{Force: true}); stopErr != nil {
 			m.logger.Warn("cleanup: stop task failed", slog.String("container_id", m.containerID(botID)), slog.Any("error", stopErr))
 		}
@@ -199,7 +199,7 @@ func (m *Manager) Delete(ctx context.Context, botID string) error {
 	}
 
 	if task, taskErr := m.service.GetTask(ctx, m.containerID(botID)); taskErr == nil {
-		if err := ctr.RemoveNetwork(ctx, task, m.containerID(botID)); err != nil {
+		if err := ctr.RemoveNetwork(ctx, task, m.containerID(botID), m.cfg.CNIBinaryDir, m.cfg.CNIConfigDir); err != nil {
 			m.logger.Warn("cleanup: remove network failed", slog.String("container_id", m.containerID(botID)), slog.Any("error", err))
 		}
 	}


### PR DESCRIPTION
In some situations without Docker, CNI may be installed outside of `/opt/cni/bin` so hardcoded paths will no longer work.

Added two config fields: `mcp.cni_bin_dir` and `mcp.cni_conf_dir`.