### PR TITLE
feat: auto-sync providers from lobehub

### DIFF
--- a/conf/providers/anthropic.yaml
+++ b/conf/providers/anthropic.yaml
@@ -4,6 +4,55 @@ icon: https://www.anthropic.com/images/icons/apple-touch-icon.png
 base_url: https://api.anthropic.com
 
 models:
+  - model_id: claude-opus-4-6
+    name: Claude Opus 4.6
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1000000
+
+  - model_id: claude-sonnet-4-6
+    name: Claude Sonnet 4.6
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1000000
+
+  - model_id: claude-opus-4-5-20251101
+    name: Claude Opus 4.5
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: claude-sonnet-4-5-20250929
+    name: Claude Sonnet 4.5
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: claude-haiku-4-5-20251001
+    name: Claude Haiku 4.5
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: claude-opus-4-1-20250805
+    name: Claude Opus 4.1
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: claude-opus-4-20250514
+    name: Claude Opus 4
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
   - model_id: claude-sonnet-4-20250514
     name: Claude Sonnet 4
     type: chat
@@ -11,22 +60,8 @@ models:
       compatibilities: [vision, tool-call, reasoning]
       context_window: 200000
 
-  - model_id: claude-4-opus-20250514
-    name: Claude 4 Opus
-    type: chat
-    config:
-      compatibilities: [vision, tool-call, reasoning]
-      context_window: 200000
-
-  - model_id: claude-3-7-sonnet-20250219
-    name: Claude 3.7 Sonnet
-    type: chat
-    config:
-      compatibilities: [vision, tool-call, reasoning]
-      context_window: 200000
-
-  - model_id: claude-3-5-haiku-20241022
-    name: Claude 3.5 Haiku
+  - model_id: claude-3-haiku-20240307
+    name: Claude 3 Haiku
     type: chat
     config:
       compatibilities: [vision, tool-call]

--- a/conf/providers/google.yaml
+++ b/conf/providers/google.yaml
@@ -4,36 +4,199 @@ icon: https://www.gstatic.com/lamda/images/gemini_favicon_f069958c85030456e93de6
 base_url: https://generativelanguage.googleapis.com/v1beta
 
 models:
+  - model_id: gemini-pro-latest
+    name: Gemini Pro Latest
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-flash-latest
+    name: Gemini Flash Latest
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-flash-lite-latest
+    name: Gemini Flash-Lite Latest
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-3.1-flash-image-preview
+    name: Nano Banana 2
+    type: chat
+    config:
+      compatibilities: [vision, reasoning, image-output]
+      context_window: 163840
+
+  - model_id: gemini-3.1-pro-preview
+    name: Gemini 3.1 Pro Preview
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-3.1-flash-lite-preview
+    name: Gemini 3.1 Flash-Lite Preview
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-3-flash-preview
+    name: Gemini 3 Flash Preview
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-3-pro-image-preview
+    name: Nano Banana Pro
+    type: chat
+    config:
+      compatibilities: [vision, reasoning, image-output]
+      context_window: 163840
+
   - model_id: gemini-2.5-pro
     name: Gemini 2.5 Pro
     type: chat
     config:
       compatibilities: [vision, tool-call, reasoning]
-      context_window: 1048576
+      context_window: 1114112
+
+  - model_id: gemini-2.5-pro-preview-06-05
+    name: Gemini 2.5 Pro Preview 06-05
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-2.5-pro-preview-05-06
+    name: Gemini 2.5 Pro Preview 05-06
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
 
   - model_id: gemini-2.5-flash
     name: Gemini 2.5 Flash
     type: chat
     config:
       compatibilities: [vision, tool-call, reasoning]
-      context_window: 1048576
+      context_window: 1114112
+
+  - model_id: gemini-2.5-flash-image
+    name: Nano Banana
+    type: chat
+    config:
+      compatibilities: [vision, image-output]
+      context_window: 98304
+
+  - model_id: gemini-2.5-flash-lite
+    name: Gemini 2.5 Flash-Lite
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
+
+  - model_id: gemini-2.5-flash-lite-preview-09-2025
+    name: Gemini 2.5 Flash-Lite Preview Sep 2025
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1114112
 
   - model_id: gemini-2.0-flash
     name: Gemini 2.0 Flash
     type: chat
     config:
       compatibilities: [vision, tool-call]
-      context_window: 1048576
+      context_window: 1056768
 
-  - model_id: gemini-2.0-flash-lite
-    name: Gemini 2.0 Flash Lite
+  - model_id: gemini-2.0-flash-001
+    name: Gemini 2.0 Flash 001
     type: chat
     config:
       compatibilities: [vision, tool-call]
-      context_window: 1048576
+      context_window: 1056768
 
-  - model_id: text-embedding-004
-    name: Text Embedding 004
-    type: embedding
+  - model_id: gemini-2.0-flash-exp-image-generation
+    name: Gemini 2.0 Flash (Image Generation) Experimental
+    type: chat
     config:
-      dimensions: 768
+      compatibilities: [vision, image-output]
+      context_window: 1056768
+
+  - model_id: gemini-2.0-flash-lite
+    name: Gemini 2.0 Flash-Lite
+    type: chat
+    config:
+      compatibilities: [vision]
+      context_window: 1056768
+
+  - model_id: gemini-2.0-flash-lite-001
+    name: Gemini 2.0 Flash-Lite 001
+    type: chat
+    config:
+      compatibilities: [vision]
+      context_window: 1056768
+
+  - model_id: gemini-1.5-flash-002
+    name: Gemini 1.5 Flash 002
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 1008192
+
+  - model_id: gemini-1.5-pro-002
+    name: Gemini 1.5 Pro 002
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 2008192
+
+  - model_id: gemini-1.5-flash-8b-latest
+    name: Gemini 1.5 Flash 8B
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 1008192
+
+  - model_id: gemma-3-1b-it
+    name: Gemma 3 1B
+    type: chat
+    config:
+      context_window: 40960
+
+  - model_id: gemma-3-4b-it
+    name: Gemma 3 4B
+    type: chat
+    config:
+      context_window: 40960
+
+  - model_id: gemma-3-12b-it
+    name: Gemma 3 12B
+    type: chat
+    config:
+      context_window: 40960
+
+  - model_id: gemma-3-27b-it
+    name: Gemma 3 27B
+    type: chat
+    config:
+      context_window: 139264
+
+  - model_id: gemma-3n-e2b-it
+    name: Gemma 3n E2B
+    type: chat
+    config:
+      context_window: 10240
+
+  - model_id: gemma-3n-e4b-it
+    name: Gemma 3n E4B
+    type: chat
+    config:
+      context_window: 10240

--- a/conf/providers/openai.yaml
+++ b/conf/providers/openai.yaml
@@ -4,6 +4,174 @@ icon: https://cdn.openai.com/API/logo-assets/openai-logomark.png
 base_url: https://api.openai.com/v1
 
 models:
+  - model_id: gpt-5.4
+    name: GPT-5.4
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1050000
+
+  - model_id: gpt-5.4-pro
+    name: GPT-5.4 Pro
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 1050000
+
+  - model_id: gpt-5.4-mini
+    name: GPT-5.4 mini
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.4-nano
+    name: GPT-5.4 nano
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.3-chat-latest
+    name: GPT-5.3 Chat
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-5.3-codex
+    name: GPT-5.3 Codex
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.2
+    name: GPT-5.2
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.2-codex
+    name: GPT-5.2 Codex
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.2-pro
+    name: GPT-5.2 pro
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.2-chat-latest
+    name: GPT-5.2 Chat
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-5.1
+    name: GPT-5.1
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.1-chat-latest
+    name: GPT-5.1 Chat
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-5.1-codex-max
+    name: GPT-5.1 Codex Max
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.1-codex
+    name: GPT-5.1 Codex
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5.1-codex-mini
+    name: GPT-5.1 Codex mini
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5-pro
+    name: GPT-5 pro
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5-codex
+    name: GPT-5 Codex
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5
+    name: GPT-5
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5-mini
+    name: GPT-5 mini
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5-nano
+    name: GPT-5 nano
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 400000
+
+  - model_id: gpt-5-chat-latest
+    name: GPT-5 Chat
+    type: chat
+    config:
+      compatibilities: [vision]
+      context_window: 400000
+
+  - model_id: o4-mini
+    name: o4-mini
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: o4-mini-deep-research
+    name: o4-mini Deep Research
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: o3-pro
+    name: o3-pro
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
   - model_id: o3
     name: o3
     type: chat
@@ -11,18 +179,32 @@ models:
       compatibilities: [vision, tool-call, reasoning]
       context_window: 200000
 
+  - model_id: o3-deep-research
+    name: o3 Deep Research
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
   - model_id: o3-mini
-    name: o3 Mini
+    name: o3-mini
     type: chat
     config:
       compatibilities: [tool-call, reasoning]
       context_window: 200000
 
-  - model_id: o4-mini
-    name: o4 Mini
+  - model_id: o1-pro
+    name: o1-pro
     type: chat
     config:
-      compatibilities: [vision, tool-call, reasoning, image-output]
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 200000
+
+  - model_id: o1
+    name: o1
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
       context_window: 200000
 
   - model_id: gpt-4.1
@@ -33,18 +215,31 @@ models:
       context_window: 1047576
 
   - model_id: gpt-4.1-mini
-    name: GPT-4.1 Mini
+    name: GPT-4.1 mini
     type: chat
     config:
       compatibilities: [vision, tool-call]
       context_window: 1047576
 
   - model_id: gpt-4.1-nano
-    name: GPT-4.1 Nano
+    name: GPT-4.1 nano
     type: chat
     config:
       compatibilities: [vision, tool-call]
       context_window: 1047576
+
+  - model_id: gpt-4o-mini
+    name: GPT-4o mini
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4o-mini-search-preview
+    name: GPT-4o mini Search Preview
+    type: chat
+    config:
+      context_window: 128000
 
   - model_id: gpt-4o
     name: GPT-4o
@@ -53,21 +248,138 @@ models:
       compatibilities: [vision, tool-call]
       context_window: 128000
 
-  - model_id: gpt-4o-mini
-    name: GPT-4o Mini
+  - model_id: gpt-4o-search-preview
+    name: GPT-4o Search Preview
+    type: chat
+    config:
+      context_window: 128000
+
+  - model_id: gpt-4o-2024-11-20
+    name: GPT-4o 1120
     type: chat
     config:
       compatibilities: [vision, tool-call]
       context_window: 128000
 
-  - model_id: text-embedding-3-small
-    name: Embedding 3 Small
-    type: embedding
+  - model_id: gpt-4o-2024-05-13
+    name: GPT-4o 0513
+    type: chat
     config:
-      dimensions: 1536
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-audio
+    name: GPT Audio
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4o-audio-preview
+    name: GPT-4o Audio Preview
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4o-mini-audio-preview
+    name: GPT-4o mini Audio
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4-turbo
+    name: GPT-4 Turbo
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4-turbo-2024-04-09
+    name: GPT-4 Turbo Vision 0409
+    type: chat
+    config:
+      compatibilities: [vision, tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4-turbo-preview
+    name: GPT-4 Turbo Preview
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4-0125-preview
+    name: GPT-4 Turbo Preview 0125
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4-1106-preview
+    name: GPT-4 Turbo Preview 1106
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 128000
+
+  - model_id: gpt-4
+    name: GPT-4
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 8192
+
+  - model_id: gpt-4-0613
+    name: GPT-4 0613
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 8192
+
+  - model_id: gpt-3.5-turbo
+    name: GPT-3.5 Turbo
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 16384
+
+  - model_id: gpt-3.5-turbo-0125
+    name: GPT-3.5 Turbo 0125
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 16384
+
+  - model_id: gpt-3.5-turbo-1106
+    name: GPT-3.5 Turbo 1106
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 16384
+
+  - model_id: gpt-3.5-turbo-instruct
+    name: GPT-3.5 Turbo Instruct
+    type: chat
+    config:
+      context_window: 4096
+
+  - model_id: computer-use-preview
+    name: Computer Use Preview
+    type: chat
+    config:
+      compatibilities: [vision, tool-call, reasoning]
+      context_window: 8192
 
   - model_id: text-embedding-3-large
-    name: Embedding 3 Large
+    name: Text Embedding 3 Large
     type: embedding
     config:
       dimensions: 3072
+
+  - model_id: text-embedding-3-small
+    name: Text Embedding 3 Small
+    type: embedding
+    config:
+      dimensions: 1536

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docs:dev": "pnpm --filter @memoh/docs dev",
     "docs:build": "pnpm --filter @memoh/docs build",
     "docs:preview": "pnpm --filter @memoh/docs preview",
+    "sync:providers": "bun scripts/sync-lobehub-providers.ts",
     "release": "bumpp",
     "generate-sdk": "openapi-ts",
     "lint": "eslint .",

--- a/scripts/sync-lobehub-providers.md
+++ b/scripts/sync-lobehub-providers.md
@@ -1,0 +1,19 @@
+Run with `bun scripts/sync-lobehub-providers.ts`.
+
+Optional:
+
+- `LOBEHUB_PATH=/path/to/lobe-chat bun scripts/sync-lobehub-providers.ts`
+
+How it works:
+
+- reads the current `conf/providers/*.yaml`
+- keeps the existing provider header (`name`, `client_type`, `icon`, `base_url`)
+- loads the full upstream provider model list from `packages/model-bank/src/aiModels/<provider>.ts`
+- syncs all upstream models that Memoh currently supports: `chat` and `embedding`
+- drops upstream-only unsupported model types like `image`, `tts`, `stt`, and `realtime`
+
+This syncs:
+
+- `conf/providers/openai.yaml`
+- `conf/providers/anthropic.yaml`
+- `conf/providers/google.yaml`

--- a/scripts/sync-lobehub-providers.ts
+++ b/scripts/sync-lobehub-providers.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface ExistingProviderFile {
+  filePath: string;
+  headerLines: string[];
+  providerId: string;
+}
+
+interface ProviderModelOutput {
+  config: {
+    compatibilities?: string[];
+    context_window?: number;
+    dimensions?: number;
+  };
+  model_id: string;
+  name: string;
+  type: string;
+}
+
+interface UpstreamModel {
+  abilities?: Record<string, boolean | undefined>;
+  contextWindowTokens?: number;
+  displayName?: string;
+  id: string;
+  maxDimension?: number;
+  type?: string;
+}
+
+const AI_MODELS_DIR = "packages/model-bank/src/aiModels";
+const PROVIDERS_DIR = "conf/providers";
+
+const projectRoot = path.resolve(import.meta.dir, "..");
+
+const COMPATIBILITY_ORDER = [
+  "vision",
+  "tool-call",
+  "reasoning",
+  "image-output",
+] as const;
+
+const COMPATIBILITY_MAP = {
+  functionCall: "tool-call",
+  imageOutput: "image-output",
+  reasoning: "reasoning",
+  vision: "vision",
+} as const;
+
+const SUPPORTED_MODEL_TYPES = new Set(["chat", "embedding"]);
+
+const resolveLobeHubRoot = () => {
+  const candidates = [
+    process.env.LOBEHUB_PATH,
+    path.resolve(projectRoot, "../lobehub"),
+    path.resolve(projectRoot, "../lobe-chat"),
+  ].filter(Boolean) as string[];
+
+  if (candidates.length === 0) {
+    throw new Error(
+      "Could not resolve LobeHub path. Set LOBEHUB_PATH or place lobehub next to Memoh.",
+    );
+  }
+
+  return candidates[0]!;
+};
+
+const importFromFile = async <T>(filePath: string): Promise<T> => {
+  const moduleUrl = pathToFileURL(filePath).href;
+  return import(moduleUrl) as Promise<T>;
+};
+
+const parseExistingProviderFile = async (
+  filePath: string,
+): Promise<ExistingProviderFile> => {
+  const raw = await readFile(filePath, "utf8");
+  const lines = raw.replaceAll("\r\n", "\n").trimEnd().split("\n");
+  const modelsIndex = lines.findIndex((line) => line.trim() === "models:");
+
+  if (modelsIndex === -1) {
+    throw new Error(`Provider file is missing models section: ${filePath}`);
+  }
+
+  return {
+    filePath,
+    headerLines: lines.slice(0, modelsIndex),
+    providerId: path.basename(filePath, path.extname(filePath)),
+  };
+};
+
+const toCompatibilities = (abilities?: UpstreamModel["abilities"]) => {
+  if (!abilities) return undefined;
+
+  const compatibilities = Object.entries(abilities)
+    .filter(([, enabled]) => Boolean(enabled))
+    .map(([key]) => COMPATIBILITY_MAP[key as keyof typeof COMPATIBILITY_MAP])
+    .filter((value): value is (typeof COMPATIBILITY_ORDER)[number] =>
+      Boolean(value),
+    )
+    .sort(
+      (left, right) =>
+        COMPATIBILITY_ORDER.indexOf(left) - COMPATIBILITY_ORDER.indexOf(right),
+    );
+
+  return compatibilities.length > 0 ? compatibilities : undefined;
+};
+
+const toOutputModel = (model: UpstreamModel): ProviderModelOutput => {
+  if (model.type === "embedding") {
+    return {
+      config: {
+        ...(typeof model.maxDimension === "number"
+          ? { dimensions: model.maxDimension }
+          : {}),
+      },
+      model_id: model.id,
+      name: model.displayName || model.id,
+      type: "embedding",
+    };
+  }
+
+  const compatibilities = toCompatibilities(model.abilities);
+
+  return {
+    config: {
+      ...(compatibilities ? { compatibilities } : {}),
+      ...(typeof model.contextWindowTokens === "number"
+        ? { context_window: model.contextWindowTokens }
+        : {}),
+    },
+    model_id: model.id,
+    name: model.displayName || model.id,
+    type: model.type || "chat",
+  };
+};
+
+const isUpstreamModel = (value: unknown): value is UpstreamModel => {
+  if (!value || typeof value !== "object") return false;
+
+  return typeof (value as { id?: unknown }).id === "string";
+};
+
+const loadProviderModels = async (lobeHubRoot: string, providerId: string) => {
+  const filePath = path.join(lobeHubRoot, AI_MODELS_DIR, `${providerId}.ts`);
+  const module = await importFromFile<{ default?: unknown }>(filePath);
+
+  if (!Array.isArray(module.default)) {
+    throw new Error(
+      `Upstream provider module does not export a default model array: ${filePath}`,
+    );
+  }
+
+  const dedupedModels = new Map<string, UpstreamModel>();
+
+  for (const item of module.default) {
+    if (!isUpstreamModel(item)) continue;
+    if (!item.type || !SUPPORTED_MODEL_TYPES.has(item.type)) continue;
+    if (dedupedModels.has(item.id)) continue;
+
+    dedupedModels.set(item.id, item);
+  }
+
+  return [...dedupedModels.values()];
+};
+
+const renderCompatibilities = (compatibilities: string[]) =>
+  `[${compatibilities.join(", ")}]`;
+
+const renderModel = (model: ProviderModelOutput) => {
+  const lines = [
+    `  - model_id: ${model.model_id}`,
+    `    name: ${model.name}`,
+    `    type: ${model.type}`,
+    "    config:",
+  ];
+
+  if (model.config.compatibilities) {
+    lines.push(
+      `      compatibilities: ${renderCompatibilities(model.config.compatibilities)}`,
+    );
+  }
+
+  if (typeof model.config.context_window === "number") {
+    lines.push(`      context_window: ${model.config.context_window}`);
+  }
+
+  if (typeof model.config.dimensions === "number") {
+    lines.push(`      dimensions: ${model.config.dimensions}`);
+  }
+
+  return lines.join("\n");
+};
+
+const renderProviderYaml = (
+  providerFile: ExistingProviderFile,
+  models: ProviderModelOutput[],
+) => {
+  return [
+    ...providerFile.headerLines,
+    "models:",
+    models.map(renderModel).join("\n\n"),
+    "",
+  ].join("\n");
+};
+
+const main = async () => {
+  const lobeHubRoot = resolveLobeHubRoot();
+  const providerDirectory = path.join(projectRoot, PROVIDERS_DIR);
+  const providerFiles = (await readdir(providerDirectory))
+    .filter((fileName) => fileName.endsWith(".yaml"))
+    .map((fileName) => path.join(providerDirectory, fileName))
+    .sort();
+
+  const parsedProviderFiles = await Promise.all(
+    providerFiles.map(parseExistingProviderFile),
+  );
+
+  for (const providerFile of parsedProviderFiles) {
+    const upstreamModels = await loadProviderModels(
+      lobeHubRoot,
+      providerFile.providerId,
+    );
+    const syncedModels = upstreamModels.map(toOutputModel);
+    const yaml = renderProviderYaml(providerFile, syncedModels);
+
+    await mkdir(path.dirname(providerFile.filePath), { recursive: true });
+    await writeFile(providerFile.filePath, yaml, "utf8");
+
+    console.log(
+      `synced ${providerFile.providerId}: ${path.relative(projectRoot, providerFile.filePath)} (${syncedModels.length} models)`,
+    );
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Bun sync script that pulls provider model definitions from LobeHub's `model-bank`
- regenerate the OpenAI, Anthropic, and Google provider YAMLs from the upstream chat and embedding model lists
- expose `bun run sync:providers` so the provider catalogs can be refreshed locally and later wired into CI

## Testing
- `pnpm lint`
- `pnpm --filter @memoh/web build`
- pre-commit hook (`go test ./...` and Go lint) passed during commit creation