### PR TITLE
fix(agent): resolve workspace dependency @memoh/agent in Docker build

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -2,9 +2,10 @@ FROM oven/bun:1 AS builder
 
 WORKDIR /build
 
-# Set up workspace structure so bun can resolve @memoh/config
+# Set up workspace structure so bun can resolve workspace deps (@memoh/config, @memoh/agent)
 COPY agent/package.json agent/bun.lock* ./agent/
 COPY packages/config/package.json ./packages/config/package.json
+COPY packages/agent/package.json ./packages/agent/package.json
 
 # Create root package.json with workspace config
 RUN echo '{"name":"@memoh/monorepo","private":true,"workspaces":["agent","packages/*"]}' > package.json
@@ -13,6 +14,7 @@ RUN cd agent && bun install
 
 # Copy source files
 COPY packages/config/ ./packages/config/
+COPY packages/agent/ ./packages/agent/
 COPY agent/ ./agent/
 
 RUN cd agent && bun run build --external jsdom


### PR DESCRIPTION
这个 PR 修复了 agent 镜像构建失败的问题 
此前 Dockerfile.agent 在 bun install 前未包含 packages/agent 的 workspace 信息，触发 @memoh/agent not found 并中断构建

修复后补充copy packages/agent/package.json 与源码目录