### PR TITLE
fix(script): fix match '~' to avoid expansion

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,8 +117,8 @@ if [ "$SILENT" = false ]; then
   read -r input < /dev/tty || true
   if [ -n "$input" ]; then
     case "$input" in
-      ~) WORKSPACE="${HOME:-/tmp}" ;;
-      ~/*) WORKSPACE="${HOME:-/tmp}${input#\~}" ;;
+      "~") WORKSPACE="${HOME:-/tmp}" ;;
+      "~"/*) WORKSPACE="${HOME:-/tmp}${input#\~}" ;;
       *) WORKSPACE="$input" ;;
     esac
   fi


### PR DESCRIPTION
<img width="1171" height="339" alt="image" src="https://github.com/user-attachments/assets/2cdad439-6912-4dea-823e-28160bbf0198" />
