### PR TITLE
fix(channel): split long streaming messages at manager level 

### DIFF
--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/memohai/memoh/internal/channel"
@@ -18,7 +19,10 @@ import (
 	"github.com/memohai/memoh/internal/media"
 )
 
-const inboundDedupTTL = time.Minute
+const (
+	inboundDedupTTL  = time.Minute
+	discordMaxLength = 2000
+)
 
 // assetOpener reads stored asset bytes by content hash.
 type assetOpener interface {
@@ -306,11 +310,11 @@ func (a *DiscordAdapter) sendDiscordMessage(ctx context.Context, session *discor
 }
 
 func truncateDiscordText(text string) string {
-	const discordMaxLength = 2000
-	if len(text) > discordMaxLength {
-		text = text[:discordMaxLength-3] + "..."
+	if utf8.RuneCountInString(text) <= discordMaxLength {
+		return text
 	}
-	return text
+	runes := []rune(text)
+	return string(runes[:discordMaxLength-3]) + "..."
 }
 
 // discordAttachmentToFile converts a channel attachment to discordgo.File

--- a/internal/channel/outbound.go
+++ b/internal/channel/outbound.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // ChunkerMode selects the text chunking strategy.
@@ -15,6 +17,8 @@ const (
 	ChunkerModeText     ChunkerMode = "text"
 	ChunkerModeMarkdown ChunkerMode = "markdown"
 )
+
+const streamFinalFirstChunkTimeout = 3 * time.Second
 
 // OutboundOrder controls the delivery order of text and media messages.
 type OutboundOrder string
@@ -518,6 +522,16 @@ func (s *managerReplySender) OpenStream(ctx context.Context, target string, opts
 		manager:     s.manager,
 		stream:      stream,
 		channelType: s.channelType,
+		send: func(ctx context.Context, msg OutboundMessage) error {
+			msg.Target = target
+			return s.Send(ctx, msg)
+		},
+		reopen: func(ctx context.Context) (OutboundStream, error) {
+			return s.streamSender.OpenStream(ctx, s.config, target, StreamOptions{
+				SourceMessageID: opts.SourceMessageID,
+				Metadata:        opts.Metadata,
+			})
+		},
 	}, nil
 }
 
@@ -525,6 +539,11 @@ type managerOutboundStream struct {
 	manager     *Manager
 	stream      OutboundStream
 	channelType ChannelType
+	send        func(ctx context.Context, msg OutboundMessage) error
+	reopen      func(ctx context.Context) (OutboundStream, error)
+	deltaRunes  int
+	deltaText   strings.Builder
+	splitCount  int
 }
 
 func (s *managerOutboundStream) Push(ctx context.Context, event StreamEvent) error {
@@ -534,7 +553,295 @@ func (s *managerOutboundStream) Push(ctx context.Context, event StreamEvent) err
 	if err := validateStreamEvent(s.manager.registry, s.channelType, event); err != nil {
 		return err
 	}
+
+	if event.Type == StreamEventDelta && event.Delta != "" && event.Phase != StreamPhaseReasoning {
+		return s.pushDelta(ctx, event)
+	}
+
+	if event.Type == StreamEventFinal && event.Final != nil && s.send != nil {
+		if s.splitCount > 0 {
+			return s.pushFinalAfterSplit(ctx, event)
+		}
+		return s.pushFinalWithChunking(ctx, event)
+	}
 	return s.stream.Push(ctx, event)
+}
+
+// streamSplitSoftRatio controls the soft-limit window. The soft limit is
+// hardLimit - hardLimit/streamSplitSoftRatio (75% of hard limit). Between
+// soft and hard the manager watches for natural break points to split
+// gracefully; if none is found it force-splits at the hard limit.
+const streamSplitSoftRatio = 4
+
+// pushDelta forwards a text delta and splits the stream into a new message
+// when accumulated text approaches the platform's TextChunkLimit. Between
+// the soft and hard limits it looks for natural break points (sentence ends,
+// line breaks) so messages don't get cut mid-sentence.
+func (s *managerOutboundStream) pushDelta(ctx context.Context, event StreamEvent) error {
+	policy := s.manager.resolveOutboundPolicy(s.channelType)
+	if policy.TextChunkLimit <= 0 || s.reopen == nil {
+		s.deltaRunes += runeLen(event.Delta)
+		return s.stream.Push(ctx, event)
+	}
+
+	newRunes := runeLen(event.Delta)
+	afterRunes := s.deltaRunes + newRunes
+	hardLimit := policy.TextChunkLimit
+	softLimit := hardLimit - hardLimit/streamSplitSoftRatio
+
+	if afterRunes <= softLimit {
+		s.deltaRunes = afterRunes
+		s.deltaText.WriteString(event.Delta)
+		return s.stream.Push(ctx, event)
+	}
+
+	if afterRunes <= hardLimit {
+		s.deltaRunes = afterRunes
+		s.deltaText.WriteString(event.Delta)
+		if err := s.stream.Push(ctx, event); err != nil {
+			return err
+		}
+		if isNaturalBreakPoint(s.deltaText.String()) {
+			s.deltaRunes = 0
+			s.deltaText.Reset()
+			return s.splitStream(ctx)
+		}
+		return nil
+	}
+
+	if err := s.splitStream(ctx); err != nil {
+		return err
+	}
+	s.deltaRunes = newRunes
+	s.deltaText.Reset()
+	s.deltaText.WriteString(event.Delta)
+	return s.stream.Push(ctx, event)
+}
+
+// splitStream finalizes the current adapter stream, opens a continuation
+// stream, and sends Status(Started) so the adapter creates a new platform
+// message before the first delta arrives.
+func (s *managerOutboundStream) splitStream(ctx context.Context) error {
+	if err := s.stream.Push(ctx, StreamEvent{
+		Type:  StreamEventFinal,
+		Final: &StreamFinalizePayload{},
+	}); err != nil {
+		return err
+	}
+	if err := s.stream.Close(ctx); err != nil {
+		return err
+	}
+
+	newStream, err := s.reopen(ctx)
+	if err != nil {
+		return err
+	}
+	s.stream = newStream
+	s.splitCount++
+
+	return s.stream.Push(ctx, StreamEvent{
+		Type:   StreamEventStatus,
+		Status: StreamStatusStarted,
+	})
+}
+
+const sentenceTerminators = ".。!！?？…⋯;；"
+
+// isNaturalBreakPoint reports whether text ends at a position suitable for
+// splitting a message — a line break or sentence-ending punctuation.
+func isNaturalBreakPoint(text string) bool {
+	if strings.HasSuffix(text, "\n") {
+		return true
+	}
+	trimmed := strings.TrimRightFunc(text, unicode.IsSpace)
+	if trimmed == "" {
+		return false
+	}
+	last, _ := utf8.DecodeLastRuneInString(trimmed)
+	return strings.ContainsRune(sentenceTerminators, last)
+}
+
+// pushFinalAfterSplit handles StreamEventFinal when the adapter has already
+// sent earlier portions of the response during streaming. It passes an
+// empty-text Final so the adapter finalizes its internal buffer, then
+// delivers any remaining attachments / actions via the non-streaming path.
+func (s *managerOutboundStream) pushFinalAfterSplit(ctx context.Context, event StreamEvent) error {
+	bufferFinal := StreamEvent{
+		Type:     StreamEventFinal,
+		Final:    &StreamFinalizePayload{},
+		Metadata: event.Metadata,
+	}
+	if err := s.stream.Push(ctx, bufferFinal); err != nil {
+		return err
+	}
+
+	if event.Final == nil {
+		return nil
+	}
+	msg := event.Final.Message
+
+	if len(msg.Attachments) > 0 {
+		if err := s.send(ctx, OutboundMessage{
+			Message: Message{
+				Attachments: msg.Attachments,
+				Thread:      msg.Thread,
+				Actions:     msg.Actions,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *managerOutboundStream) pushFinalWithChunking(ctx context.Context, event StreamEvent) error {
+	policy := s.manager.resolveOutboundPolicy(s.channelType)
+	if policy.TextChunkLimit <= 0 {
+		if s.manager.logger != nil {
+			s.manager.logger.Debug("stream final chunking skipped: non-positive chunk limit",
+				slog.String("channel", s.channelType.String()),
+				slog.Int("chunk_limit", policy.TextChunkLimit),
+			)
+		}
+		return s.stream.Push(ctx, event)
+	}
+	msg := normalizeOutboundMessage(event.Final.Message)
+	text := strings.TrimSpace(msg.PlainText())
+	textRunes := runeLen(text)
+	if s.manager.logger != nil {
+		s.manager.logger.Debug("stream final chunking evaluate",
+			slog.String("channel", s.channelType.String()),
+			slog.Int("chunk_limit", policy.TextChunkLimit),
+			slog.Int("text_runes", textRunes),
+			slog.Int("attachments", len(msg.Attachments)),
+			slog.String("format", string(msg.Format)),
+		)
+	}
+	if text == "" || runeLen(text) <= policy.TextChunkLimit {
+		if s.manager.logger != nil {
+			s.manager.logger.Debug("stream final chunking skipped: text within limit",
+				slog.String("channel", s.channelType.String()),
+				slog.Int("text_runes", textRunes),
+				slog.Int("chunk_limit", policy.TextChunkLimit),
+			)
+		}
+		return s.stream.Push(ctx, event)
+	}
+
+	chunker := policy.Chunker
+	if msg.Format == MessageFormatMarkdown {
+		chunker = ChunkMarkdownText
+	}
+	chunks := chunker(text, policy.TextChunkLimit)
+	if len(chunks) <= 1 {
+		if s.manager.logger != nil {
+			s.manager.logger.Debug("stream final chunking skipped: chunker returned single chunk",
+				slog.String("channel", s.channelType.String()),
+				slog.Int("chunks", len(chunks)),
+			)
+		}
+		return s.stream.Push(ctx, event)
+	}
+
+	hasAttachments := len(msg.Attachments) > 0
+	if s.manager.logger != nil {
+		s.manager.logger.Info("stream final chunking applied",
+			slog.String("channel", s.channelType.String()),
+			slog.Int("chunks", len(chunks)),
+			slog.Bool("has_attachments", hasAttachments),
+		)
+	}
+
+	firstMsg := msg
+	firstMsg.Text = chunks[0]
+	firstMsg.Parts = nil
+	firstMsg.Attachments = nil
+	firstMsg.Actions = nil
+	firstChunkEvent := StreamEvent{
+		Type:     StreamEventFinal,
+		Final:    &StreamFinalizePayload{Message: firstMsg},
+		Metadata: event.Metadata,
+	}
+	firstChunkCtx, cancelFirstChunk := context.WithTimeout(ctx, streamFinalFirstChunkTimeout)
+	defer cancelFirstChunk()
+	if err := s.stream.Push(firstChunkCtx, firstChunkEvent); err != nil {
+		if s.manager.logger != nil {
+			s.manager.logger.Warn("stream final first chunk push failed, fallback to direct sends",
+				slog.String("channel", s.channelType.String()),
+				slog.Duration("timeout", streamFinalFirstChunkTimeout),
+				slog.Any("error", err),
+			)
+		}
+		return s.sendChunkedFinal(ctx, msg, chunks, 0, hasAttachments)
+	}
+	return s.sendChunkedFinal(ctx, msg, chunks, 1, hasAttachments)
+}
+
+func (s *managerOutboundStream) sendChunkedFinal(ctx context.Context, msg Message, chunks []string, startIndex int, hasAttachments bool) error {
+	if startIndex < 0 {
+		startIndex = 0
+	}
+	for idx := startIndex; idx < len(chunks); idx++ {
+		chunk := chunks[idx]
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		isLast := idx == len(chunks)-1
+		var actions []Action
+		if isLast && !hasAttachments {
+			actions = msg.Actions
+		}
+		if err := s.send(ctx, OutboundMessage{
+			Message: Message{
+				Format:   msg.Format,
+				Text:     chunk,
+				Thread:   msg.Thread,
+				Reply:    msg.Reply,
+				Metadata: msg.Metadata,
+				Actions:  actions,
+			},
+		}); err != nil {
+			if s.manager.logger != nil {
+				s.manager.logger.Error("stream final overflow chunk send failed",
+					slog.String("channel", s.channelType.String()),
+					slog.Int("chunk_index", idx+1),
+					slog.Int("total_chunks", len(chunks)),
+					slog.Any("error", err),
+				)
+			}
+			return err
+		}
+	}
+
+	if hasAttachments {
+		if err := s.send(ctx, OutboundMessage{
+			Message: Message{
+				Attachments: msg.Attachments,
+				Thread:      msg.Thread,
+				Reply:       msg.Reply,
+				Metadata:    msg.Metadata,
+				Actions:     msg.Actions,
+			},
+		}); err != nil {
+			if s.manager.logger != nil {
+				s.manager.logger.Error("stream final attachments send failed",
+					slog.String("channel", s.channelType.String()),
+					slog.Int("attachments", len(msg.Attachments)),
+					slog.Any("error", err),
+				)
+			}
+			return err
+		}
+	}
+	if s.manager.logger != nil {
+		s.manager.logger.Info("stream final chunking completed",
+			slog.String("channel", s.channelType.String()),
+			slog.Int("chunks", len(chunks)),
+			slog.Bool("has_attachments", hasAttachments),
+		)
+	}
+	return nil
 }
 
 func (s *managerOutboundStream) Close(ctx context.Context) error {

--- a/internal/channel/outbound_test.go
+++ b/internal/channel/outbound_test.go
@@ -1,11 +1,16 @@
 package channel
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 )
 
 type streamValidationAdapter struct {
-	channelType ChannelType
+	channelType    ChannelType
+	outboundPolicy OutboundPolicy
 }
 
 func (a *streamValidationAdapter) Type() ChannelType {
@@ -18,10 +23,14 @@ func (a *streamValidationAdapter) Descriptor() Descriptor {
 		DisplayName: "stream-validation",
 		Capabilities: ChannelCapabilities{
 			Text:           true,
+			Markdown:       true,
 			Attachments:    true,
 			Streaming:      true,
 			BlockStreaming: true,
+			Buttons:        true,
+			Threads:        true,
 		},
+		OutboundPolicy: a.outboundPolicy,
 	}
 }
 
@@ -92,6 +101,905 @@ func TestValidateStreamEventInvalidPayload(t *testing.T) {
 			t.Parallel()
 			if err := validateStreamEvent(registry, channelType, tt.event); err == nil {
 				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+// recordingStream captures events pushed to it.
+type recordingStream struct {
+	mu     sync.Mutex
+	events []StreamEvent
+}
+
+func (r *recordingStream) Push(_ context.Context, event StreamEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	return nil
+}
+
+func (r *recordingStream) Close(_ context.Context) error { return nil }
+
+func (r *recordingStream) Events() []StreamEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]StreamEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+type failingFinalStream struct {
+	recordingStream
+}
+
+func (f *failingFinalStream) Push(_ context.Context, event StreamEvent) error {
+	if event.Type == StreamEventFinal {
+		return context.DeadlineExceeded
+	}
+	return f.recordingStream.Push(context.Background(), event)
+}
+
+func newChunkingTestStream(t *testing.T, chunkLimit int) (*managerOutboundStream, *recordingStream, *[]OutboundMessage) {
+	t.Helper()
+	registry := NewRegistry()
+	adapter := &streamValidationAdapter{
+		channelType:    ChannelType("test"),
+		outboundPolicy: OutboundPolicy{TextChunkLimit: chunkLimit},
+	}
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register adapter failed: %v", err)
+	}
+	manager := &Manager{registry: registry}
+
+	rec := &recordingStream{}
+	var sent []OutboundMessage
+	var mu sync.Mutex
+
+	stream := &managerOutboundStream{
+		manager:     manager,
+		stream:      rec,
+		channelType: ChannelType("test"),
+		send: func(_ context.Context, msg OutboundMessage) error {
+			mu.Lock()
+			defer mu.Unlock()
+			sent = append(sent, msg)
+			return nil
+		},
+	}
+	return stream, rec, &sent
+}
+
+func TestPushFinalWithChunking_ShortText(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 2000)
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{Text: "short text", Format: MessageFormatPlain},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d", len(events))
+	}
+	if events[0].Final.Message.Text != "short text" {
+		t.Fatalf("expected original text, got %q", events[0].Final.Message.Text)
+	}
+	if len(*sent) != 0 {
+		t.Fatalf("expected no overflow sends, got %d", len(*sent))
+	}
+}
+
+func TestPushFinalWithChunking_LongText(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 100)
+
+	lines := make([]string, 0, 10)
+	for i := range 10 {
+		line := strings.Repeat("x", 20)
+		if i > 0 {
+			line = strings.Repeat("y", 20)
+		}
+		lines = append(lines, line)
+	}
+	longText := strings.Join(lines, "\n")
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{Text: longText, Format: MessageFormatPlain},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event (first chunk), got %d", len(events))
+	}
+	firstChunk := events[0].Final.Message.Text
+	if runeLen(firstChunk) > 100 {
+		t.Fatalf("first chunk exceeds limit: %d runes", runeLen(firstChunk))
+	}
+	if len(*sent) == 0 {
+		t.Fatal("expected overflow sends, got none")
+	}
+	for i, msg := range *sent {
+		if runeLen(msg.Message.Text) > 100 {
+			t.Fatalf("overflow chunk %d exceeds limit: %d runes", i, runeLen(msg.Message.Text))
+		}
+	}
+
+	var reconstructed strings.Builder
+	reconstructed.WriteString(firstChunk)
+	for _, msg := range *sent {
+		reconstructed.WriteString("\n")
+		reconstructed.WriteString(msg.Message.Text)
+	}
+	if strings.TrimSpace(reconstructed.String()) != strings.TrimSpace(longText) {
+		t.Fatal("reconstructed text does not match original")
+	}
+}
+
+func TestPushFinalWithChunking_AttachmentsSeparated(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 50)
+
+	longText := strings.Repeat("a", 30) + "\n" + strings.Repeat("b", 30)
+	attachments := []Attachment{{Type: AttachmentImage, URL: "https://example.com/img.png"}}
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:        longText,
+				Format:      MessageFormatPlain,
+				Attachments: attachments,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d", len(events))
+	}
+	if len(events[0].Final.Message.Attachments) != 0 {
+		t.Fatal("first chunk should not contain attachments")
+	}
+
+	hasAttachment := false
+	for _, msg := range *sent {
+		if len(msg.Message.Attachments) > 0 {
+			hasAttachment = true
+			if msg.Message.Attachments[0].URL != "https://example.com/img.png" {
+				t.Fatal("attachment URL mismatch")
+			}
+		}
+	}
+	if !hasAttachment {
+		t.Fatal("expected attachments in overflow sends")
+	}
+}
+
+func TestPushFinalWithChunking_NonFinalPassthrough(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 100)
+
+	event := StreamEvent{
+		Type:   StreamEventStatus,
+		Status: StreamStatusStarted,
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != StreamEventStatus {
+		t.Fatalf("expected status event, got %s", events[0].Type)
+	}
+	if len(*sent) != 0 {
+		t.Fatalf("expected no overflow sends, got %d", len(*sent))
+	}
+}
+
+func TestPushFinalWithChunking_MarkdownFormat(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 100)
+
+	para1 := strings.Repeat("a", 60)
+	para2 := strings.Repeat("b", 60)
+	longText := para1 + "\n\n" + para2
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{Text: longText, Format: MessageFormatMarkdown},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d", len(events))
+	}
+	if events[0].Final.Message.Format != MessageFormatMarkdown {
+		t.Fatal("first chunk should preserve markdown format")
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("expected 1 overflow send, got %d", len(*sent))
+	}
+	if (*sent)[0].Message.Format != MessageFormatMarkdown {
+		t.Fatal("overflow chunk should preserve markdown format")
+	}
+}
+
+func TestPushFinalWithChunking_ActionsOnLastChunk(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 50)
+
+	longText := strings.Repeat("a", 30) + "\n" + strings.Repeat("b", 30)
+	actions := []Action{{Type: "button", Label: "Click me", URL: "https://example.com"}}
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:    longText,
+				Format:  MessageFormatPlain,
+				Actions: actions,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d", len(events))
+	}
+	if len(events[0].Final.Message.Actions) != 0 {
+		t.Fatal("first chunk should NOT have actions when there are overflow chunks")
+	}
+	if len(*sent) == 0 {
+		t.Fatal("expected overflow sends")
+	}
+	lastSent := (*sent)[len(*sent)-1]
+	if len(lastSent.Message.Actions) != 1 || lastSent.Message.Actions[0].Label != "Click me" {
+		t.Fatal("actions should be on the last overflow message")
+	}
+}
+
+func TestPushFinalWithChunking_ActionsOnAttachmentMsg(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 50)
+
+	longText := strings.Repeat("a", 30) + "\n" + strings.Repeat("b", 30)
+	actions := []Action{{Type: "button", Label: "OK"}}
+	attachments := []Attachment{{Type: AttachmentImage, URL: "https://example.com/img.png"}}
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:        longText,
+				Format:      MessageFormatPlain,
+				Actions:     actions,
+				Attachments: attachments,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events[0].Final.Message.Actions) != 0 {
+		t.Fatal("first chunk should NOT have actions")
+	}
+
+	var attachmentMsg *OutboundMessage
+	for i := range *sent {
+		if len((*sent)[i].Message.Attachments) > 0 {
+			attachmentMsg = &(*sent)[i]
+		}
+	}
+	if attachmentMsg == nil {
+		t.Fatal("expected attachment message in overflow")
+	}
+	if len(attachmentMsg.Message.Actions) != 1 || attachmentMsg.Message.Actions[0].Label != "OK" {
+		t.Fatal("actions should be on the attachment (last) message")
+	}
+
+	for _, msg := range *sent {
+		if len(msg.Message.Attachments) == 0 && len(msg.Message.Actions) > 0 {
+			t.Fatal("text-only overflow chunks should NOT have actions when attachment message exists")
+		}
+	}
+}
+
+func TestPushFinalWithChunking_ThreadPropagated(t *testing.T) {
+	t.Parallel()
+	stream, rec, sent := newChunkingTestStream(t, 50)
+
+	longText := strings.Repeat("a", 30) + "\n" + strings.Repeat("b", 30)
+	thread := &ThreadRef{ID: "thread-123"}
+
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:   longText,
+				Format: MessageFormatPlain,
+				Thread: thread,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d", len(events))
+	}
+
+	if len(*sent) == 0 {
+		t.Fatal("expected overflow sends")
+	}
+	for i, msg := range *sent {
+		if msg.Message.Thread == nil || msg.Message.Thread.ID != "thread-123" {
+			t.Fatalf("overflow chunk %d should have thread propagated", i)
+		}
+	}
+}
+
+func TestPushFinalWithChunking_FirstChunkPushFailureFallback(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	adapter := &streamValidationAdapter{
+		channelType:    ChannelType("test"),
+		outboundPolicy: OutboundPolicy{TextChunkLimit: 100},
+	}
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register adapter failed: %v", err)
+	}
+	manager := &Manager{registry: registry}
+
+	rec := &failingFinalStream{}
+	var sent []OutboundMessage
+	stream := &managerOutboundStream{
+		manager:     manager,
+		stream:      rec,
+		channelType: ChannelType("test"),
+		send: func(_ context.Context, msg OutboundMessage) error {
+			sent = append(sent, msg)
+			return nil
+		},
+	}
+
+	longText := strings.Repeat("a", 80) + "\n" + strings.Repeat("b", 80) + "\n" + strings.Repeat("c", 80)
+	event := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{Text: longText, Format: MessageFormatPlain},
+		},
+	}
+	if err := stream.Push(context.Background(), event); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	if len(rec.Events()) != 0 {
+		t.Fatalf("expected no stream events after first chunk push failure, got %d", len(rec.Events()))
+	}
+	if len(sent) < 2 {
+		t.Fatalf("expected fallback sends for all chunks, got %d", len(sent))
+	}
+
+	var reconstructed strings.Builder
+	for i, msg := range sent {
+		if i > 0 {
+			reconstructed.WriteString("\n")
+		}
+		reconstructed.WriteString(msg.Message.Text)
+	}
+	if strings.TrimSpace(reconstructed.String()) != strings.TrimSpace(longText) {
+		t.Fatal("fallback reconstructed text does not match original")
+	}
+}
+
+// reopenableStream wraps a list of recordingStreams; each reopen returns the next.
+type reopenableStream struct {
+	streams []*recordingStream
+	idx     int
+}
+
+func (r *reopenableStream) current() *recordingStream {
+	if r.idx >= len(r.streams) {
+		return nil
+	}
+	return r.streams[r.idx]
+}
+
+func (r *reopenableStream) reopen(_ context.Context) (OutboundStream, error) {
+	r.idx++
+	if r.idx >= len(r.streams) {
+		return nil, fmt.Errorf("no more streams")
+	}
+	return r.streams[r.idx], nil
+}
+
+func newDeltaSplitTestStream(t *testing.T, chunkLimit int, streamCount int) (*managerOutboundStream, *reopenableStream, *[]OutboundMessage) {
+	t.Helper()
+	registry := NewRegistry()
+	adapter := &streamValidationAdapter{
+		channelType:    ChannelType("test"),
+		outboundPolicy: OutboundPolicy{TextChunkLimit: chunkLimit},
+	}
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register adapter failed: %v", err)
+	}
+	manager := &Manager{registry: registry}
+
+	streams := make([]*recordingStream, streamCount)
+	for i := range streams {
+		streams[i] = &recordingStream{}
+	}
+	reo := &reopenableStream{streams: streams}
+
+	var sent []OutboundMessage
+	var mu sync.Mutex
+
+	stream := &managerOutboundStream{
+		manager:     manager,
+		stream:      streams[0],
+		channelType: ChannelType("test"),
+		send: func(_ context.Context, msg OutboundMessage) error {
+			mu.Lock()
+			defer mu.Unlock()
+			sent = append(sent, msg)
+			return nil
+		},
+		reopen: reo.reopen,
+	}
+	return stream, reo, &sent
+}
+
+func TestPushDelta_NoSplitUnderLimit(t *testing.T) {
+	t.Parallel()
+	stream, reo, _ := newDeltaSplitTestStream(t, 100, 2)
+
+	for i := range 5 {
+		_ = i
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("a", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	events := reo.streams[0].Events()
+	if len(events) != 5 {
+		t.Fatalf("expected 5 delta events on stream 0, got %d", len(events))
+	}
+	if stream.splitCount != 0 {
+		t.Fatal("expected no splits")
+	}
+}
+
+func TestPushDelta_SplitsAtLimit(t *testing.T) {
+	t.Parallel()
+	stream, reo, _ := newDeltaSplitTestStream(t, 100, 3)
+
+	for range 12 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("x", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	if stream.splitCount != 1 {
+		t.Fatalf("expected 1 split, got %d", stream.splitCount)
+	}
+
+	s0 := reo.streams[0].Events()
+	hasFinal := false
+	deltaCount := 0
+	for _, e := range s0 {
+		if e.Type == StreamEventFinal {
+			hasFinal = true
+		}
+		if e.Type == StreamEventDelta {
+			deltaCount++
+		}
+	}
+	if !hasFinal {
+		t.Fatal("stream 0 should have received a Final event for finalization")
+	}
+	if deltaCount != 10 {
+		t.Fatalf("stream 0 should have 10 deltas (100 runes), got %d", deltaCount)
+	}
+
+	s1 := reo.streams[1].Events()
+	hasStarted := false
+	deltaCount1 := 0
+	for _, e := range s1 {
+		if e.Type == StreamEventStatus && e.Status == StreamStatusStarted {
+			hasStarted = true
+		}
+		if e.Type == StreamEventDelta {
+			deltaCount1++
+		}
+	}
+	if !hasStarted {
+		t.Fatal("continuation stream should receive Status(Started) before deltas")
+	}
+	if deltaCount1 != 2 {
+		t.Fatalf("stream 1 should have 2 deltas (overflow), got %d", deltaCount1)
+	}
+}
+
+func TestPushDelta_MultipleSplits(t *testing.T) {
+	t.Parallel()
+	stream, reo, _ := newDeltaSplitTestStream(t, 50, 5)
+
+	for range 15 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("y", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	if stream.splitCount != 2 {
+		t.Fatalf("expected 2 splits for 150 runes / 50 limit, got %d", stream.splitCount)
+	}
+
+	for i := 0; i <= 2; i++ {
+		events := reo.streams[i].Events()
+		if len(events) == 0 {
+			t.Fatalf("stream %d has no events", i)
+		}
+	}
+}
+
+func TestPushDelta_FinalAfterSplitUsesBuffer(t *testing.T) {
+	t.Parallel()
+	stream, reo, sent := newDeltaSplitTestStream(t, 50, 3)
+
+	for range 8 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("z", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	if stream.splitCount == 0 {
+		t.Fatal("expected at least 1 split")
+	}
+
+	finalEvent := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:   strings.Repeat("z", 80),
+				Format: MessageFormatPlain,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), finalEvent); err != nil {
+		t.Fatalf("Final Push failed: %v", err)
+	}
+
+	lastStream := reo.current()
+	events := lastStream.Events()
+	hasFinal := false
+	for _, e := range events {
+		if e.Type == StreamEventFinal {
+			hasFinal = true
+			if !e.Final.Message.IsEmpty() {
+				t.Fatal("after split, Final should have empty message (adapter uses buffer)")
+			}
+		}
+	}
+	if !hasFinal {
+		t.Fatal("last stream should have received a Final event")
+	}
+	_ = sent
+}
+
+func TestPushDelta_FinalWithAttachmentsAfterSplit(t *testing.T) {
+	t.Parallel()
+	stream, _, sent := newDeltaSplitTestStream(t, 50, 3)
+
+	for range 8 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("w", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	attachments := []Attachment{{Type: AttachmentImage, URL: "https://example.com/img.png"}}
+	actions := []Action{{Type: "button", Label: "OK"}}
+	finalEvent := StreamEvent{
+		Type: StreamEventFinal,
+		Final: &StreamFinalizePayload{
+			Message: Message{
+				Text:        strings.Repeat("w", 80),
+				Format:      MessageFormatPlain,
+				Attachments: attachments,
+				Actions:     actions,
+			},
+		},
+	}
+	if err := stream.Push(context.Background(), finalEvent); err != nil {
+		t.Fatalf("Final Push failed: %v", err)
+	}
+
+	if len(*sent) != 1 {
+		t.Fatalf("expected 1 attachment send, got %d", len(*sent))
+	}
+	if len((*sent)[0].Message.Attachments) != 1 {
+		t.Fatal("expected attachments forwarded via send")
+	}
+	if len((*sent)[0].Message.Actions) != 1 || (*sent)[0].Message.Actions[0].Label != "OK" {
+		t.Fatal("expected actions forwarded with attachments")
+	}
+}
+
+func TestPushDelta_NoSplitWhenNoLimit(t *testing.T) {
+	t.Parallel()
+	stream, reo, _ := newDeltaSplitTestStream(t, 0, 2)
+
+	for range 20 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("a", 100),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	if stream.splitCount != 0 {
+		t.Fatal("expected no splits when TextChunkLimit is 0")
+	}
+
+	events := reo.streams[0].Events()
+	if len(events) != 20 {
+		t.Fatalf("expected all 20 deltas on stream 0, got %d", len(events))
+	}
+}
+
+func TestPushDelta_ReasoningPhaseNotCounted(t *testing.T) {
+	t.Parallel()
+	stream, _, _ := newDeltaSplitTestStream(t, 50, 2)
+
+	for range 10 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("r", 100),
+			Phase: StreamPhaseReasoning,
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+
+	if stream.splitCount != 0 {
+		t.Fatal("reasoning deltas should not trigger splits")
+	}
+	if stream.deltaRunes != 0 {
+		t.Fatal("reasoning deltas should not be counted")
+	}
+}
+
+func TestPushDelta_SplitsAtNaturalBreak(t *testing.T) {
+	t.Parallel()
+	// limit=100, softLimit = 100 - 100/4 = 75
+	stream, reo, _ := newDeltaSplitTestStream(t, 100, 3)
+
+	// Push 70 runes — under soft limit.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: strings.Repeat("a", 70),
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 0 {
+		t.Fatal("should not split under soft limit")
+	}
+
+	// Push 10 runes ending with a sentence period → 80 runes total,
+	// above soft (75) but under hard (100). Text ends with "." → natural break.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: strings.Repeat("b", 9) + ".",
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 1 {
+		t.Fatalf("expected split at natural break point, got %d splits", stream.splitCount)
+	}
+	if stream.deltaRunes != 0 {
+		t.Fatalf("deltaRunes should reset after natural-break split, got %d", stream.deltaRunes)
+	}
+
+	// Verify stream 0 got both deltas and a Final.
+	s0 := reo.streams[0].Events()
+	deltaCount := 0
+	hasFinal := false
+	for _, e := range s0 {
+		if e.Type == StreamEventDelta {
+			deltaCount++
+		}
+		if e.Type == StreamEventFinal {
+			hasFinal = true
+		}
+	}
+	if deltaCount != 2 {
+		t.Fatalf("stream 0: expected 2 deltas, got %d", deltaCount)
+	}
+	if !hasFinal {
+		t.Fatal("stream 0 should have a Final event")
+	}
+
+	// Push more content to the continuation stream.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: "continuation text",
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	s1 := reo.streams[1].Events()
+	hasStarted := false
+	for _, e := range s1 {
+		if e.Type == StreamEventStatus && e.Status == StreamStatusStarted {
+			hasStarted = true
+		}
+	}
+	if !hasStarted {
+		t.Fatal("continuation stream should receive Status(Started)")
+	}
+}
+
+func TestPushDelta_NoEarlySplitWithoutBreakPoint(t *testing.T) {
+	t.Parallel()
+	// limit=100, softLimit=75
+	stream, _, _ := newDeltaSplitTestStream(t, 100, 3)
+
+	// Push 90 runes of plain text (no break point) — above soft, under hard.
+	for range 9 {
+		if err := stream.Push(context.Background(), StreamEvent{
+			Type:  StreamEventDelta,
+			Delta: strings.Repeat("x", 10),
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+	}
+	if stream.splitCount != 0 {
+		t.Fatalf("should NOT split in soft zone without a natural break, got %d", stream.splitCount)
+	}
+	if stream.deltaRunes != 90 {
+		t.Fatalf("expected 90 accumulated runes, got %d", stream.deltaRunes)
+	}
+
+	// Push 20 more runes → 110 total → exceeds hard limit → force split.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: strings.Repeat("x", 20),
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 1 {
+		t.Fatalf("expected force-split at hard limit, got %d splits", stream.splitCount)
+	}
+}
+
+func TestPushDelta_NewlineTriggersBreak(t *testing.T) {
+	t.Parallel()
+	stream, _, _ := newDeltaSplitTestStream(t, 100, 3)
+
+	// 76 runes — just past soft limit (75).
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: strings.Repeat("w", 76),
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 0 {
+		t.Fatal("no break yet")
+	}
+
+	// Newline → natural break.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: "\n",
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 1 {
+		t.Fatalf("expected split on newline in soft zone, got %d", stream.splitCount)
+	}
+}
+
+func TestPushDelta_ChinesePunctuationBreak(t *testing.T) {
+	t.Parallel()
+	stream, _, _ := newDeltaSplitTestStream(t, 100, 3)
+
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: strings.Repeat("字", 76),
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	// Chinese period → natural break.
+	if err := stream.Push(context.Background(), StreamEvent{
+		Type:  StreamEventDelta,
+		Delta: "。",
+	}); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if stream.splitCount != 1 {
+		t.Fatalf("expected split on Chinese period, got %d", stream.splitCount)
+	}
+}
+
+func TestIsNaturalBreakPoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		text   string
+		expect bool
+	}{
+		{"empty", "", false},
+		{"plain word", "hello", false},
+		{"period", "end.", true},
+		{"period with trailing space", "end. ", true},
+		{"question mark", "why?", true},
+		{"exclamation", "wow!", true},
+		{"Chinese period", "结束。", true},
+		{"Chinese question", "什么？", true},
+		{"Chinese exclamation", "好！", true},
+		{"ellipsis", "wait…", true},
+		{"newline", "line\n", true},
+		{"double newline", "paragraph\n\n", true},
+		{"semicolon", "clause;", true},
+		{"Chinese semicolon", "分号；", true},
+		{"comma", "hello,", false},
+		{"mid-word", "incompl", false},
+		{"version number", "v2.0", false},
+		{"code dot", "obj.method", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isNaturalBreakPoint(tc.text)
+			if got != tc.expect {
+				t.Errorf("isNaturalBreakPoint(%q) = %v, want %v", tc.text, got, tc.expect)
 			}
 		})
 	}


### PR DESCRIPTION
# Summary
for #168
Split long AI responses into multiple platform messages during streaming instead of truncating them. The manager counts accumulated delta runes and opens a new stream when approaching the platform's TextChunkLimit. Uses a soft/hard limit strategy that prefers splitting at sentence ends or line breaks over cutting mid-sentence.

- Add pushDelta with soft (75%) / hard (100%) limit and natural break point detection
- Add splitStream, pushFinalAfterSplit, pushFinalWithChunking helpers
- Fix Discord adapter to use RuneCount Message Length
- Add tests for delta splitting, natural breaks, and final handling