### PR TITLE
fix(agent): force flush remaining text before calling tools

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -499,6 +499,20 @@ export const createAgent = (
             break
           }
           case 'tool-call':
+            // Flush any remaining buffered content before ending the text stream.
+            const remainder = attachmentsExtractor.flushRemainder()
+            if (remainder.visibleText) {
+              yield {
+                type: 'text_delta',
+                delta: remainder.visibleText,
+              }
+            }
+            if (remainder.attachments.length) {
+              yield {
+                type: 'attachment_delta',
+                attachments: remainder.attachments,
+              }
+            }
             yield {
               type: 'tool_call_start',
               toolName: chunk.toolName,


### PR DESCRIPTION
修复前：语序错乱

> 但那是之前查询的结果。
> 
> 让
> ```
> ✅ chiyuki_query_balance 已完成
> > 输入
> > 结果
> ```
> 
> 我看看现在能不能直接调用MCP服务器的工具：
> 工具在的。余额现在是10.14元。

修复后：语序正确

> 但那是之前查询的结果。
> 
> 让我看看现在能不能直接调用MCP服务器的工具：
> ```
> ✅ chiyuki_query_balance 已完成
> > 输入
> > 结果
> ```
> 
> 工具在的。余额现在是10.14元。