### PR TITLE
feat(cmd/agent): add asset opener support to feishu adapter

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -396,7 +396,9 @@ func provideChannelRegistry(log *slog.Logger, hub *local.RouteHub, mediaService 
 	qqAdapter.SetAssetOpener(mediaService)
 	registry.MustRegister(qqAdapter)
 
-	registry.MustRegister(feishu.NewFeishuAdapter(log))
+	feishuAdapter := feishu.NewFeishuAdapter(log)
+	feishuAdapter.SetAssetOpener(mediaService)
+	registry.MustRegister(feishuAdapter)
 	registry.MustRegister(local.NewCLIAdapter(hub))
 	registry.MustRegister(local.NewWebAdapter(hub))
 	return registry


### PR DESCRIPTION
这个 PR 修复了飞书通道发送附件时报错 `Error: attachment reference is required: provide platform_key/content_hash/base64/url` 的问题。此前 `FeishuAdapter` 虽已支持 `SetAssetOpener`，但启动注册阶段未注入 `mediaService`，使用 `content_hash` 发送data里的附件时会直接失败。

修复后：在 cmd/agent/main.go 注册飞书适配器时补齐了 `mediaService` 注入，使附件发送链路可从data里打开文件