### PR TITLE
fix(web): fix bot history overflow and pagination wrapping

### DIFF
--- a/packages/web/src/components/master-detail-sidebar-layout/index.vue
+++ b/packages/web/src/components/master-detail-sidebar-layout/index.vue
@@ -16,7 +16,7 @@
             <slot name="sidebar-footer" />
           </SidebarFooter>
         </Sidebar>
-        <section class="flex-1 h-full">
+        <section class="flex-1 min-w-0 h-full">
           <slot name="detail" />
         </section>
       </SidebarProvider>

--- a/packages/web/src/pages/bots/components/bot-history.vue
+++ b/packages/web/src/pages/bots/components/bot-history.vue
@@ -82,9 +82,9 @@
       <!-- Pagination -->
       <div
         v-if="totalPages > 1"
-        class="flex items-center justify-between pt-4"
+        class="flex items-center justify-between gap-3 pt-4"
       >
-        <span class="text-sm text-muted-foreground">
+        <span class="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
           {{ paginationSummary }}
         </span>
         <Pagination
@@ -92,6 +92,7 @@
           :items-per-page="PAGE_SIZE"
           :sibling-count="1"
           :page="currentPage"
+          class="w-auto shrink-0"
           show-edges
           @update:page="currentPage = $event"
         >

--- a/packages/web/src/pages/bots/components/message-list.vue
+++ b/packages/web/src/pages/bots/components/message-list.vue
@@ -51,7 +51,7 @@
             :class="{ 'font-mono text-xs': msg.role === 'tool' || msg.role === 'system' }"
           >
             <div
-              class="whitespace-pre-wrap wrap-break-word"
+              class="whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
               :class="{ 'line-clamp-4': !expandedIds.includes(msgKey(msg, idx)) }"
             >
               {{ formatContent(msg.content) }}


### PR DESCRIPTION
## Summary
- fix long bot history message rendering so very long tokens can wrap without stretching the layout width
- add `min-w-0` to the master-detail content area to prevent flex children from creating oversized horizontal overflow
- keep history pagination summary and controls on one row by preventing summary wrapping and avoiding full-width pagination root

## Test plan
- [x] Open bot detail -> History tab and verify long single-token content does not create a large horizontal scrollbar
- [x] Verify pagination summary (e.g. `1-20 / N`) remains on one line in normal desktop widths
- [x] Confirm no new lints in modified files