### PR TITLE
fix(webhook): missing client import

### DIFF
--- a/packages/web/src/pages/bots/components/channel-settings-panel.vue
+++ b/packages/web/src/pages/bots/components/channel-settings-panel.vue
@@ -242,6 +242,7 @@ import { useI18n } from 'vue-i18n'
 import { useMutation, useQueryCache } from '@pinia/colada'
 import { putBotsByIdChannelByPlatform, deleteBotsByIdChannelByPlatform, patchBotsByIdChannelByPlatformStatus } from '@memoh/sdk'
 import type { HandlersChannelMeta, ChannelChannelConfig, ChannelFieldSchema, ChannelUpsertConfigRequest } from '@memoh/sdk'
+import { client } from '@memoh/sdk/client'
 import ConfirmPopover from '@/components/confirm-popover/index.vue'
 
 interface BotChannelItem {


### PR DESCRIPTION
The issue takes place when I’m trying to add Feishu as my bot platform, and the webhook URL didn’t show up when I finished the configuration. Normally add a Feishu platform as per document and select webhook to reproduce.