### PR TITLE
fix(channel): return success when bind code is re-checked by same identity

### DIFF
--- a/internal/channel/inbound/identity.go
+++ b/internal/channel/inbound/identity.go
@@ -384,9 +384,9 @@ func (r *IdentityResolver) tryHandleBindCode(ctx context.Context, msg channel.In
 		return IdentityDecision{Stop: true, Reply: channel.Message{Text: text}}
 	}
 	if !code.UsedAt.IsZero() {
-    	if code.UsedByChannelIdentityID == channelIdentityID {
-            return true, reply(r.bindReply), code.IssuedByUserID, nil
-        }
+		if code.UsedByChannelIdentityID == channelIdentityID {
+			return true, reply(r.bindReply), code.IssuedByUserID, nil
+		}
 		return true, reply("Bind code already used."), "", nil
 	}
 	if !code.ExpiresAt.IsZero() && time.Now().UTC().After(code.ExpiresAt) {


### PR DESCRIPTION
# Problem
When binding a user identity via Telegram, the bot returns "Bind code already used" even though the binding process has succeeded in the database.

# Root Cause
`IdentityResolver.Resolve()` is being called twice for each inbound message: by the middleware layer and `HandleInbound`. The second response overwrites the first, so the user only sees the error.

# Fix
Add a check in `tryHandleBindCode`, When a bind code has already been used, check if it was used by the same channel identity. If yes, then return the success reply instead of an error.