### PR TITLE
fix(mcp): replace dot with underscore in tool name to meet ai sdk's need

### DIFF
--- a/internal/mcp/sources/federation/source.go
+++ b/internal/mcp/sources/federation/source.go
@@ -192,7 +192,7 @@ func (s *Source) buildToolsAndRoutes(ctx context.Context, botID string) ([]mcpgw
 					origin := strings.TrimSpace(tool.Name)
 					alias := origin
 					if prefix != "" {
-						alias = prefix + "." + origin
+						alias = prefix + "_" + origin
 					}
 					tool.Name = alias
 					if strings.TrimSpace(tool.Description) != "" {


### PR DESCRIPTION
agent 会把工具名称重命名为 mcp_server_name.tool_name，而有些 ai 的 sdk（比如我用的 deepseek）不吃这个，如果有 mcp 服务器被启用，就会爆

```
Error: Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
```

遂把点改成下划线