### PR TITLE
fix: use anyOf for nullable max_calls schema

### DIFF
--- a/internal/agent/tools/schedule.go
+++ b/internal/agent/tools/schedule.go
@@ -92,7 +92,7 @@ func (p *ScheduleProvider) Tools(_ context.Context, session SessionContext) ([]s
 				"properties": map[string]any{
 					"name": map[string]any{"type": "string"}, "description": map[string]any{"type": "string"},
 					"pattern": map[string]any{"type": "string"}, "command": map[string]any{"type": "string"},
-					"max_calls": map[string]any{"type": []string{"integer", "null"}, "description": "Optional max calls, null means unlimited"},
+					"max_calls": map[string]any{"anyOf": []map[string]any{{"type": "integer"}, {"type": "null"}}, "description": "Optional max calls, null means unlimited"},
 					"enabled":   map[string]any{"type": "boolean"},
 				},
 				"required": []string{"name", "description", "pattern", "command"},
@@ -136,7 +136,7 @@ func (p *ScheduleProvider) Tools(_ context.Context, session SessionContext) ([]s
 					"id": map[string]any{"type": "string"}, "name": map[string]any{"type": "string"},
 					"description": map[string]any{"type": "string"}, "pattern": map[string]any{"type": "string"},
 					"command":   map[string]any{"type": "string"},
-					"max_calls": map[string]any{"type": []string{"integer", "null"}},
+					"max_calls": map[string]any{"anyOf": []map[string]any{{"type": "integer"}, {"type": "null"}}},
 					"enabled":   map[string]any{"type": "boolean"},
 				},
 				"required": []string{"id"},


### PR DESCRIPTION
## Summary
- replace the nullable array-of-types form for schedule max_calls with anyOf
- keep the schema OpenAI-compatible for both create and update schedule payloads

## Testing
- not run locally on this host because the Go toolchain is not installed on /Users/pojian
