### PR TITLE
fix: skill normalize

### DIFF
--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -236,12 +236,11 @@ func (r *Resolver) resolve(ctx context.Context, req conversation.ChatRequest) (r
 		} else {
 			usableSkills = make([]gatewaySkill, 0, len(entries))
 			for _, e := range entries {
-				usableSkills = append(usableSkills, gatewaySkill{
-					Name:        e.Name,
-					Description: e.Description,
-					Content:     e.Content,
-					Metadata:    e.Metadata,
-				})
+				skill, ok := normalizeGatewaySkill(e)
+				if !ok {
+					continue
+				}
+				usableSkills = append(usableSkills, skill)
 			}
 		}
 	}
@@ -1097,6 +1096,27 @@ func sanitizeMessages(messages []conversation.ModelMessage) []conversation.Model
 		cleaned = append(cleaned, msg)
 	}
 	return cleaned
+}
+
+func normalizeGatewaySkill(entry SkillEntry) (gatewaySkill, bool) {
+	name := strings.TrimSpace(entry.Name)
+	if name == "" {
+		return gatewaySkill{}, false
+	}
+	description := strings.TrimSpace(entry.Description)
+	if description == "" {
+		description = name
+	}
+	content := strings.TrimSpace(entry.Content)
+	if content == "" {
+		content = description
+	}
+	return gatewaySkill{
+		Name:        name,
+		Description: description,
+		Content:     content,
+		Metadata:    entry.Metadata,
+	}, true
 }
 
 func dedup(items []string) []string {

--- a/internal/conversation/flow/resolver_skills_test.go
+++ b/internal/conversation/flow/resolver_skills_test.go
@@ -1,0 +1,32 @@
+package flow
+
+import "testing"
+
+func TestNormalizeGatewaySkill_Fallbacks(t *testing.T) {
+	got, ok := normalizeGatewaySkill(SkillEntry{
+		Name: "  demo-skill  ",
+	})
+	if !ok {
+		t.Fatal("expected valid skill")
+	}
+	if got.Name != "demo-skill" {
+		t.Fatalf("expected trimmed name demo-skill, got %q", got.Name)
+	}
+	if got.Description != "demo-skill" {
+		t.Fatalf("expected description fallback to name, got %q", got.Description)
+	}
+	if got.Content != "demo-skill" {
+		t.Fatalf("expected content fallback to description, got %q", got.Content)
+	}
+}
+
+func TestNormalizeGatewaySkill_RejectsEmptyName(t *testing.T) {
+	_, ok := normalizeGatewaySkill(SkillEntry{
+		Name:        "   ",
+		Description: "desc",
+		Content:     "content",
+	})
+	if ok {
+		t.Fatal("expected invalid skill when name is empty")
+	}
+}

--- a/internal/handlers/skills_test.go
+++ b/internal/handlers/skills_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import "testing"
+
+func TestParseSkillFile_NoFrontmatterFallbacks(t *testing.T) {
+	raw := "# Use this skill\n\nDo something useful."
+	got := parseSkillFile(raw, "plain-skill")
+
+	if got.Name != "plain-skill" {
+		t.Fatalf("expected name plain-skill, got %q", got.Name)
+	}
+	if got.Description != "plain-skill" {
+		t.Fatalf("expected description plain-skill, got %q", got.Description)
+	}
+	if got.Content != raw {
+		t.Fatalf("expected content to keep original markdown, got %q", got.Content)
+	}
+}
+
+func TestParseSkillFile_FrontmatterDescriptionFallback(t *testing.T) {
+	raw := "---\nname: hello-skill\n---\n\nBody content"
+	got := parseSkillFile(raw, "fallback")
+
+	if got.Name != "hello-skill" {
+		t.Fatalf("expected frontmatter name hello-skill, got %q", got.Name)
+	}
+	if got.Description != "hello-skill" {
+		t.Fatalf("expected description fallback to name, got %q", got.Description)
+	}
+	if got.Content != "Body content" {
+		t.Fatalf("expected content Body content, got %q", got.Content)
+	}
+}
+
+func TestParseSkillFile_EmptyBodyFallbacksToDescription(t *testing.T) {
+	raw := "---\nname: hello-skill\ndescription: say hello\n---\n"
+	got := parseSkillFile(raw, "fallback")
+
+	if got.Content != "say hello" {
+		t.Fatalf("expected content fallback to description, got %q", got.Content)
+	}
+}


### PR DESCRIPTION
这个 PR 修复了 Skill 加载链路的一个兼容性问题。此前当 agent 生成的 SKILL.md 缺少标准 frontmatter 或 description 时，会触发 usableSkills 校验错误 Skill description is required，进而影响后续聊天请求

修复后：在读取和发送 skill 两个环节都增加了规范化和兜底处理，缺失的 description/content 会自动补齐，无效 skill 会被过滤，不再因为单个坏 skill 让整条对话链路失败。同时补充了对应回归测试