### PR TITLE
fix(web): add email channel icon

### DIFF
--- a/packages/web/src/utils/channel-icons.ts
+++ b/packages/web/src/utils/channel-icons.ts
@@ -15,6 +15,7 @@ const CHANNEL_ICONS: Record<string, [string, string]> = {
   web: ['fas', 'globe'],
   slack: ['fab', 'slack'],
   discord: ['fab', 'discord'],
+  email: ['fas', 'envelope'],
 }
 
 const DEFAULT_ICON: [string, string] = ['far', 'comment']


### PR DESCRIPTION
## Summary
Email is a supported channel (email bindings, providers, outbox) but `channel-icons.ts` had no entry for it, so the UI fell back to the generic `['far', 'comment']` icon.

## Change
- Add `email: ['fas', 'envelope']` to `CHANNEL_ICONS` so email channel shows the envelope icon.

Made with [Cursor](https://cursor.com)