### PR TITLE
fix: preserve attachment base64 for telegram fallback

### DIFF
--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -860,3 +860,21 @@ func TestFileNameFromMime(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveTelegramFile_ContainerPathWithBase64FallbackForVideo(t *testing.T) {
+	t.Parallel()
+
+	dataURL := "data:video/mp4;base64,AAAA"
+	att := channel.Attachment{Type: channel.AttachmentVideo, URL: "/data/media/output.mp4", Base64: dataURL, Name: "output.mp4", Mime: "video/mp4"}
+	file, err := resolveTelegramFile(context.Background(), att.URL, "", att.Base64, "", att, "", "", nil)
+	if err != nil {
+		t.Fatalf("resolveTelegramFile returned error: %v", err)
+	}
+	bytes, ok := file.(tgbotapi.FileBytes)
+	if !ok {
+		t.Fatalf("expected FileBytes, got %T", file)
+	}
+	if bytes.Name != "output.mp4" {
+		t.Fatalf("expected output.mp4, got %q", bytes.Name)
+	}
+}

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -2208,6 +2208,7 @@ func parseAttachmentDelta(raw json.RawMessage) []channel.Attachment {
 		Path        string         `json:"path"`
 		PlatformKey string         `json:"platform_key"`
 		ContentHash string         `json:"content_hash"`
+		Base64      string         `json:"base64"`
 		Name        string         `json:"name"`
 		Mime        string         `json:"mime"`
 		Size        int64          `json:"size"`
@@ -2231,6 +2232,7 @@ func parseAttachmentDelta(raw json.RawMessage) []channel.Attachment {
 			URL:         url,
 			PlatformKey: strings.TrimSpace(item.PlatformKey),
 			ContentHash: strings.TrimSpace(item.ContentHash),
+			Base64:      strings.TrimSpace(item.Base64),
 			Name:        name,
 			Mime:        strings.TrimSpace(item.Mime),
 			Size:        item.Size,

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -1707,3 +1707,30 @@ func TestMapChannelToChatAttachments(t *testing.T) {
 		t.Fatalf("expected non-asset attachment URL, got %q", mapped[1].URL)
 	}
 }
+
+func TestParseAttachmentDeltaPreservesBase64(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal([]conversation.ChatAttachment{{
+		Type:   string(channel.AttachmentVideo),
+		URL:    "/data/media/output.mp4",
+		Base64: "data:video/mp4;base64,AAAA",
+		Name:   "output.mp4",
+		Mime:   "video/mp4",
+	}})
+	if err != nil {
+		t.Fatalf("marshal attachments: %v", err)
+	}
+
+	attachments := parseAttachmentDelta(raw)
+
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if got := attachments[0].Base64; got != "data:video/mp4;base64,AAAA" {
+		t.Fatalf("expected base64 preserved, got %q", got)
+	}
+	if got := attachments[0].URL; got != "/data/media/output.mp4" {
+		t.Fatalf("expected url preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
$## Summary\n- preserve attachment base64 data when replaying streamed attachment deltas\n- let Telegram file sending fall back to embedded base64 when platform keys and content hashes are unavailable\n- add regression coverage for attachment delta parsing and Telegram video fallback\n- fix the attachment delta regression test to pass JSON into parseAttachmentDelta\n\nCloses #311
