### PR TITLE
chore: require config.toml for deployment, update docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     container_name: memoh-migrate
     entrypoint: ["/app/memoh-server", "migrate", "up"]
     volumes:
-      - ${MEMOH_CONFIG:-./conf/app.docker.toml}:/app/config.toml:ro
+      - ${MEMOH_CONFIG:-./config.toml}:/app/config.toml:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -57,7 +57,7 @@ services:
     privileged: true
     pid: host
     volumes:
-      - ${MEMOH_CONFIG:-./conf/app.docker.toml}:/app/config.toml:ro
+      - ${MEMOH_CONFIG:-./config.toml}:/app/config.toml:ro
       - containerd_data:/var/lib/containerd
       - server_cni_state:/var/lib/cni
       - memoh_data:/opt/memoh/data
@@ -77,7 +77,7 @@ services:
     image: memohai/agent:latest
     container_name: memoh-agent
     volumes:
-      - ${MEMOH_CONFIG:-./conf/app.docker.toml}:/config.toml:ro
+      - ${MEMOH_CONFIG:-./config.toml}:/config.toml:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "8081:8081"


### PR DESCRIPTION
## Summary

- **Breaking (deployment)**: `docker-compose.yml` now defaults to `./config.toml` instead of `conf/app.docker.toml`. Users must `cp conf/app.docker.toml config.toml` before running `docker compose up`. The install script already does this automatically.
- This enforces explicit configuration for production (no more running with hardcoded default passwords), while the dev environment (`devenv/`) still uses `conf/app.dev.toml` directly.
- Updated `DEPLOYMENT.md`, `docs/installation/docker.md`, and `docs/installation/config-toml.md`:
  - Clear instructions to copy config template before starting
  - Added `registry` and CNI fields to `[mcp]` docs
  - Added `server_addr` to `[agent_gateway]` docs
  - Removed obsolete `[brave]` section (search providers managed via web UI)
  - Fixed default values (postgres user, mcp image)
  - Added China mainland mirror documentation

## Test Plan
- [ ] `docker compose config` validates with `./config.toml` present
- [ ] `docker compose up` fails gracefully when `config.toml` is missing
- [ ] Install script still works end-to-end
- [ ] Dev environment (`devenv/`) unaffected