### PR TITLE
fix(dev): persist Postgres data in dev compose

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: memoh
       POSTGRES_PASSWORD: memoh123
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "${MEMOH_DEV_POSTGRES_PORT:-15432}:5432"


### PR DESCRIPTION
## Summary
- mount the dev Postgres named volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`
- align the dev compose config with the `postgres:18-alpine` image's declared volume and `PGDATA` layout
- prevent dev `down`/`up` cycles from silently switching to a fresh anonymous Postgres volume

## Context
The SELinux/dev compose workflow was mounting the named volume at `/var/lib/postgresql/data`, but the `postgres:18-alpine` image actually declares:
- `VOLUME /var/lib/postgresql`
- `PGDATA=/var/lib/postgresql/18/docker`

That mismatch caused the real database files to live under an anonymous volume mounted at `/var/lib/postgresql`, while the named `postgres_data` volume stayed effectively unused. As long as the original container kept running, data appeared normal. After `docker compose down` and a later `up`, Docker attached a new anonymous parent volume, Postgres saw an empty data directory, and ran `initdb`, which looked like all dev data had disappeared.

This change makes the named volume own the actual Postgres parent directory so dev data survives normal `down`/`up` restarts.

## Verification
- inspected the running container mounts and confirmed the anonymous `/var/lib/postgresql` volume was the real data location before the fix
- updated compose config and confirmed the Postgres container now mounts only `memoh-dev_postgres_data` at `/var/lib/postgresql`
- restarted the dev stack and verified Postgres logs show `Database directory appears to contain a database; Skipping initialization`