### PR TITLE
chore(editor): add Zed workspace settings aligned with VSCode

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,50 @@
+{
+  "hard_tabs": false,
+  "tab_size": 2,
+  "format_on_save": "off",
+  "remove_trailing_whitespace_on_save": false,
+  "languages": {
+    "TypeScript": {
+      "hard_tabs": false,
+      "tab_size": 2,
+      "format_on_save": "off",
+      "code_actions_on_format": {
+        "source.fixAll.eslint": false,
+        "source.organizeImports": false
+      }
+    },
+    "JavaScript": {
+      "hard_tabs": false,
+      "tab_size": 2,
+      "format_on_save": "off",
+      "code_actions_on_format": {
+        "source.fixAll.eslint": false,
+        "source.organizeImports": false
+      }
+    },
+    "TSX": {
+      "hard_tabs": false,
+      "tab_size": 2,
+      "format_on_save": "off",
+      "code_actions_on_format": {
+        "source.fixAll.eslint": false,
+        "source.organizeImports": false
+      }
+    },
+    "Vue": {
+      "hard_tabs": false,
+      "tab_size": 2,
+      "format_on_save": "off"
+    },
+    "Go": {
+      "hard_tabs": false,
+      "tab_size": 4,
+      "format_on_save": "off"
+    },
+    "Python": {
+      "hard_tabs": false,
+      "tab_size": 4,
+      "format_on_save": "off"
+    }
+  }
+}


### PR DESCRIPTION
这个 PR 补充了 Zed 的项目配置。此前仓库仅维护 VSCode 设置，使用 Zed 时缩进和保存行为不一致

本次新增 .zed/settings.json 并对齐现有编辑规则，统一了 全局与 TypeScript、JavaScript、Vue、Go、Python 的缩进和保存策略。