### PR TITLE
docs: Fix misleading information in the quick start section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Or manually:
 ```bash
 git clone --depth 1 https://github.com/memohai/Memoh.git
 cd Memoh
+cp conf/app.docker.toml config.toml
+# Edit config.toml
 sudo docker compose up -d
 ```
 


### PR DESCRIPTION
Update the quick start section in README.md by adding a manual step to copy the configuration file.  
Failing to set the configuration file or database password before starting Docker will result in a startup failure.