### PR TITLE
feat(tool): paginated file read with safety limits for container

### DIFF
--- a/internal/mcp/providers/container/provider_test.go
+++ b/internal/mcp/providers/container/provider_test.go
@@ -57,21 +57,17 @@ func TestExecutor_CallTool_Read(t *testing.T) {
 			cmd := strings.Join(req.Command, " ")
 			switch callCount {
 			case 1:
-				// First call: IsTextFile check (head -c 8192)
 				if !strings.Contains(cmd, "head -c 8192") {
-					t.Errorf("expected head check, got %q", cmd)
+					t.Errorf("expected bounded binary probe, got %q", cmd)
 				}
-				return &mcpgw.ExecWithCaptureResult{Stdout: "hello world", ExitCode: 0}, nil
 			case 2:
-				// Second call: sed to read file
 				if !strings.Contains(cmd, "sed -n") {
 					t.Errorf("expected sed command, got %q", cmd)
 				}
-				return &mcpgw.ExecWithCaptureResult{Stdout: "hello world", ExitCode: 0}, nil
 			default:
 				t.Errorf("unexpected extra call #%d: %q", callCount, cmd)
-				return &mcpgw.ExecWithCaptureResult{ExitCode: 0}, nil
 			}
+			return &mcpgw.ExecWithCaptureResult{Stdout: "hello world", ExitCode: 0}, nil
 		},
 	}
 	exec := NewExecutor(nil, runner, "/data")
@@ -89,9 +85,66 @@ func TestExecutor_CallTool_Read(t *testing.T) {
 	if content["content"] == "" {
 		t.Errorf("content should not be empty, got %v", content["content"])
 	}
-	// Verify we made only the expected 2 calls.
 	if callCount != 2 {
 		t.Errorf("expected 2 exec calls, got %d", callCount)
+	}
+}
+
+func TestExecutor_CallTool_Read_InvalidPaginationArgs(t *testing.T) {
+	runner := &fakeExecRunner{
+		handler: func(req mcpgw.ExecRequest) (*mcpgw.ExecWithCaptureResult, error) {
+			t.Fatalf("unexpected exec call: %v", req.Command)
+			return nil, nil
+		},
+	}
+	exec := NewExecutor(nil, runner, "/data")
+	ctx := context.Background()
+	session := mcpgw.ToolSessionContext{BotID: "bot1"}
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "invalid line_offset type",
+			args: map[string]any{"path": "test.txt", "line_offset": "abc"},
+			want: "invalid line_offset",
+		},
+		{
+			name: "invalid n_lines type",
+			args: map[string]any{"path": "test.txt", "n_lines": "abc"},
+			want: "invalid n_lines",
+		},
+		{
+			name: "line_offset below minimum",
+			args: map[string]any{"path": "test.txt", "line_offset": 0},
+			want: "line_offset must be >= 1",
+		},
+		{
+			name: "n_lines below minimum",
+			args: map[string]any{"path": "test.txt", "n_lines": 0},
+			want: "n_lines must be >= 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := exec.CallTool(ctx, session, "read", tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if isErr, _ := result["isError"].(bool); !isErr {
+				t.Fatalf("expected tool error containing %q", tt.want)
+			}
+			msg := ""
+			if content, ok := result["content"].([]map[string]any); ok && len(content) > 0 {
+				msg, _ = content[0]["text"].(string)
+			}
+			if !strings.Contains(msg, tt.want) {
+				t.Fatalf("error = %q, want substring %q", msg, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/providers/container/prune.go
+++ b/internal/mcp/providers/container/prune.go
@@ -104,13 +104,18 @@ func itoa(n int) string {
 	var buf [20]byte
 	i := len(buf)
 	sign := n < 0
+	var u uint64
 	if sign {
-		n = -n
+		// Avoid overflow for MinInt.
+		u = uint64(-(n + 1))
+		u++
+	} else {
+		u = uint64(n)
 	}
-	for n > 0 {
+	for u > 0 {
 		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
+		buf[i] = byte('0' + u%10)
+		u /= 10
 	}
 	if sign {
 		i--

--- a/internal/mcp/providers/container/prune_test.go
+++ b/internal/mcp/providers/container/prune_test.go
@@ -1,0 +1,29 @@
+package container
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestItoa_MatchesStrconv(t *testing.T) {
+	minInt := -int(^uint(0)>>1) - 1
+
+	tests := []int{
+		0,
+		1,
+		-1,
+		42,
+		-42,
+		123456789,
+		-123456789,
+		minInt,
+	}
+
+	for _, n := range tests {
+		got := itoa(n)
+		want := strconv.Itoa(n)
+		if got != want {
+			t.Fatalf("itoa(%d) = %q, want %q", n, got, want)
+		}
+	}
+}


### PR DESCRIPTION
这个PR新增了read工具的分页读取能力。此前读取依赖整文件输出与统一裁剪，在大文件、超长单行或越界偏移场景下，内容完整性和续读语义都不够稳定

本次实现了 line_offset/n_lines 分页参数、按行编号输出、文本文件检测与行截断标记

现在每次读取仅执行目标区间的sed，还有EndOfFile、MaxBytesReached、Truncated提示提供给模型