### PR TITLE
fix(mcp): propagate network errors from replaceContainerSnapshot

### DIFF
--- a/internal/mcp/versioning.go
+++ b/internal/mcp/versioning.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"math"
 	"strings"
 	"time"
@@ -392,16 +391,18 @@ func (m *Manager) replaceContainerSnapshot(ctx context.Context, botID, container
 	// unconditionally so the next call dials fresh to the new process.
 	m.grpcPool.Remove(botID)
 
-	if netResult, err := m.service.SetupNetwork(ctx, ctr.NetworkSetupRequest{
+	netResult, err := m.service.SetupNetwork(ctx, ctr.NetworkSetupRequest{
 		ContainerID: containerID,
 		CNIBinDir:   m.cfg.CNIBinaryDir,
 		CNIConfDir:  m.cfg.CNIConfigDir,
-	}); err != nil {
-		m.logger.Warn("network setup failed after snapshot replace",
-			slog.String("container_id", containerID), slog.Any("error", err))
-	} else {
-		m.SetContainerIP(botID, netResult.IP)
+	})
+	if err != nil {
+		return fmt.Errorf("network setup after snapshot replace: %w", err)
 	}
+	if netResult.IP == "" {
+		return fmt.Errorf("network setup returned no IP after snapshot replace for %s", containerID)
+	}
+	m.SetContainerIP(botID, netResult.IP)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Network setup failure after snapshot replace (rollback/commit) was silently swallowed — the container would start but remain unreachable via gRPC.
- Follows up on #202 which fixed the same pattern in other code paths but missed `replaceContainerSnapshot`.

## Changes

| File | Fix |
|------|-----|
| `internal/mcp/versioning.go` | Return error from `SetupNetwork` instead of logging a warning; also error when IP is empty |

## Test plan

- [x] Create a snapshot, rollback — verify container is reachable via gRPC after rollback
- [x] Simulate CNI failure during rollback — verify error is returned, not silently swallowed