### PR TITLE
fix(containerd): normalize image references for containerd compatibility

### DIFF
--- a/internal/containerd/service.go
+++ b/internal/containerd/service.go
@@ -130,6 +130,7 @@ func (s *DefaultService) PullImage(ctx context.Context, ref string, opts *PullIm
 	if ref == "" {
 		return ImageInfo{}, ErrInvalidArgument
 	}
+	ref = config.NormalizeImageRef(ref)
 
 	ctx = s.withNamespace(ctx)
 	pullOpts := []containerd.RemoteOpt{}


### PR DESCRIPTION
## Summary

- Containerd does not auto-prepend `docker.io/` to short Docker Hub image names like `memohai/mcp:latest`, treating `memohai` as a registry host and failing with EOF
- Add `NormalizeImageRef()` to ensure all image references are fully qualified before being passed to containerd
- Integrate normalization into existing `ImageRef()` method so it works alongside the registry mirror feature
- Also normalize in `PullImage()` as a safety net for external callers

**Before**: `image = "memohai/mcp:latest"` → containerd requests `https://memohai/v2/mcp/manifests/latest` → EOF  
**After**: `image = "memohai/mcp:latest"` → normalized to `docker.io/memohai/mcp:latest` → works correctly

## Test Plan
- [x] Verify `memohai/mcp:latest` is normalized to `docker.io/memohai/mcp:latest`
- [x] Verify `docker.io/memohai/mcp:latest` passes through unchanged
- [x] Verify `registry.memoh.net/memohai/mcp:latest` passes through unchanged
- [x] Verify registry mirror config still takes priority when set