### PR TITLE
fix(models): use bot memory_model_id for memory LLM selection

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -676,7 +676,8 @@ func (c *lazyLLMClient) resolve(ctx context.Context) (memory.LLM, error) {
 	if c.modelsService == nil || c.queries == nil {
 		return nil, fmt.Errorf("models service not configured")
 	}
-	memoryModel, memoryProvider, err := models.SelectMemoryModel(ctx, c.modelsService, c.queries)
+	botID := memory.BotIDFromContext(ctx)
+	memoryModel, memoryProvider, err := models.SelectMemoryModelForBot(ctx, c.modelsService, c.queries, botID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/memory/context.go
+++ b/internal/memory/context.go
@@ -1,0 +1,28 @@
+package memory
+
+import (
+	"context"
+	"strings"
+)
+
+type contextKey string
+
+const memoryBotIDContextKey contextKey = "memory_bot_id"
+
+// WithBotID attaches bot ID to context so model selection can honor bot settings.
+func WithBotID(ctx context.Context, botID string) context.Context {
+	botID = strings.TrimSpace(botID)
+	if botID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, memoryBotIDContextKey, botID)
+}
+
+// BotIDFromContext returns bot ID carried by WithBotID.
+func BotIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	botID, _ := ctx.Value(memoryBotIDContextKey).(string)
+	return strings.TrimSpace(botID)
+}


### PR DESCRIPTION
这个 PR 修复了记忆选模未按 Bot 配置生效的问题。此前记忆链路会从全局 chat 模型列表取首项，未尊重bot设置种的 bots.memory_model_id，在多模型场景下会导致记忆写入、压缩走错模型并引发超时或失败

修复后将 bot_id 透传到 memory LLM 选模流程，优先按该 Bot 的 memory_model_id选择模型；同时新增类型校验，若该模型非 chat 或不可用则回退默认策略