### PR TITLE
fix(sidebar): fix desktop sidebar collapsed by default on first visit

### DIFF
--- a/apps/web/src/layout/main-layout/index.vue
+++ b/apps/web/src/layout/main-layout/index.vue
@@ -17,5 +17,5 @@
 <script setup lang="ts">
 import { SidebarProvider } from '@memohai/ui'
 
-const sidebarDefaultOpen = document.cookie.includes('sidebar_state=true')
+const sidebarDefaultOpen = !document.cookie.includes('sidebar_state=false')
 </script>

--- a/packages/ui/src/components/sidebar/Sidebar.vue
+++ b/packages/ui/src/components/sidebar/Sidebar.vue
@@ -5,7 +5,7 @@ import { Sheet, SheetContent } from '#/components/sheet'
 import SheetDescription from '#/components/sheet/SheetDescription.vue'
 import SheetHeader from '#/components/sheet/SheetHeader.vue'
 import SheetTitle from '#/components/sheet/SheetTitle.vue'
-import { SIDEBAR_WIDTH_MOBILE, useSidebar } from './utils'
+import { SIDEBAR_WIDTH, SIDEBAR_WIDTH_MOBILE, useSidebar } from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -64,6 +64,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     :data-collapsible="state === 'collapsed' ? collapsible : ''"
     :data-variant="variant"
     :data-side="side"
+    :style="{ '--sidebar-width': SIDEBAR_WIDTH }"
   >
     <!-- This is what handles the sidebar gap on desktop  -->
     <div

--- a/packages/ui/src/components/sidebar/utils.ts
+++ b/packages/ui/src/components/sidebar/utils.ts
@@ -4,7 +4,7 @@ import { createContext } from 'reka-ui'
 export const SIDEBAR_COOKIE_NAME = 'sidebar_state'
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 export const SIDEBAR_WIDTH = '14rem'
-export const SIDEBAR_WIDTH_MOBILE = '18rem'
+export const SIDEBAR_WIDTH_MOBILE = '24rem'
 export const SIDEBAR_WIDTH_ICON = '3rem'
 export const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
 


### PR DESCRIPTION
- Fix cookie check logic: use `!includes('sidebar_state=false')` instead of `includes('sidebar_state=true')` so sidebar defaults to open when no cookie is set
- Add --sidebar-width CSS variable binding to desktop sidebar element
- Adjust SIDEBAR_WIDTH_MOBILE value

before fix, default behaviour is 

<img width="546" height="614" alt="image" src="https://github.com/user-attachments/assets/0436fe9b-9048-4968-8743-35deaf5aba5e" />

after fix:

<img width="613" height="1014" alt="image" src="https://github.com/user-attachments/assets/2a8ddcc3-5e1e-4dc4-9a2c-49c4422b2621" />
