### PR TITLE
fix(telegram): aggregate media_group inbound 

### DIFF
--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -858,7 +858,18 @@ func mapStreamChunkToChannelEvents(chunk conversation.StreamChunk) ([]channel.St
 }
 
 func buildInboundQuery(message channel.Message) string {
-	return strings.TrimSpace(message.PlainText())
+	text := strings.TrimSpace(message.PlainText())
+	if text != "" {
+		return text
+	}
+	if len(message.Attachments) == 0 {
+		return ""
+	}
+	count := len(message.Attachments)
+	if count == 1 {
+		return "[User sent 1 attachment]"
+	}
+	return fmt.Sprintf("[User sent %d attachments]", count)
 }
 
 func normalizeContentPartType(raw string) channel.MessagePartType {


### PR DESCRIPTION
这个 PR 修复了 Telegram 多图相册入站被拆分的问题。此前 media_group 会按单条 update 分别触发处理，caption 常只落在后一张，导致前图缺少文本上下文并触发校验失败

修复后：按 chat_id + MediaGroupID 聚合相册，并在处理非相册消息前先 flush 同会话缓存，同时对仅附件消息补充 [User sent N attachments] fallback query