### PR TITLE
fix(dev): merge duplicate mise monorepo roots

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,5 @@
 [monorepo]
-config_roots = ["apps/web", "apps/desktop", "apps/browser", "packages/ui", "packages/sdk", "packages/config"]
-
-[monorepo]
-config_roots = ["apps/web", "cmd/agent"]
+config_roots = ["apps/web", "apps/desktop", "apps/browser", "packages/ui", "packages/sdk", "packages/config", "cmd/agent"]
 
 [tools]
 # Go version from go.mod


### PR DESCRIPTION
## Summary
- merge the duplicated `mise.toml` `[monorepo]` blocks into a single valid table
- keep all intended `config_roots` from both recent changes, including the new SELinux/dev workflow and `cmd/agent`
- restore `mise` task parsing so commands like `mise run dev:logs:selinux` work again

## Context
A recent sequence of merges made `main` invalid TOML:
- #296 introduced a `[monorepo]` table for desktop/browser/package roots
- #290 added another top-level `[monorepo]` table for `cmd/agent`

TOML does not allow duplicate tables at the same level, so `mise` started failing with:
- `duplicate key`
- `Invalid TOML in config file: /home/.../mise.toml`

This fix combines both sets of roots into one `[monorepo]` table, preserving the intended behavior without changing any task definitions.

## Verification
- confirmed `mise.toml` parses after the change
- confirmed `mise` recognizes `dev:logs:selinux` again via `mise tasks ls`