### PR TITLE
fix(feishu): reduce API calls with webhook config lookup and caching

### DIFF
--- a/db/queries/channels.sql
+++ b/db/queries/channels.sql
@@ -8,6 +8,12 @@ FROM bot_channel_configs
 WHERE bot_id = $1 AND channel_type = $2
 LIMIT 1;
 
+-- name: GetBotChannelConfigByID :one
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+FROM bot_channel_configs
+WHERE id = $1
+LIMIT 1;
+
 -- name: GetBotChannelConfigByExternalIdentity :one
 SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
 FROM bot_channel_configs
@@ -65,4 +71,3 @@ SELECT id, user_id, channel_type, config, created_at, updated_at
 FROM user_channel_bindings
 WHERE channel_type = $1
 ORDER BY created_at DESC;
-

--- a/internal/channel/adapters/feishu/bot_identity.go
+++ b/internal/channel/adapters/feishu/bot_identity.go
@@ -30,15 +30,24 @@ func (a *FeishuAdapter) resolveBotOpenID(ctx context.Context, cfg channel.Channe
 	if openID := resolveConfiguredBotOpenID(cfg); openID != "" {
 		return openID
 	}
+	if cfg.ID != "" {
+		if v, ok := a.botOpenIDs.Load(cfg.ID); ok {
+			return v.(string)
+		}
+	}
 	discovered, externalID, err := a.DiscoverSelf(ctx, cfg.Credentials)
 	if err != nil {
-		if a != nil && a.logger != nil {
+		if a.logger != nil {
 			a.logger.Warn("discover self fallback failed", slog.String("config_id", cfg.ID), slog.Any("error", err))
 		}
 		return ""
 	}
-	if discoveredOpenID := strings.TrimSpace(channel.ReadString(discovered, "open_id", "openId")); discoveredOpenID != "" {
-		return discoveredOpenID
+	openID := strings.TrimSpace(channel.ReadString(discovered, "open_id", "openId"))
+	if openID == "" {
+		openID = resolveConfiguredBotOpenID(channel.ChannelConfig{ExternalIdentity: externalID})
 	}
-	return resolveConfiguredBotOpenID(channel.ChannelConfig{ExternalIdentity: externalID})
+	if openID != "" && cfg.ID != "" {
+		a.botOpenIDs.Store(cfg.ID, openID)
+	}
+	return openID
 }

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,8 +32,12 @@ type assetOpener interface {
 
 // FeishuAdapter implements the channel.Adapter, channel.Sender, and channel.Receiver interfaces for Feishu.
 type FeishuAdapter struct {
-	logger *slog.Logger
-	assets assetOpener
+	logger               *slog.Logger
+	assets               assetOpener
+	senderProfiles       sync.Map
+	senderProfileSweepMu sync.Mutex
+	senderProfileSweepAt time.Time
+	botOpenIDs           sync.Map
 }
 
 const processingBusyReactionType = "Typing"
@@ -615,7 +620,7 @@ func (a *FeishuAdapter) OpenStream(ctx context.Context, cfg channel.ChannelConfi
 		cfg:           cfg,
 		target:        target,
 		reply:         opts.Reply,
-		client:        client,
+		messageAPI:    client.Im.Message,
 		receiveID:     receiveID,
 		receiveType:   receiveType,
 		patchInterval: feishuStreamPatchInterval,

--- a/internal/channel/adapters/feishu/sender_profile.go
+++ b/internal/channel/adapters/feishu/sender_profile.go
@@ -21,11 +21,37 @@ type feishuSenderProfile struct {
 	avatarURL   string
 }
 
-const feishuChatMembersPageSize = 100
+const (
+	feishuChatMembersPageSize = 100
+	senderProfileCacheTTL     = 5 * time.Minute
+	senderProfileSweepWindow  = 1 * time.Minute
+)
+
+type feishuSenderProfileLookup interface {
+	LookupContact(ctx context.Context, openID, userID string) (feishuSenderProfile, error)
+	LookupGroupMember(ctx context.Context, chatID, memberIDType, memberID string) (feishuSenderProfile, error)
+}
+
+type larkSenderProfileLookup struct {
+	client *lark.Client
+}
+
+func (l larkSenderProfileLookup) LookupContact(ctx context.Context, openID, userID string) (feishuSenderProfile, error) {
+	return lookupSenderProfileFromContact(ctx, l.client, openID, userID)
+}
+
+func (l larkSenderProfileLookup) LookupGroupMember(ctx context.Context, chatID, memberIDType, memberID string) (feishuSenderProfile, error) {
+	return lookupSenderProfileFromGroupMember(ctx, l.client, chatID, memberIDType, memberID)
+}
+
+type cachedSenderProfile struct {
+	profile   feishuSenderProfile
+	expiresAt time.Time
+}
 
 // enrichSenderProfile fills sender display name / username for inbound messages.
-// It first tries Contact.User.Get (open_id/user_id), then falls back to group member
-// lookup when permissions are limited.
+// In group chats it prefers chat-specific aliases, then falls back to the global
+// contact profile when no group-scoped name is available.
 func (a *FeishuAdapter) enrichSenderProfile(ctx context.Context, cfg channel.ChannelConfig, event *larkim.P2MessageReceiveV1, msg *channel.InboundMessage) {
 	if msg == nil {
 		return
@@ -49,70 +75,126 @@ func (a *FeishuAdapter) enrichSenderProfile(ctx context.Context, cfg channel.Cha
 		chatID = strings.TrimSpace(*event.Event.Message.ChatId)
 	}
 
+	cacheKey := strings.Join([]string{cfg.ID, strings.TrimPrefix(chatID, "chat_id:"), openID, userID}, "|")
+	if cached, ok := a.loadCachedSenderProfile(cacheKey); ok {
+		applySenderProfile(msg, cached)
+		return
+	}
+
 	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	profile, err := a.lookupSenderProfile(lookupCtx, cfg, openID, userID, chatID)
-	if err != nil {
-		if a.logger != nil {
-			a.logger.Debug("feishu sender profile lookup failed",
-				slog.String("config_id", cfg.ID),
-				slog.String("open_id", openID),
-				slog.String("user_id", userID),
-				slog.String("chat_id", chatID),
-				slog.Any("error", err),
-			)
-		}
-	}
-	if strings.TrimSpace(profile.displayName) == "" && strings.TrimSpace(profile.username) == "" && strings.TrimSpace(profile.avatarURL) == "" {
-		profile = fallbackSenderProfile(openID, userID)
-	}
-	applySenderProfile(msg, profile)
-}
-
-func (*FeishuAdapter) lookupSenderProfile(ctx context.Context, cfg channel.ChannelConfig, openID, userID, chatID string) (feishuSenderProfile, error) {
 	feishuCfg, err := parseConfig(cfg.Credentials)
 	if err != nil {
-		return feishuSenderProfile{}, err
+		applySenderProfile(msg, fallbackSenderProfile(openID, userID))
+		return
 	}
-	client := feishuCfg.newClient()
+	profile, err := lookupSenderProfileWithLookup(lookupCtx, larkSenderProfileLookup{client: feishuCfg.newClient()}, openID, userID, chatID)
+	if err != nil && a.logger != nil {
+		a.logger.Debug("feishu sender profile lookup failed",
+			slog.String("config_id", cfg.ID),
+			slog.String("open_id", openID),
+			slog.String("user_id", userID),
+			slog.String("chat_id", chatID),
+			slog.Any("error", err),
+		)
+	}
+	if profile.displayName != "" || profile.username != "" || profile.avatarURL != "" {
+		a.storeCachedSenderProfile(cacheKey, profile)
+		applySenderProfile(msg, profile)
+	} else {
+		applySenderProfile(msg, fallbackSenderProfile(openID, userID))
+	}
+}
+
+func lookupSenderProfileWithLookup(ctx context.Context, lookup feishuSenderProfileLookup, openID, userID, chatID string) (feishuSenderProfile, error) {
+	if lookup == nil {
+		return feishuSenderProfile{}, errors.New("sender profile lookup not configured")
+	}
+	chatID = strings.TrimPrefix(strings.TrimSpace(chatID), "chat_id:")
 
 	var lastErr error
-	chatID = strings.TrimSpace(chatID)
-	chatID = strings.TrimPrefix(chatID, "chat_id:")
-
-	// Group scene: chat members has the highest chance to return a human-readable name.
-	if chatID != "" && openID != "" {
-		if profile, err := lookupSenderProfileFromGroupMember(ctx, client, chatID, "open_id", openID); err == nil {
-			if strings.TrimSpace(profile.displayName) != "" || strings.TrimSpace(profile.username) != "" {
-				return profile, nil
+	if chatID != "" {
+		if openID != "" {
+			if p, err := lookup.LookupGroupMember(ctx, chatID, "open_id", openID); err == nil {
+				if p.displayName != "" || p.username != "" || p.avatarURL != "" {
+					return p, nil
+				}
+			} else {
+				lastErr = err
 			}
-		} else {
-			lastErr = err
 		}
-	}
-	if chatID != "" && userID != "" {
-		if profile, err := lookupSenderProfileFromGroupMember(ctx, client, chatID, "user_id", userID); err == nil {
-			if strings.TrimSpace(profile.displayName) != "" || strings.TrimSpace(profile.username) != "" {
-				return profile, nil
+		if userID != "" {
+			if p, err := lookup.LookupGroupMember(ctx, chatID, "user_id", userID); err == nil {
+				if p.displayName != "" || p.username != "" || p.avatarURL != "" {
+					return p, nil
+				}
+			} else {
+				lastErr = err
 			}
-		} else {
-			lastErr = err
 		}
 	}
 
-	if profile, err := lookupSenderProfileFromContact(ctx, client, openID, userID); err == nil {
-		if strings.TrimSpace(profile.displayName) != "" || strings.TrimSpace(profile.username) != "" {
-			return profile, nil
+	if p, err := lookup.LookupContact(ctx, openID, userID); err == nil {
+		if p.displayName != "" || p.username != "" || p.avatarURL != "" {
+			return p, nil
 		}
 	} else {
 		lastErr = err
 	}
 
-	if lastErr != nil {
-		return feishuSenderProfile{}, lastErr
+	return feishuSenderProfile{}, lastErr
+}
+
+func (a *FeishuAdapter) loadCachedSenderProfile(key string) (feishuSenderProfile, bool) {
+	if a == nil || strings.TrimSpace(key) == "" {
+		return feishuSenderProfile{}, false
 	}
-	return feishuSenderProfile{}, nil
+	raw, ok := a.senderProfiles.Load(key)
+	if !ok {
+		return feishuSenderProfile{}, false
+	}
+	entry, ok := raw.(cachedSenderProfile)
+	if !ok {
+		a.senderProfiles.Delete(key)
+		return feishuSenderProfile{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		a.senderProfiles.Delete(key)
+		return feishuSenderProfile{}, false
+	}
+	return entry.profile, true
+}
+
+func (a *FeishuAdapter) storeCachedSenderProfile(key string, profile feishuSenderProfile) {
+	if a == nil || strings.TrimSpace(key) == "" {
+		return
+	}
+	now := time.Now()
+	a.senderProfiles.Store(key, cachedSenderProfile{
+		profile:   profile,
+		expiresAt: now.Add(senderProfileCacheTTL),
+	})
+	a.maybeSweepExpiredSenderProfiles(now)
+}
+
+func (a *FeishuAdapter) maybeSweepExpiredSenderProfiles(now time.Time) {
+	if a == nil {
+		return
+	}
+	a.senderProfileSweepMu.Lock()
+	defer a.senderProfileSweepMu.Unlock()
+	if !a.senderProfileSweepAt.IsZero() && now.Sub(a.senderProfileSweepAt) < senderProfileSweepWindow {
+		return
+	}
+	a.senderProfileSweepAt = now
+	a.senderProfiles.Range(func(key, value any) bool {
+		entry, ok := value.(cachedSenderProfile)
+		if !ok || now.After(entry.expiresAt) {
+			a.senderProfiles.Delete(key)
+		}
+		return true
+	})
 }
 
 func lookupSenderProfileFromContact(ctx context.Context, client *lark.Client, openID, userID string) (feishuSenderProfile, error) {
@@ -227,9 +309,8 @@ func fallbackSenderProfile(openID, userID string) feishuSenderProfile {
 	if username == "" {
 		return feishuSenderProfile{}
 	}
-	displayName := username
 	return feishuSenderProfile{
-		displayName: displayName,
+		displayName: username,
 		username:    username,
 	}
 }

--- a/internal/channel/adapters/feishu/sender_profile_test.go
+++ b/internal/channel/adapters/feishu/sender_profile_test.go
@@ -1,10 +1,39 @@
 package feishu
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/memohai/memoh/internal/channel"
 )
+
+type fakeSenderProfileLookup struct {
+	calls        []string
+	contact      feishuSenderProfile
+	contactErr   error
+	groupOpen    feishuSenderProfile
+	groupOpenErr error
+	groupUser    feishuSenderProfile
+	groupUserErr error
+}
+
+func (f *fakeSenderProfileLookup) LookupContact(_ context.Context, openID, userID string) (feishuSenderProfile, error) {
+	f.calls = append(f.calls, "contact:"+openID+":"+userID)
+	return f.contact, f.contactErr
+}
+
+func (f *fakeSenderProfileLookup) LookupGroupMember(_ context.Context, chatID, memberIDType, memberID string) (feishuSenderProfile, error) {
+	f.calls = append(f.calls, "group:"+chatID+":"+memberIDType+":"+memberID)
+	switch memberIDType {
+	case "open_id":
+		return f.groupOpen, f.groupOpenErr
+	case "user_id":
+		return f.groupUser, f.groupUserErr
+	default:
+		return feishuSenderProfile{}, nil
+	}
+}
 
 func TestApplySenderProfileFillDisplayAndUsername(t *testing.T) {
 	msg := &channel.InboundMessage{
@@ -63,5 +92,112 @@ func TestApplySenderProfileKeepExistingIdentityFields(t *testing.T) {
 	}
 	if got := msg.Sender.Attribute("username"); got != "old_user" {
 		t.Fatalf("expected original attribute username preserved, got %q", got)
+	}
+}
+
+func TestLookupSenderProfileLookupOrder(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		openID      string
+		userID      string
+		chatID      string
+		lookup      *fakeSenderProfileLookup
+		wantProfile feishuSenderProfile
+		wantCalls   []string
+	}{
+		{
+			name:   "contact without group context",
+			openID: "ou_123",
+			userID: "u_123",
+			lookup: &fakeSenderProfileLookup{
+				contact: feishuSenderProfile{
+					displayName: "Alice Zhang",
+					username:    "alice",
+				},
+			},
+			wantProfile: feishuSenderProfile{displayName: "Alice Zhang", username: "alice"},
+			wantCalls:   []string{"contact:ou_123:u_123"},
+		},
+		{
+			name:   "group alias wins over contact profile",
+			openID: "ou_456",
+			userID: "u_456",
+			chatID: "oc_group_2",
+			lookup: &fakeSenderProfileLookup{
+				contact: feishuSenderProfile{
+					displayName: "Alice Global",
+					username:    "alice",
+				},
+				groupOpen: feishuSenderProfile{
+					displayName: "Alice In Group",
+					username:    "alice-group",
+				},
+			},
+			wantProfile: feishuSenderProfile{displayName: "Alice In Group", username: "alice-group"},
+			wantCalls:   []string{"group:oc_group_2:open_id:ou_456"},
+		},
+		{
+			name:   "group miss falls back to contact profile",
+			openID: "ou_456",
+			userID: "u_456",
+			chatID: "oc_group_2",
+			lookup: &fakeSenderProfileLookup{
+				contact: feishuSenderProfile{
+					displayName: "Bob Global",
+					username:    "bob",
+				},
+			},
+			wantProfile: feishuSenderProfile{displayName: "Bob Global", username: "bob"},
+			wantCalls: []string{
+				"group:oc_group_2:open_id:ou_456",
+				"group:oc_group_2:user_id:u_456",
+				"contact:ou_456:u_456",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			profile, err := lookupSenderProfileWithLookup(context.Background(), tc.lookup, tc.openID, tc.userID, tc.chatID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if profile != tc.wantProfile {
+				t.Fatalf("unexpected profile: got %#v want %#v", profile, tc.wantProfile)
+			}
+			if len(tc.lookup.calls) != len(tc.wantCalls) {
+				t.Fatalf("unexpected lookup count: %#v", tc.lookup.calls)
+			}
+			for i, want := range tc.wantCalls {
+				if tc.lookup.calls[i] != want {
+					t.Fatalf("unexpected lookup order: %#v", tc.lookup.calls)
+				}
+			}
+		})
+	}
+}
+
+func TestStoreCachedSenderProfileSweepsExpiredEntries(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewFeishuAdapter(nil)
+	adapter.senderProfiles.Store("expired", cachedSenderProfile{
+		profile:   feishuSenderProfile{displayName: "Old Name"},
+		expiresAt: time.Now().Add(-time.Minute),
+	})
+	adapter.senderProfileSweepAt = time.Now().Add(-senderProfileSweepWindow - time.Second)
+
+	adapter.storeCachedSenderProfile("fresh", feishuSenderProfile{displayName: "Fresh Name"})
+
+	if _, ok := adapter.senderProfiles.Load("expired"); ok {
+		t.Fatal("expected expired sender profile cache entry to be swept")
+	}
+	if cached, ok := adapter.loadCachedSenderProfile("fresh"); !ok || cached.displayName != "Fresh Name" {
+		t.Fatalf("expected fresh sender profile cache entry to remain, got %#v ok=%v", cached, ok)
 	}
 }

--- a/internal/channel/adapters/feishu/stream.go
+++ b/internal/channel/adapters/feishu/stream.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 
 	"github.com/memohai/memoh/internal/channel"
@@ -29,7 +29,7 @@ type feishuOutboundStream struct {
 	cfg           channel.ChannelConfig
 	target        string
 	reply         *channel.ReplyRef
-	client        *lark.Client
+	messageAPI    feishuStreamMessageAPI
 	receiveID     string
 	receiveType   string
 	cardMessageID string
@@ -38,6 +38,12 @@ type feishuOutboundStream struct {
 	lastPatched   string
 	patchInterval time.Duration
 	closed        atomic.Bool
+}
+
+type feishuStreamMessageAPI interface {
+	Create(ctx context.Context, req *larkim.CreateMessageReq, options ...larkcore.RequestOptionFunc) (*larkim.CreateMessageResp, error)
+	Reply(ctx context.Context, req *larkim.ReplyMessageReq, options ...larkcore.RequestOptionFunc) (*larkim.ReplyMessageResp, error)
+	Patch(ctx context.Context, req *larkim.PatchMessageReq, options ...larkcore.RequestOptionFunc) (*larkim.PatchMessageResp, error)
 }
 
 func (s *feishuOutboundStream) Push(ctx context.Context, event channel.StreamEvent) error {
@@ -75,16 +81,10 @@ func (s *feishuOutboundStream) Push(ctx context.Context, event channel.StreamEve
 		if s.cardMessageID != "" && bufText != "" {
 			_ = s.patchCard(ctx, bufText)
 		}
-		s.cardMessageID = ""
-		s.lastPatched = ""
-		s.lastPatchedAt = time.Time{}
-		s.textBuffer.Reset()
+		s.resetDraftBuffer()
 		return nil
 	case channel.StreamEventToolCallEnd:
-		s.cardMessageID = ""
-		s.lastPatched = ""
 		s.lastPatchedAt = time.Time{}
-		s.textBuffer.Reset()
 		return nil
 	case channel.StreamEventAttachment:
 		if len(event.Attachments) == 0 {
@@ -163,8 +163,8 @@ func (s *feishuOutboundStream) ensureCard(ctx context.Context, text string) erro
 	if strings.TrimSpace(s.cardMessageID) != "" {
 		return nil
 	}
-	if s.client == nil {
-		return errors.New("feishu client not configured")
+	if s.messageAPI == nil {
+		return errors.New("feishu message api not configured")
 	}
 	content, err := buildFeishuStreamCardContent(text)
 	if err != nil {
@@ -179,7 +179,7 @@ func (s *feishuOutboundStream) ensureCard(ctx context.Context, text string) erro
 				Uuid(uuid.NewString()).
 				Build()).
 			Build()
-		replyResp, err := s.client.Im.Message.Reply(ctx, replyReq)
+		replyResp, err := s.messageAPI.Reply(ctx, replyReq)
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func (s *feishuOutboundStream) ensureCard(ctx context.Context, text string) erro
 			Uuid(uuid.NewString()).
 			Build()).
 		Build()
-	createResp, err := s.client.Im.Message.Create(ctx, createReq)
+	createResp, err := s.messageAPI.Create(ctx, createReq)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (s *feishuOutboundStream) patchCard(ctx context.Context, text string) error
 			Content(content).
 			Build()).
 		Build()
-	patchResp, err := s.client.Im.Message.Patch(ctx, patchReq)
+	patchResp, err := s.messageAPI.Patch(ctx, patchReq)
 	if err != nil {
 		return err
 	}
@@ -259,6 +259,11 @@ func (s *feishuOutboundStream) patchCard(ctx context.Context, text string) error
 	s.lastPatched = contentText
 	s.lastPatchedAt = time.Now()
 	return nil
+}
+
+func (s *feishuOutboundStream) resetDraftBuffer() {
+	s.textBuffer.Reset()
+	s.lastPatchedAt = time.Time{}
 }
 
 // extractReadableFromJSON tries to extract human-readable text from JSON-like content.

--- a/internal/channel/adapters/feishu/stream_test.go
+++ b/internal/channel/adapters/feishu/stream_test.go
@@ -1,8 +1,60 @@
 package feishu
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/memohai/memoh/internal/channel"
 )
+
+type fakeFeishuStreamMessageAPI struct {
+	createCalls []string
+	replyCalls  []string
+	patchCalls  []string
+}
+
+func (f *fakeFeishuStreamMessageAPI) Create(_ context.Context, req *larkim.CreateMessageReq, _ ...larkcore.RequestOptionFunc) (*larkim.CreateMessageResp, error) {
+	content := ""
+	if req != nil && req.Body != nil && req.Body.Content != nil {
+		content = strings.TrimSpace(*req.Body.Content)
+	}
+	f.createCalls = append(f.createCalls, content)
+	messageID := "om_stream_created"
+	return &larkim.CreateMessageResp{
+		CodeError: larkcore.CodeError{Code: 0},
+		Data: &larkim.CreateMessageRespData{
+			MessageId: &messageID,
+		},
+	}, nil
+}
+
+func (f *fakeFeishuStreamMessageAPI) Reply(_ context.Context, req *larkim.ReplyMessageReq, _ ...larkcore.RequestOptionFunc) (*larkim.ReplyMessageResp, error) {
+	content := ""
+	if req != nil && req.Body != nil && req.Body.Content != nil {
+		content = strings.TrimSpace(*req.Body.Content)
+	}
+	f.replyCalls = append(f.replyCalls, content)
+	messageID := "om_stream_reply"
+	return &larkim.ReplyMessageResp{
+		CodeError: larkcore.CodeError{Code: 0},
+		Data: &larkim.ReplyMessageRespData{
+			MessageId: &messageID,
+		},
+	}, nil
+}
+
+func (f *fakeFeishuStreamMessageAPI) Patch(_ context.Context, req *larkim.PatchMessageReq, _ ...larkcore.RequestOptionFunc) (*larkim.PatchMessageResp, error) {
+	content := ""
+	if req != nil && req.Body != nil && req.Body.Content != nil {
+		content = strings.TrimSpace(*req.Body.Content)
+	}
+	f.patchCalls = append(f.patchCalls, content)
+	return &larkim.PatchMessageResp{CodeError: larkcore.CodeError{Code: 0}}, nil
+}
 
 func TestExtractReadableFromJSON(t *testing.T) {
 	t.Parallel()
@@ -25,6 +77,104 @@ func TestExtractReadableFromJSON(t *testing.T) {
 			got := extractReadableFromJSON(tc.in)
 			if got != tc.want {
 				t.Errorf("extractReadableFromJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFeishuOutboundStreamToolCallBoundaries(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name               string
+		run                func(context.Context, *feishuOutboundStream) error
+		wantLastPatch      string
+		wantAbsentFragment string
+	}{
+		{
+			name: "post-tool delta keeps single card",
+			run: func(ctx context.Context, stream *feishuOutboundStream) error {
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventStatus, Status: channel.StreamStatusStarted}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventDelta, Delta: "hello"}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventToolCallStart}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventToolCallEnd}); err != nil {
+					return err
+				}
+				return stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventDelta, Delta: "world"})
+			},
+			wantLastPatch:      "world",
+			wantAbsentFragment: "hello",
+		},
+		{
+			name: "final text overrides pre-tool draft",
+			run: func(ctx context.Context, stream *feishuOutboundStream) error {
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventStatus, Status: channel.StreamStatusStarted}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventDelta, Delta: "draft before tool"}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventToolCallStart}); err != nil {
+					return err
+				}
+				if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventToolCallEnd}); err != nil {
+					return err
+				}
+				return stream.Push(ctx, channel.StreamEvent{
+					Type: channel.StreamEventFinal,
+					Final: &channel.StreamFinalizePayload{
+						Message: channel.Message{Text: "final answer"},
+					},
+				})
+			},
+			wantLastPatch:      "final answer",
+			wantAbsentFragment: "draft before tool",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := &fakeFeishuStreamMessageAPI{}
+			stream := &feishuOutboundStream{
+				adapter:       NewFeishuAdapter(nil),
+				cfg:           channel.ChannelConfig{ID: "cfg-1"},
+				target:        "chat_id:oc_group_1",
+				messageAPI:    api,
+				receiveID:     "oc_group_1",
+				receiveType:   larkim.ReceiveIdTypeChatId,
+				patchInterval: 0,
+			}
+
+			if err := tc.run(context.Background(), stream); err != nil {
+				t.Fatalf("stream sequence failed: %v", err)
+			}
+			if len(api.createCalls) != 1 {
+				t.Fatalf("expected exactly one card create, got %d", len(api.createCalls))
+			}
+			if len(api.replyCalls) != 0 {
+				t.Fatalf("expected no reply call, got %d", len(api.replyCalls))
+			}
+			if len(api.patchCalls) < 2 {
+				t.Fatalf("expected card patches across tool boundaries, got %d", len(api.patchCalls))
+			}
+			if stream.cardMessageID != "om_stream_created" {
+				t.Fatalf("expected card message id to be preserved, got %q", stream.cardMessageID)
+			}
+			lastPatch := stream.lastPatched
+			if !strings.Contains(lastPatch, tc.wantLastPatch) {
+				t.Fatalf("expected last patch to contain %q, got %s", tc.wantLastPatch, lastPatch)
+			}
+			if tc.wantAbsentFragment != "" && strings.Contains(lastPatch, tc.wantAbsentFragment) {
+				t.Fatalf("expected last patch to drop stale fragment %q, got %s", tc.wantAbsentFragment, lastPatch)
 			}
 		})
 	}

--- a/internal/channel/adapters/feishu/webhook_handler.go
+++ b/internal/channel/adapters/feishu/webhook_handler.go
@@ -3,12 +3,14 @@ package feishu
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
@@ -18,7 +20,7 @@ import (
 )
 
 type webhookConfigStore interface {
-	ListConfigsByType(ctx context.Context, channelType channel.ChannelType) ([]channel.ChannelConfig, error)
+	GetConfigByID(ctx context.Context, configID string) (channel.ChannelConfig, error)
 }
 
 type webhookInboundManager interface {
@@ -213,14 +215,18 @@ func writeEventResponse(c echo.Context, resp *larkevent.EventResp) error {
 }
 
 func (h *WebhookHandler) findConfigByID(ctx context.Context, configID string) (channel.ChannelConfig, error) {
-	items, err := h.store.ListConfigsByType(ctx, Type)
+	if _, err := uuid.Parse(strings.TrimSpace(configID)); err != nil {
+		return channel.ChannelConfig{}, echo.NewHTTPError(http.StatusNotFound, "channel config not found")
+	}
+	item, err := h.store.GetConfigByID(ctx, configID)
 	if err != nil {
+		if errors.Is(err, channel.ErrChannelConfigNotFound) {
+			return channel.ChannelConfig{}, echo.NewHTTPError(http.StatusNotFound, "channel config not found")
+		}
 		return channel.ChannelConfig{}, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	for _, item := range items {
-		if strings.TrimSpace(item.ID) == configID {
-			return item, nil
-		}
+	if item.ChannelType != Type {
+		return channel.ChannelConfig{}, echo.NewHTTPError(http.StatusNotFound, "channel config not found")
 	}
-	return channel.ChannelConfig{}, echo.NewHTTPError(http.StatusNotFound, "channel config not found")
+	return item, nil
 }

--- a/internal/channel/adapters/feishu/webhook_handler_test.go
+++ b/internal/channel/adapters/feishu/webhook_handler_test.go
@@ -14,18 +14,23 @@ import (
 	"github.com/memohai/memoh/internal/channel"
 )
 
-const testWebhookConfigID = "cfg-1"
+const (
+	testWebhookConfigID      = "550e8400-e29b-41d4-a716-446655440000"
+	testOtherWebhookConfigID = "550e8400-e29b-41d4-a716-446655440001"
+)
 
 type fakeWebhookStore struct {
-	configs []channel.ChannelConfig
-	err     error
+	config   channel.ChannelConfig
+	getCalls []string
+	getErr   error
 }
 
-func (s *fakeWebhookStore) ListConfigsByType(_ context.Context, _ channel.ChannelType) ([]channel.ChannelConfig, error) {
-	if s.err != nil {
-		return nil, s.err
+func (s *fakeWebhookStore) GetConfigByID(_ context.Context, configID string) (channel.ChannelConfig, error) {
+	s.getCalls = append(s.getCalls, configID)
+	if s.getErr != nil {
+		return channel.ChannelConfig{}, s.getErr
 	}
-	return s.configs, nil
+	return s.config, nil
 }
 
 type fakeWebhookManager struct {
@@ -84,13 +89,11 @@ func TestWebhookHandler_URLVerification(t *testing.T) {
 			t.Parallel()
 
 			store := &fakeWebhookStore{
-				configs: []channel.ChannelConfig{
-					{
-						ID:          testWebhookConfigID,
-						BotID:       "bot-1",
-						ChannelType: Type,
-						Credentials: tc.credentials,
-					},
+				config: channel.ChannelConfig{
+					ID:          testWebhookConfigID,
+					BotID:       "bot-1",
+					ChannelType: Type,
+					Credentials: tc.credentials,
 				},
 			}
 			manager := &fakeWebhookManager{}
@@ -142,17 +145,15 @@ func TestWebhookHandler_URLVerificationWithEncryptKeyWithoutVerificationToken(t 
 	t.Parallel()
 
 	store := &fakeWebhookStore{
-		configs: []channel.ChannelConfig{
-			{
-				ID:          testWebhookConfigID,
-				BotID:       "bot-1",
-				ChannelType: Type,
-				Credentials: map[string]any{
-					"app_id":       "app",
-					"app_secret":   "secret",
-					"encrypt_key":  "encrypt-key",
-					"inbound_mode": "webhook",
-				},
+		config: channel.ChannelConfig{
+			ID:          testWebhookConfigID,
+			BotID:       "bot-1",
+			ChannelType: Type,
+			Credentials: map[string]any{
+				"app_id":       "app",
+				"app_secret":   "secret",
+				"encrypt_key":  "encrypt-key",
+				"inbound_mode": "webhook",
 			},
 		},
 	}
@@ -209,30 +210,70 @@ func TestWebhookHandler_Probe(t *testing.T) {
 	}
 }
 
-func TestWebhookHandler_ConfigLookupRejectsNotFound(t *testing.T) {
+func TestWebhookHandler_ConfigLookupRejectsNotFoundCases(t *testing.T) {
 	t.Parallel()
 
-	store := &fakeWebhookStore{}
-	h := NewWebhookHandler(nil, store, &fakeWebhookManager{})
-
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/channels/feishu/webhook/not-found", strings.NewReader(`{}`))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetParamNames("config_id")
-	c.SetParamValues("not-found")
-
-	err := h.Handle(c)
-	if err == nil {
-		t.Fatal("expected not found error")
+	cases := []struct {
+		name      string
+		configID  string
+		store     *fakeWebhookStore
+		wantCalls []string
+	}{
+		{
+			name:      "invalid uuid",
+			configID:  "not-a-uuid",
+			store:     &fakeWebhookStore{},
+			wantCalls: nil,
+		},
+		{
+			name:     "other channel type",
+			configID: testOtherWebhookConfigID,
+			store: &fakeWebhookStore{
+				config: channel.ChannelConfig{
+					ID:          testOtherWebhookConfigID,
+					BotID:       "bot-1",
+					ChannelType: channel.ChannelType("telegram"),
+				},
+			},
+			wantCalls: []string{testOtherWebhookConfigID},
+		},
 	}
-	he := &echo.HTTPError{}
-	if !errors.As(err, &he) {
-		t.Fatalf("expected HTTPError, got %T", err)
-	}
-	if he.Code != http.StatusNotFound {
-		t.Fatalf("unexpected status code: %d", he.Code)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewWebhookHandler(nil, tc.store, &fakeWebhookManager{})
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/channels/feishu/webhook/"+tc.configID, strings.NewReader(`{}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("config_id")
+			c.SetParamValues(tc.configID)
+
+			err := h.Handle(c)
+			if err == nil {
+				t.Fatal("expected not found error")
+			}
+			he := &echo.HTTPError{}
+			if !errors.As(err, &he) {
+				t.Fatalf("expected HTTPError, got %T", err)
+			}
+			if he.Code != http.StatusNotFound {
+				t.Fatalf("unexpected status code: %d", he.Code)
+			}
+			if len(tc.store.getCalls) != len(tc.wantCalls) {
+				t.Fatalf("unexpected store lookup calls: %#v", tc.store.getCalls)
+			}
+			for i, want := range tc.wantCalls {
+				if tc.store.getCalls[i] != want {
+					t.Fatalf("unexpected store lookup calls: %#v", tc.store.getCalls)
+				}
+			}
+		})
 	}
 }
 
@@ -240,20 +281,18 @@ func TestWebhookHandler_EventCallbackDispatchesInbound(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeWebhookStore{
-		configs: []channel.ChannelConfig{
-			{
-				ID:          testWebhookConfigID,
-				BotID:       "bot-1",
-				ChannelType: Type,
-				SelfIdentity: map[string]any{
-					"open_id": "ou_bot_1",
-				},
-				Credentials: map[string]any{
-					"app_id":             "app",
-					"app_secret":         "secret",
-					"verification_token": "verify-token",
-					"inbound_mode":       "webhook",
-				},
+		config: channel.ChannelConfig{
+			ID:          testWebhookConfigID,
+			BotID:       "bot-1",
+			ChannelType: Type,
+			SelfIdentity: map[string]any{
+				"open_id": "ou_bot_1",
+			},
+			Credentials: map[string]any{
+				"app_id":             "app",
+				"app_secret":         "secret",
+				"verification_token": "verify-token",
+				"inbound_mode":       "webhook",
 			},
 		},
 	}
@@ -278,6 +317,9 @@ func TestWebhookHandler_EventCallbackDispatchesInbound(t *testing.T) {
 	if len(manager.calls) != 1 {
 		t.Fatalf("expected one inbound call, got %d", len(manager.calls))
 	}
+	if len(store.getCalls) != 1 || store.getCalls[0] != testWebhookConfigID {
+		t.Fatalf("expected direct config lookup by id, got %#v", store.getCalls)
+	}
 	got := manager.calls[0].msg
 	if got.BotID != "bot-1" {
 		t.Fatalf("unexpected bot id: %s", got.BotID)
@@ -291,18 +333,16 @@ func TestWebhookHandler_EventCallbackUsesExternalIdentityForMentionFilter(t *tes
 	t.Parallel()
 
 	store := &fakeWebhookStore{
-		configs: []channel.ChannelConfig{
-			{
-				ID:               testWebhookConfigID,
-				BotID:            "bot-1",
-				ChannelType:      Type,
-				ExternalIdentity: "open_id:ou_bot_1",
-				Credentials: map[string]any{
-					"app_id":             "app",
-					"app_secret":         "secret",
-					"verification_token": "verify-token",
-					"inbound_mode":       "webhook",
-				},
+		config: channel.ChannelConfig{
+			ID:               testWebhookConfigID,
+			BotID:            "bot-1",
+			ChannelType:      Type,
+			ExternalIdentity: "open_id:ou_bot_1",
+			Credentials: map[string]any{
+				"app_id":             "app",
+				"app_secret":         "secret",
+				"verification_token": "verify-token",
+				"inbound_mode":       "webhook",
 			},
 		},
 	}
@@ -333,26 +373,28 @@ func TestWebhookHandler_EventCallbackUsesExternalIdentityForMentionFilter(t *tes
 	}
 }
 
-func TestWebhookHandler_EventCallbackRejectsInvalidTokenWhenEncryptKeyMissing(t *testing.T) {
+func TestWebhookHandler_EventCallbackRejectsInvalidAuth(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name        string
 		credentials map[string]any
 		body        string
+		wantStatus  int
 	}{
 		{
-			name: "plaintext callback",
+			name: "invalid verification token",
 			credentials: map[string]any{
 				"app_id":             "app",
 				"app_secret":         "secret",
 				"verification_token": "verify-token",
 				"inbound_mode":       "webhook",
 			},
-			body: `{"schema":"2.0","header":{"event_id":"evt_1","event_type":"im.message.receive_v1","token":"forged-token"},"event":{"sender":{"sender_id":{"open_id":"ou_user_1"}},"message":{"message_id":"om_1","chat_id":"oc_1","chat_type":"p2p","message_type":"text","content":"{\"text\":\"hello\"}"}},"type":"event_callback"}`,
+			body:       `{"schema":"2.0","header":{"event_id":"evt_1","event_type":"im.message.receive_v1","token":"forged-token"},"event":{"sender":{"sender_id":{"open_id":"ou_user_1"}},"message":{"message_id":"om_1","chat_id":"oc_1","chat_type":"p2p","message_type":"text","content":"{\"text\":\"hello\"}"}},"type":"event_callback"}`,
+			wantStatus: http.StatusUnauthorized,
 		},
 		{
-			name: "encrypted callback",
+			name: "encrypted callback with invalid verification token",
 			credentials: map[string]any{
 				"app_id":             "app",
 				"app_secret":         "secret",
@@ -367,6 +409,17 @@ func TestWebhookHandler_EventCallbackRejectsInvalidTokenWhenEncryptKeyMissing(t 
 				}
 				return `{"encrypt":"` + encrypt + `"}`
 			}(),
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing webhook secrets",
+			credentials: map[string]any{
+				"app_id":       "app",
+				"app_secret":   "secret",
+				"inbound_mode": "webhook",
+			},
+			body:       `{"schema":"2.0","header":{"event_id":"evt_1","event_type":"im.message.receive_v1","token":"verify-token"},"event":{"sender":{"sender_id":{"open_id":"ou_user_1"}},"message":{"message_id":"om_1","chat_id":"oc_1","chat_type":"p2p","message_type":"text","content":"{\"text\":\"hello\"}"}},"type":"event_callback"}`,
+			wantStatus: http.StatusBadRequest,
 		},
 	}
 
@@ -376,13 +429,11 @@ func TestWebhookHandler_EventCallbackRejectsInvalidTokenWhenEncryptKeyMissing(t 
 			t.Parallel()
 
 			store := &fakeWebhookStore{
-				configs: []channel.ChannelConfig{
-					{
-						ID:          testWebhookConfigID,
-						BotID:       "bot-1",
-						ChannelType: Type,
-						Credentials: tc.credentials,
-					},
+				config: channel.ChannelConfig{
+					ID:          testWebhookConfigID,
+					BotID:       "bot-1",
+					ChannelType: Type,
+					Credentials: tc.credentials,
 				},
 			}
 			manager := &fakeWebhookManager{}
@@ -398,13 +449,13 @@ func TestWebhookHandler_EventCallbackRejectsInvalidTokenWhenEncryptKeyMissing(t 
 
 			err := h.Handle(c)
 			if err == nil {
-				t.Fatal("expected unauthorized error")
+				t.Fatal("expected auth error")
 			}
 			he := &echo.HTTPError{}
 			if !errors.As(err, &he) {
 				t.Fatalf("expected HTTPError, got %T", err)
 			}
-			if he.Code != http.StatusUnauthorized {
+			if he.Code != tc.wantStatus {
 				t.Fatalf("unexpected status code: %d", he.Code)
 			}
 			if len(manager.calls) != 0 {
@@ -418,17 +469,15 @@ func TestWebhookHandler_RejectsOversizedBody(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeWebhookStore{
-		configs: []channel.ChannelConfig{
-			{
-				ID:          testWebhookConfigID,
-				BotID:       "bot-1",
-				ChannelType: Type,
-				Credentials: map[string]any{
-					"app_id":             "app",
-					"app_secret":         "secret",
-					"verification_token": "verify-token",
-					"inbound_mode":       "webhook",
-				},
+		config: channel.ChannelConfig{
+			ID:          testWebhookConfigID,
+			BotID:       "bot-1",
+			ChannelType: Type,
+			Credentials: map[string]any{
+				"app_id":             "app",
+				"app_secret":         "secret",
+				"verification_token": "verify-token",
+				"inbound_mode":       "webhook",
 			},
 		},
 	}

--- a/internal/channel/service.go
+++ b/internal/channel/service.go
@@ -215,6 +215,25 @@ func (s *Store) ResolveEffectiveConfig(ctx context.Context, botID string, channe
 	return ChannelConfig{}, fmt.Errorf("%w", ErrChannelConfigNotFound)
 }
 
+// GetConfigByID returns a channel configuration by its persisted config ID.
+func (s *Store) GetConfigByID(ctx context.Context, configID string) (ChannelConfig, error) {
+	if s.queries == nil {
+		return ChannelConfig{}, errors.New("channel queries not configured")
+	}
+	pgConfigID, err := db.ParseUUID(configID)
+	if err != nil {
+		return ChannelConfig{}, err
+	}
+	row, err := s.queries.GetBotChannelConfigByID(ctx, pgConfigID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ChannelConfig{}, fmt.Errorf("%w", ErrChannelConfigNotFound)
+		}
+		return ChannelConfig{}, err
+	}
+	return normalizeChannelConfigFromRow(row)
+}
+
 // ListConfigsByType returns all channel configurations of the given type.
 func (s *Store) ListConfigsByType(ctx context.Context, channelType ChannelType) ([]ChannelConfig, error) {
 	if s.queries == nil {

--- a/internal/db/sqlc/channels.sql.go
+++ b/internal/db/sqlc/channels.sql.go
@@ -90,6 +90,33 @@ func (q *Queries) GetBotChannelConfigByExternalIdentity(ctx context.Context, arg
 	return i, err
 }
 
+const getBotChannelConfigByID = `-- name: GetBotChannelConfigByID :one
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+FROM bot_channel_configs
+WHERE id = $1
+LIMIT 1
+`
+
+func (q *Queries) GetBotChannelConfigByID(ctx context.Context, id pgtype.UUID) (BotChannelConfig, error) {
+	row := q.db.QueryRow(ctx, getBotChannelConfigByID, id)
+	var i BotChannelConfig
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.ChannelType,
+		&i.Credentials,
+		&i.ExternalIdentity,
+		&i.SelfIdentity,
+		&i.Routing,
+		&i.Capabilities,
+		&i.Disabled,
+		&i.VerifiedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getUserChannelBinding = `-- name: GetUserChannelBinding :one
 SELECT id, user_id, channel_type, config, created_at, updated_at
 FROM user_channel_bindings


### PR DESCRIPTION
- Add GetConfigByID SQL query and Store method; webhook handler now looks up config directly by UUID instead of listing all configs
- Cache bot open_id per config ID to avoid repeated DiscoverSelf calls on every webhook request
- Cache sender profiles (display name / username) with 5-min TTL to avoid per-message Contact.User and ChatMembers API calls
- Extract feishuStreamMessageAPI interface in stream.go to improve testability; fix tool-call boundary so card persists across tool calls
- Add tests for stream tool-call boundaries, sender profile lookup order, and cache sweep behavior