### PR TITLE
fix[server]: check container running

### DIFF
--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -82,10 +82,8 @@ func newestContainerID(containers []ctr.ContainerInfo) (string, bool) {
 // ---------------------------------------------------------------------------
 
 func (m *Manager) isTaskRunning(ctx context.Context, containerID string) bool {
-	tasks, err := m.service.ListTasks(ctx, &ctr.ListTasksOptions{
-		Filter: "container.id==" + containerID,
-	})
-	return err == nil && len(tasks) > 0 && tasks[0].Status == ctr.TaskStatusRunning
+	task, err := m.service.GetTaskInfo(ctx, containerID)
+	return err == nil && task.Status == ctr.TaskStatusRunning
 }
 
 func (m *Manager) setupNetworkAndGetIP(ctx context.Context, containerID string) (string, error) {
@@ -152,14 +150,9 @@ func (m *Manager) EnsureRunning(ctx context.Context, botID string) error {
 		return m.SetupBotContainer(ctx, botID)
 	}
 
-	tasks, err := m.service.ListTasks(ctx, &ctr.ListTasksOptions{
-		Filter: "container.id==" + containerID,
-	})
-	if err != nil {
-		return err
-	}
-	if len(tasks) > 0 {
-		if tasks[0].Status == ctr.TaskStatusRunning {
+	taskInfo, err := m.service.GetTaskInfo(ctx, containerID)
+	if err == nil {
+		if taskInfo.Status == ctr.TaskStatusRunning {
 			return m.setupNetworkOrFail(ctx, containerID, botID)
 		}
 		if err := m.service.DeleteTask(ctx, containerID, &ctr.DeleteTaskOptions{Force: true}); err != nil {
@@ -169,6 +162,8 @@ func (m *Manager) EnsureRunning(ctx context.Context, botID string) error {
 				return err
 			}
 		}
+	} else if !errdefs.IsNotFound(err) {
+		return err
 	}
 
 	if err := m.service.StartContainer(ctx, containerID, nil); err != nil {


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**:   
During reboot, when multiple containers are running, isTaskRunning may incorrectly determine the task status of a specific container. This is because the current implementation relies on ListTasks with a Filter to locate the corresponding task. However, in containerd v2.2.1, the Filter in the Tasks.List request is discarded without processing.

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.