### PR TITLE
feat(ui): add read-only styles to input component

### DIFF
--- a/packages/ui/src/components/input/Input.vue
+++ b/packages/ui/src/components/input/Input.vue
@@ -28,6 +28,7 @@ const modelValue = useVModel(props, 'modelValue', emits, {
       'placeholder:text-gray-400 dark:placeholder:text-gray-500',
       'shadow-sm transition-all outline-none',
       'focus:border-primary focus:ring-2 focus:ring-primary/20',
+      'read-only:bg-gray-50 dark:read-only:bg-gray-900/40 read-only:text-gray-500 dark:read-only:text-gray-400 read-only:cursor-not-allowed',
       'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
       'file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium',
       props.class,


### PR DESCRIPTION
## Diff

### Before
<img width="2710" height="1844" alt="before light" src="https://github.com/user-attachments/assets/db6734b9-2b22-4dfa-81d5-f83420af1c89" />
<img width="2710" height="1844" alt="before dark" src="https://github.com/user-attachments/assets/00ce5990-fc21-438f-aad0-729974ac43c7" />

### After
<img width="2710" height="1844" alt="after light" src="https://github.com/user-attachments/assets/f3bbb6e2-baa6-43ce-b9cf-af6ea01e981d" />
<img width="2710" height="1844" alt="after dark" src="https://github.com/user-attachments/assets/1e405a13-2d54-462a-ad29-5838f0a3fa21" />
