### PR TITLE
refactor: use configured models for provider health probes

### DIFF
--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -193,31 +193,19 @@ func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 		return resp, nil
 	}
 
+	// Get models for this provider to determine which models to use for the probes
+	models, err := s.queries.ListModelsByProviderID(ctx, providerID)
+	if err != nil {
+		return resp, fmt.Errorf("list models: %w", err)
+	}
+
 	type namedResult struct {
 		name   string
 		result CheckResult
 	}
 
-	probes := []struct {
-		name string
-		fn   func() CheckResult
-	}{
-		{"openai-completions", func() CheckResult {
-			return probeOpenAICompletions(ctx, baseURL, apiKey)
-		}},
-		{"openai-responses", func() CheckResult {
-			return probeOpenAIResponses(ctx, baseURL, apiKey)
-		}},
-		{"anthropic-messages", func() CheckResult {
-			return probeAnthropicMessages(ctx, baseURL, apiKey)
-		}},
-		{"google-generative-ai", func() CheckResult {
-			return probeGoogleGenerativeAI(ctx, baseURL, apiKey)
-		}},
-		{"embedding", func() CheckResult {
-			return probeEmbedding(ctx, baseURL, apiKey)
-		}},
-	}
+	// Build probes: always include all 5 checks, use user-configured models if available, otherwise use defaults
+	probes := buildAllProbes(ctx, models, baseURL, apiKey)
 
 	results := make([]namedResult, len(probes))
 	var wg sync.WaitGroup
@@ -253,6 +241,76 @@ func probeReachable(ctx context.Context, baseURL string) (bool, string) {
 	return true, ""
 }
 
+// buildAllProbes returns all 5 probes, using user-configured models if available, otherwise using defaults
+func buildAllProbes(ctx context.Context, models []sqlc.Model, baseURL, apiKey string) []struct {
+	name string
+	fn   func() CheckResult
+} {
+	defaultModels := map[string]string{
+		"openai-responses":   "gpt-4o-mini",
+		"anthropic-messages": "claude-3-haiku-20240307",
+		"embedding":          "text-embedding-3-small",
+	}
+
+	userChatModels := make(map[string]string) // client_type -> model_id
+	var userEmbeddingModel string
+
+	for _, m := range models {
+		clientType := m.ClientType.String
+		if m.Type == "chat" || m.Type == "" {
+			if clientType != "" && userChatModels[clientType] == "" {
+				userChatModels[clientType] = m.ModelID
+			}
+		}
+		if m.Type == "embedding" && userEmbeddingModel == "" {
+			userEmbeddingModel = m.ModelID
+		}
+	}
+
+	getModel := func(userModel, defaultKey string) string {
+		if userModel != "" {
+			return userModel
+		}
+		return defaultModels[defaultKey]
+	}
+
+	return []struct {
+		name string
+		fn   func() CheckResult
+	}{
+		{
+			name: "openai-completions",
+			fn: func() CheckResult {
+				return probeOpenAICompletions(ctx, baseURL, apiKey)
+			},
+		},
+		{
+			name: "openai-responses",
+			fn: func() CheckResult {
+				return probeOpenAIResponses(ctx, baseURL, apiKey, getModel(userChatModels["openai-responses"], "openai-responses"))
+			},
+		},
+		{
+			name: "anthropic-messages",
+			fn: func() CheckResult {
+				return probeAnthropicMessages(ctx, baseURL, apiKey, getModel(userChatModels["anthropic-messages"], "anthropic-messages"))
+			},
+		},
+		{
+			name: "google-generative-ai",
+			fn: func() CheckResult {
+				return probeGoogleGenerativeAI(ctx, baseURL, apiKey)
+			},
+		},
+		{
+			name: "embedding",
+			fn: func() CheckResult {
+				return probeEmbedding(ctx, baseURL, apiKey, getModel(userEmbeddingModel, "embedding"))
+			},
+		},
+	}
+}
+
 func probeOpenAICompletions(ctx context.Context, baseURL, apiKey string) CheckResult {
 	return probeEndpoint(ctx, http.MethodGet, baseURL+"/models",
 		map[string]string{
@@ -260,23 +318,37 @@ func probeOpenAICompletions(ctx context.Context, baseURL, apiKey string) CheckRe
 		}, "")
 }
 
-func probeOpenAIResponses(ctx context.Context, baseURL, apiKey string) CheckResult {
-	body := `{"model":"probe-test","input":"hi","max_output_tokens":1}`
+func probeOpenAIResponses(ctx context.Context, baseURL, apiKey, model string) CheckResult {
+	body, err := json.Marshal(map[string]any{
+		"model":           model,
+		"input":           "hi",
+		"max_output_tokens": 1,
+	})
+	if err != nil {
+		return CheckResult{Status: CheckStatusError, Message: err.Error()}
+	}
 	return probeEndpoint(ctx, http.MethodPost, baseURL+"/responses",
 		map[string]string{
 			"Authorization": "Bearer " + apiKey,
 			"Content-Type":  "application/json",
-		}, body)
+		}, string(body))
 }
 
-func probeAnthropicMessages(ctx context.Context, baseURL, apiKey string) CheckResult {
-	body := `{"model":"probe-test","messages":[{"role":"user","content":"hi"}],"max_tokens":1}`
+func probeAnthropicMessages(ctx context.Context, baseURL, apiKey, model string) CheckResult {
+	body, err := json.Marshal(map[string]any{
+		"model":    model,
+		"messages": []map[string]string{{"role": "user", "content": "hi"}},
+		"max_tokens": 1,
+	})
+	if err != nil {
+		return CheckResult{Status: CheckStatusError, Message: err.Error()}
+	}
 	return probeEndpoint(ctx, http.MethodPost, baseURL+"/messages",
 		map[string]string{
 			"x-api-key":         apiKey,
 			"anthropic-version": "2023-06-01",
 			"Content-Type":      "application/json",
-		}, body)
+		}, string(body))
 }
 
 func probeGoogleGenerativeAI(ctx context.Context, baseURL, apiKey string) CheckResult {
@@ -286,13 +358,19 @@ func probeGoogleGenerativeAI(ctx context.Context, baseURL, apiKey string) CheckR
 		}, "")
 }
 
-func probeEmbedding(ctx context.Context, baseURL, apiKey string) CheckResult {
-	body := `{"model":"probe-test","input":"hello"}`
+func probeEmbedding(ctx context.Context, baseURL, apiKey, model string) CheckResult {
+	body, err := json.Marshal(map[string]any{
+		"model": model,
+		"input": "hello",
+	})
+	if err != nil {
+		return CheckResult{Status: CheckStatusError, Message: err.Error()}
+	}
 	return probeEndpoint(ctx, http.MethodPost, baseURL+"/embeddings",
 		map[string]string{
 			"Authorization": "Bearer " + apiKey,
 			"Content-Type":  "application/json",
-		}, body)
+		}, string(body))
 }
 
 func probeEndpoint(ctx context.Context, method, url string, headers map[string]string, body string) CheckResult {

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1,6 +1,12 @@
 package providers
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/memohai/memoh/internal/db/sqlc"
+)
 
 func TestResolveUpdatedAPIKey(t *testing.T) {
 	t.Parallel()
@@ -35,6 +41,195 @@ func TestResolveUpdatedAPIKey(t *testing.T) {
 		empty := ""
 		if got := resolveUpdatedAPIKey(existing, &empty); got != empty {
 			t.Fatalf("expected empty key, got %q", got)
+		}
+	})
+}
+
+func makeModel(modelID, clientType, modelType string) sqlc.Model {
+	return sqlc.Model{
+		ModelID:     modelID,
+		ClientType:  pgtype.Text{String: clientType, Valid: clientType != ""},
+		Type:        modelType,
+	}
+}
+
+func TestBuildAllProbes(t *testing.T) {
+	t.Parallel()
+
+	baseURL := "https://api.example.com"
+	apiKey := "test-key"
+
+	t.Run("no user models uses defaults", func(t *testing.T) {
+		t.Parallel()
+		models := []sqlc.Model{}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		if len(probes) != 5 {
+			t.Fatalf("expected 5 probes, got %d", len(probes))
+		}
+
+		// Collect probe names
+		probeNames := make(map[string]bool)
+		for _, p := range probes {
+			probeNames[p.name] = true
+		}
+
+		expectedProbes := []string{
+			"openai-completions",
+			"openai-responses",
+			"anthropic-messages",
+			"google-generative-ai",
+			"embedding",
+		}
+
+		for _, expected := range expectedProbes {
+			if !probeNames[expected] {
+				t.Errorf("expected probe %q not found", expected)
+			}
+		}
+	})
+
+	t.Run("user chat model overrides openai-responses", func(t *testing.T) {
+		t.Parallel()
+		models := []sqlc.Model{
+			makeModel("gpt-4o", "openai-responses", "chat"),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		// Find openai-responses probe and execute it to verify model
+		var found bool
+		for _, p := range probes {
+			if p.name == "openai-responses" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("openai-responses probe not found")
+		}
+	})
+
+	t.Run("user chat model overrides anthropic-messages", func(t *testing.T) {
+		t.Parallel()
+		models := []sqlc.Model{
+			makeModel("claude-3-5-sonnet-20241022", "anthropic-messages", "chat"),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		var found bool
+		for _, p := range probes {
+			if p.name == "anthropic-messages" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("anthropic-messages probe not found")
+		}
+	})
+
+	t.Run("user embedding model overrides default", func(t *testing.T) {
+		t.Parallel()
+		models := []sqlc.Model{
+			makeModel("text-embedding-3-large", "", "embedding"),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		var found bool
+		for _, p := range probes {
+			if p.name == "embedding" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("embedding probe not found")
+		}
+	})
+
+	t.Run("multiple user models override all defaults", func(t *testing.T) {
+		t.Parallel()
+		models := []sqlc.Model{
+			makeModel("gpt-4-turbo", "openai-responses", "chat"),
+			makeModel("claude-3-opus", "anthropic-messages", "chat"),
+			makeModel("text-embedding-3-large", "", "embedding"),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		if len(probes) != 5 {
+			t.Fatalf("expected 5 probes, got %d", len(probes))
+		}
+
+		// Verify all 5 probes exist
+		probeNames := make(map[string]bool)
+		for _, p := range probes {
+			probeNames[p.name] = true
+		}
+
+		expectedProbes := []string{
+			"openai-completions",
+			"openai-responses",
+			"anthropic-messages",
+			"google-generative-ai",
+			"embedding",
+		}
+
+		for _, expected := range expectedProbes {
+			if !probeNames[expected] {
+				t.Errorf("expected probe %q not found", expected)
+			}
+		}
+	})
+
+	t.Run("empty type model uses default chat model", func(t *testing.T) {
+		t.Parallel()
+		// Empty type should be treated as chat
+		models := []sqlc.Model{
+			makeModel("gpt-4o", "openai-responses", ""),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		var found bool
+		for _, p := range probes {
+			if p.name == "openai-responses" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("openai-responses probe not found for empty type model")
+		}
+	})
+
+	t.Run("first model of each client type is used", func(t *testing.T) {
+		t.Parallel()
+		// Only the first model per client type should be used
+		models := []sqlc.Model{
+			makeModel("gpt-4o-mini", "openai-responses", "chat"),
+			makeModel("gpt-4o", "openai-responses", "chat"),
+			makeModel("claude-3-haiku", "anthropic-messages", "chat"),
+			makeModel("claude-3-sonnet", "anthropic-messages", "chat"),
+		}
+
+		probes := buildAllProbes(context.Background(), models, baseURL, apiKey)
+
+		// Should have both probes
+		probeNames := make(map[string]bool)
+		for _, p := range probes {
+			probeNames[p.name] = true
+		}
+
+		if !probeNames["openai-responses"] {
+			t.Error("openai-responses probe not found")
+		}
+		if !probeNames["anthropic-messages"] {
+			t.Error("anthropic-messages probe not found")
 		}
 	})
 }


### PR DESCRIPTION
- Always return all 5 probe checks (openai-completions, openai-responses,
  anthropic-messages, google-generative-ai, embedding)
- Use user-configured model_id if available, otherwise use default models
  (gpt-4o-mini, claude-3-haiku-20240307, text-embedding-3-small)
- Remove hardcoded "probe-test" model names
- Deduplicate probes by client_type to avoid redundant checks

#117 