### PR TITLE
fix: enable monorepo root config for mise tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
+experimental_monorepo_root = true
+
 [monorepo]
-config_roots = ["apps/web", "apps/desktop", "apps/browser", "packages/ui", "packages/sdk", "packages/config", "cmd/agent"]
+config_roots = ["apps/web", "cmd/agent"]
 
 [tools]
 # Go version from go.mod


### PR DESCRIPTION
## Summary
Enable `experimental_monorepo_root` and trim `config_roots` to the subprojects that currently define `mise.toml`.

## Why
`mise run setup` is reproducibly broken on main because `//:` task prefix seems no longer resolved here unless the root config is explicitly marked as a monorepo root.

## Environment

```
❯ mise -v            
              _                                        __              
   ____ ___  (_)_______        ___  ____        ____  / /___ _________
  / __ `__ \/ / ___/ _ \______/ _ \/ __ \______/ __ \/ / __ `/ ___/ _ \
 / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
/_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                            /_/                 by @jdx
2026.4.0 linux-x64 (2026-04-01)
```

## Before
<img width="722" height="115" alt="image" src="https://github.com/user-attachments/assets/8d7e6328-0424-4357-96c6-ce31d37d91bd" />

<details>

<summary>mise task validate</summary>

```bash
Memoh on  main via  v1.25.7 via  v24.14.1 
❯ mise tasks validate

34 task(s) validated with 14 issue(s):

  ✗ 14 error(s)

Task: build-embedded-assets
  ✗ Dependency '//:pnpm-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: build-unified
  ✗ Dependency '//:build-embedded-assets' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: lint
  ✗ Dependency '//:lint:go' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:lint:es' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: lint:fix
  ✗ Dependency '//:lint:go:fix' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:lint:es:fix' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: release-binaries
  ✗ Dependency '//:pnpm-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: sdk-generate
  ✗ Dependency '//:pnpm-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:swagger-generate' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: setup
  ✗ Dependency '//:install-workspace-toolkit' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:sqlc-generate' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:pnpm-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists
  ✗ Dependency '//:go-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

Task: swagger-generate
  ✗ Dependency '//:go-install' not found [missing-dependency]
      Referenced in 'depends' but no matching task exists

mise ERROR Validation failed with 14 error(s)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

</details>

## After

<img width="725" height="87" alt="image" src="https://github.com/user-attachments/assets/32a44006-470d-4f98-8810-aca914d03186" />

And also `mise run setup` work properly