### PR TITLE
fix: persist usage with camelCase keys

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,8 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/usagejson"
+
 	"github.com/memohai/memoh/internal/agent/tools"
 	"github.com/memohai/memoh/internal/models"
 	"github.com/memohai/memoh/internal/workspace/bridge"
@@ -284,7 +286,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		totalUsage.OutputTokenDetails.TextTokens += step.Usage.OutputTokenDetails.TextTokens
 		totalUsage.OutputTokenDetails.ReasoningTokens += step.Usage.OutputTokenDetails.ReasoningTokens
 	}
-	usageJSON, _ := json.Marshal(totalUsage)
+	usageJSON := usagejson.Marshal(totalUsage)
 
 	termEvent := StreamEvent{
 		Messages: mustMarshal(finalMessages),

--- a/internal/agent/tools/subagent.go
+++ b/internal/agent/tools/subagent.go
@@ -12,6 +12,8 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/usagejson"
+
 	"github.com/memohai/memoh/internal/db/sqlc"
 	messagepkg "github.com/memohai/memoh/internal/message"
 	"github.com/memohai/memoh/internal/models"
@@ -278,7 +280,7 @@ func (p *SpawnProvider) persistMessages(
 		}
 		var usage json.RawMessage
 		if msg.Usage != nil {
-			usage, _ = json.Marshal(msg.Usage)
+			usage = usagejson.MarshalPtr(msg.Usage)
 		}
 		if _, err := p.messageService.Persist(ctx, messagepkg.PersistInput{
 			BotID:     botID,

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/usagejson"
+
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/sqlc"
 	"github.com/memohai/memoh/internal/models"
@@ -126,7 +128,7 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		return err
 	}
 
-	usageJSON, _ := json.Marshal(result.Usage)
+	usageJSON := usagejson.Marshal(result.Usage)
 
 	modelUUID := db.ParseUUIDOrEmpty(cfg.ModelID)
 

--- a/internal/conversation/flow/resolver_messages.go
+++ b/internal/conversation/flow/resolver_messages.go
@@ -6,6 +6,8 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/usagejson"
+
 	"github.com/memohai/memoh/internal/conversation"
 )
 
@@ -26,7 +28,7 @@ func sdkMessagesToModelMessages(msgs []sdk.Message) []conversation.ModelMessage 
 		}
 		var usage json.RawMessage
 		if msg.Usage != nil {
-			usage, _ = json.Marshal(msg.Usage)
+			usage = usagejson.MarshalPtr(msg.Usage)
 		}
 		result = append(result, conversation.ModelMessage{
 			Role:    string(msg.Role),

--- a/internal/conversation/flow/resolver_trigger.go
+++ b/internal/conversation/flow/resolver_trigger.go
@@ -9,6 +9,8 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/usagejson"
+
 	agentpkg "github.com/memohai/memoh/internal/agent"
 	"github.com/memohai/memoh/internal/conversation"
 	"github.com/memohai/memoh/internal/heartbeat"
@@ -61,7 +63,7 @@ func (r *Resolver) TriggerSchedule(ctx context.Context, botID string, payload sc
 	roundMessages := prependUserMessage(req.Query, outputMessages)
 	storeErr := r.storeRound(ctx, req, roundMessages, rc.model.ID)
 
-	totalUsageJSON, _ := json.Marshal(result.Usage)
+	totalUsageJSON := usagejson.Marshal(result.Usage)
 	return schedule.TriggerResult{
 		Status:     "ok",
 		Text:       strings.TrimSpace(result.Text),
@@ -131,7 +133,7 @@ func (r *Resolver) TriggerHeartbeat(ctx context.Context, botID string, payload h
 	roundMessages := prependUserMessage(heartbeatPrompt, outputMessages)
 	_ = r.storeRound(ctx, req, roundMessages, rc.model.ID)
 
-	totalUsageJSON, _ := json.Marshal(result.Usage)
+	totalUsageJSON := usagejson.Marshal(result.Usage)
 	return heartbeat.TriggerResult{
 		Status:     status,
 		Text:       text,

--- a/internal/usagejson/usage.go
+++ b/internal/usagejson/usage.go
@@ -1,0 +1,59 @@
+package usagejson
+
+import (
+    "encoding/json"
+
+    sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+type Usage struct {
+    InputTokens        int                `json:"inputTokens,omitempty"`
+    OutputTokens       int                `json:"outputTokens,omitempty"`
+    TotalTokens        int                `json:"totalTokens,omitempty"`
+    ReasoningTokens    int                `json:"reasoningTokens,omitempty"`
+    CachedInputTokens  int                `json:"cachedInputTokens,omitempty"`
+    InputTokenDetails  InputTokenDetails  `json:"inputTokenDetails,omitempty"`
+    OutputTokenDetails OutputTokenDetails `json:"outputTokenDetails,omitempty"`
+}
+
+type InputTokenDetails struct {
+    NoCacheTokens    int `json:"noCacheTokens,omitempty"`
+    CacheReadTokens  int `json:"cacheReadTokens,omitempty"`
+    CacheWriteTokens int `json:"cacheWriteTokens,omitempty"`
+}
+
+type OutputTokenDetails struct {
+    TextTokens      int `json:"textTokens,omitempty"`
+    ReasoningTokens int `json:"reasoningTokens,omitempty"`
+}
+
+func FromSDK(u sdk.Usage) Usage {
+    return Usage{
+        InputTokens:       u.InputTokens,
+        OutputTokens:      u.OutputTokens,
+        TotalTokens:       u.TotalTokens,
+        ReasoningTokens:   u.ReasoningTokens,
+        CachedInputTokens: u.CachedInputTokens,
+        InputTokenDetails: InputTokenDetails{
+            NoCacheTokens:    u.InputTokenDetails.NoCacheTokens,
+            CacheReadTokens:  u.InputTokenDetails.CacheReadTokens,
+            CacheWriteTokens: u.InputTokenDetails.CacheWriteTokens,
+        },
+        OutputTokenDetails: OutputTokenDetails{
+            TextTokens:      u.OutputTokenDetails.TextTokens,
+            ReasoningTokens: u.OutputTokenDetails.ReasoningTokens,
+        },
+    }
+}
+
+func Marshal(u sdk.Usage) []byte {
+    b, _ := json.Marshal(FromSDK(u))
+    return b
+}
+
+func MarshalPtr(u *sdk.Usage) []byte {
+    if u == nil {
+        return nil
+    }
+    return Marshal(*u)
+}

--- a/internal/usagejson/usage_test.go
+++ b/internal/usagejson/usage_test.go
@@ -1,0 +1,39 @@
+package usagejson
+
+import (
+    "strings"
+    "testing"
+
+    sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestMarshalUsesCamelCaseKeys(t *testing.T) {
+    raw := string(Marshal(sdk.Usage{
+        InputTokens:      12,
+        OutputTokens:     34,
+        TotalTokens:      46,
+        ReasoningTokens:  5,
+        CachedInputTokens: 6,
+        InputTokenDetails: sdk.InputTokenDetail{
+            NoCacheTokens: 1,
+            CacheReadTokens: 2,
+            CacheWriteTokens: 3,
+        },
+        OutputTokenDetails: sdk.OutputTokenDetail{
+            TextTokens: 4,
+            ReasoningTokens: 5,
+        },
+    }))
+
+    for _, want := range []string{"\"inputTokens\":12", "\"outputTokens\":34", "\"cacheReadTokens\":2", "\"cacheWriteTokens\":3"} {
+        if !strings.Contains(raw, want) {
+            t.Fatalf("expected marshaled usage to contain %s, got %s", want, raw)
+        }
+    }
+
+    for _, unwanted := range []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"} {
+        if strings.Contains(raw, unwanted) {
+            t.Fatalf("expected marshaled usage not to contain %s, got %s", unwanted, raw)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- serialize persisted usage payloads with camelCase keys
- keep token usage queries aligned with stored JSON field names
- add regression coverage for usage key formatting
- remove unsupported `AudioTokens` access so the SDK build/lint checks can pass

Closes #340
