### PR TITLE
fix(containerd): restore CNI MASQUERADE after container restart

### DIFF
--- a/devenv/server-entrypoint.sh
+++ b/devenv/server-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Ensure IP forwarding and subnet MASQUERADE for CNI.
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || true
+iptables -t nat -C POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -A POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE 2>/dev/null || true
+
 # Setup cgroup v2 delegation for nested containerd.
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   mkdir -p /sys/fs/cgroup/init

--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -3,6 +3,11 @@ set -e
 
 MCP_IMAGE="${MCP_IMAGE:-docker.io/library/memoh-mcp:latest}"
 
+# ---- Ensure IP forwarding and subnet MASQUERADE for CNI ----
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || true
+iptables -t nat -C POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -A POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE 2>/dev/null || true
+
 # ---- Setup cgroup v2 delegation for nested containerd ----
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   echo "Setting up cgroup v2 delegation..."

--- a/internal/containerd/network.go
+++ b/internal/containerd/network.go
@@ -53,9 +53,10 @@ func setupCNINetwork(ctx context.Context, task client.Task, containerID string, 
 		if !isDuplicateAllocationError(err) {
 			return err
 		}
-		if rmErr := cni.Remove(ctx, containerID, netnsPath); rmErr != nil {
-			return rmErr
-		}
+		// Stale IPAM allocation (e.g. after container restart with persisted
+		// /var/lib/cni). Remove may fail if the previous iptables/veth state
+		// is already gone; ignore the error so the retry Setup still runs.
+		_ = cni.Remove(ctx, containerID, netnsPath)
 		_, err = cni.Setup(ctx, containerID, netnsPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

- Fix `cni.Remove()` failure blocking retry `cni.Setup()` after container restart with stale IPAM state
- Add global MASQUERADE rule + `ip_forward` in server entrypoints as belt-and-suspenders fallback

## Root Cause

When Docker container restarts, iptables state is lost but `/var/lib/cni` IPAM persists via volume. `cni.Setup()` hits "duplicate allocation", `cni.Remove()` fails on missing iptables chains, and the old code `return rmErr` prevented the retry — leaving bot containers without SNAT/MASQUERADE.

Closes #161