### PR TITLE
fix(inbound): use bot owner token for agent gateway callbacks

### DIFF
--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -86,6 +86,7 @@ type ChannelInboundProcessor struct {
 	jwtSecret        string
 	tokenTTL         time.Duration
 	identity         *IdentityResolver
+	policy           PolicyService
 	acl              chatACL
 	observer         channel.StreamObserver
 	ttsService       ttsSynthesizer
@@ -121,6 +122,7 @@ func NewChannelInboundProcessor(
 		jwtSecret:     strings.TrimSpace(jwtSecret),
 		tokenTTL:      tokenTTL,
 		identity:      identityResolver,
+		policy:        policyService,
 	}
 }
 
@@ -370,16 +372,30 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 		}
 	}
 
-	// Issue user JWT for downstream calls (MCP, schedule, etc.). For guests use chat token as Bearer.
+	// Issue bot-owner JWT for downstream calls (MCP tools, schedule, etc.).
+	// The agent uses this token to call back into the server's container/MCP
+	// endpoints which require bot-owner or admin access. Using the chatting
+	// user's identity would cause 403 for non-owner users.
 	token := ""
-	if identity.UserID != "" && p.jwtSecret != "" {
-		signed, _, err := auth.GenerateToken(identity.UserID, p.jwtSecret, p.tokenTTL)
-		if err != nil {
-			if p.logger != nil {
-				p.logger.Warn("issue channel token failed", slog.Any("error", err))
+	if p.jwtSecret != "" {
+		tokenUserID := strings.TrimSpace(identity.UserID)
+		if p.policy != nil {
+			if ownerID, err := p.policy.BotOwnerUserID(ctx, identity.BotID); err == nil && ownerID != "" {
+				tokenUserID = ownerID
+			} else if p.logger != nil {
+				p.logger.Warn("resolve bot owner for token failed, falling back to caller identity",
+					slog.String("bot_id", identity.BotID), slog.Any("error", err))
 			}
-		} else {
-			token = "Bearer " + signed
+		}
+		if tokenUserID != "" {
+			signed, _, err := auth.GenerateToken(tokenUserID, p.jwtSecret, p.tokenTTL)
+			if err != nil {
+				if p.logger != nil {
+					p.logger.Warn("issue channel token failed", slog.Any("error", err))
+				}
+			} else {
+				token = "Bearer " + signed
+			}
 		}
 	}
 	if token == "" && chatToken != "" {


### PR DESCRIPTION
## Summary

- Fix HTTP 403 `bot access denied` when non-owner users chat with a bot through external channels (Telegram, Discord, Feishu, etc.) and the agent invokes MCP tools.
- Root cause: the inbound channel processor issued a JWT for the **chatting user**, but container/MCP callback endpoints (`/bots/{id}/tools`, `/bots/{id}/mcp-stdio`) require **bot owner or admin** access.
- Now resolves the bot owner via `PolicyService` and issues the downstream token under the owner's identity, consistent with schedule, heartbeat, and email gateways.

## Changes

- `internal/channel/inbound/channel.go`: Store `PolicyService` reference in `ChannelInboundProcessor`; resolve bot owner user ID for downstream JWT generation instead of using the chatting user's identity.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/channel/inbound/...` passes
- [x] `go test ./internal/conversation/... ./internal/handlers/... ./internal/acl/...` passes
- [ ] Manual: non-owner user chats with bot via Telegram/Discord, verify MCP tools no longer return 403