### PR TITLE
Add local file path support for Telegram attachments

### DIFF
--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -867,11 +868,12 @@ func sendTelegramAttachmentWithAssets(ctx context.Context, bot *tgbotapi.BotAPI,
 
 func sendTelegramAttachmentImpl(ctx context.Context, bot *tgbotapi.BotAPI, target string, att channel.Attachment, caption string, replyTo int, parseMode string, opener assetOpener) error {
 	urlRef := strings.TrimSpace(att.URL)
+	pathRef := strings.TrimSpace(att.Path)
 	keyRef := strings.TrimSpace(att.PlatformKey)
 	sourcePlatform := strings.TrimSpace(att.SourcePlatform)
 	base64Ref := strings.TrimSpace(att.Base64)
 	assetID := strings.TrimSpace(att.ContentHash)
-	if urlRef == "" && keyRef == "" && base64Ref == "" && assetID == "" {
+	if urlRef == "" && pathRef == "" && keyRef == "" && base64Ref == "" && assetID == "" {
 		return errors.New("attachment reference is required")
 	}
 	if strings.TrimSpace(caption) == "" && strings.TrimSpace(att.Caption) != "" {
@@ -883,7 +885,7 @@ func sendTelegramAttachmentImpl(ctx context.Context, bot *tgbotapi.BotAPI, targe
 			botID = bid
 		}
 	}
-	file, err := resolveTelegramFile(ctx, urlRef, keyRef, base64Ref, sourcePlatform, att, assetID, botID, opener)
+	file, err := resolveTelegramFile(ctx, urlRef, pathRef, keyRef, base64Ref, sourcePlatform, att, assetID, botID, opener)
 	if err != nil {
 		return err
 	}
@@ -980,8 +982,8 @@ func sendTelegramAttachmentImpl(ctx context.Context, bot *tgbotapi.BotAPI, targe
 }
 
 // resolveTelegramFile determines the best tgbotapi.RequestFileData for an attachment.
-// Priority: PlatformKey > ContentHash (storage) > public URL > base64 data URL.
-func resolveTelegramFile(ctx context.Context, urlRef, keyRef, base64Ref, sourcePlatform string, att channel.Attachment, assetID, botID string, opener assetOpener) (tgbotapi.RequestFileData, error) {
+// Priority: PlatformKey > ContentHash (storage) > local path > public URL > base64 data URL.
+func resolveTelegramFile(ctx context.Context, urlRef, pathRef, keyRef, base64Ref, sourcePlatform string, att channel.Attachment, assetID, botID string, opener assetOpener) (tgbotapi.RequestFileData, error) {
 	if keyRef != "" && (sourcePlatform == "" || strings.EqualFold(sourcePlatform, Type.String())) {
 		return tgbotapi.FileID(keyRef), nil
 	}
@@ -997,6 +999,16 @@ func resolveTelegramFile(ctx context.Context, urlRef, keyRef, base64Ref, sourceP
 				}
 				return tgbotapi.FileBytes{Name: name, Bytes: data}, nil
 			}
+		}
+	}
+	if pathRef != "" {
+		data, err := os.ReadFile(pathRef) //nolint:gosec // G304: path comes from agent FileAttachment, not user input
+		if err == nil && len(data) > 0 {
+			name := strings.TrimSpace(att.Name)
+			if name == "" {
+				name = fileNameFromMime(att.Mime, string(att.Type))
+			}
+			return tgbotapi.FileBytes{Name: name, Bytes: data}, nil
 		}
 	}
 	if urlRef != "" && !strings.HasPrefix(strings.ToLower(urlRef), "data:") && !strings.HasPrefix(urlRef, "/") {

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -724,7 +725,7 @@ func TestResolveTelegramFile_PlatformKey(t *testing.T) {
 	t.Parallel()
 
 	att := channel.Attachment{Type: channel.AttachmentImage, PlatformKey: "file_id_123"}
-	file, err := resolveTelegramFile(context.Background(), "", "file_id_123", "", "", att, "", "", nil)
+	file, err := resolveTelegramFile(context.Background(), "", "", "file_id_123", "", "", att, "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -737,7 +738,7 @@ func TestResolveTelegramFile_PublicURL(t *testing.T) {
 	t.Parallel()
 
 	att := channel.Attachment{Type: channel.AttachmentImage}
-	file, err := resolveTelegramFile(context.Background(), "https://example.com/img.png", "", "", "", att, "", "", nil)
+	file, err := resolveTelegramFile(context.Background(), "https://example.com/img.png", "", "", "", "", att, "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -751,7 +752,7 @@ func TestResolveTelegramFile_DataURL(t *testing.T) {
 
 	dataURL := "data:image/png;base64,iVBORw0KGgo="
 	att := channel.Attachment{Type: channel.AttachmentImage, Mime: "image/png", Name: "test.png"}
-	file, err := resolveTelegramFile(context.Background(), "", "", dataURL, "", att, "", "", nil)
+	file, err := resolveTelegramFile(context.Background(), "", "", "", dataURL, "", att, "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -771,7 +772,7 @@ func TestResolveTelegramFile_NoReference(t *testing.T) {
 	t.Parallel()
 
 	att := channel.Attachment{Type: channel.AttachmentImage}
-	_, err := resolveTelegramFile(context.Background(), "", "", "", "", att, "", "", nil)
+	_, err := resolveTelegramFile(context.Background(), "", "", "", "", "", att, "", "", nil)
 	if err == nil {
 		t.Fatal("expected error when no reference available")
 	}
@@ -782,12 +783,42 @@ func TestResolveTelegramFile_ContainerPathFallsToBase64(t *testing.T) {
 
 	dataURL := "data:image/jpeg;base64,/9j/4AAQ"
 	att := channel.Attachment{Type: channel.AttachmentImage, Mime: "image/jpeg"}
-	file, err := resolveTelegramFile(context.Background(), "/data/media/image/a.jpg", "", dataURL, "", att, "", "", nil)
+	file, err := resolveTelegramFile(context.Background(), "/data/media/image/a.jpg", "", "", dataURL, "", att, "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := file.(tgbotapi.FileBytes); !ok {
 		t.Fatalf("expected FileBytes for container path + base64, got %T", file)
+	}
+}
+
+func TestResolveTelegramFile_LocalPath(t *testing.T) {
+	t.Parallel()
+
+	f, err := os.CreateTemp(t.TempDir(), "video-*.mp4")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	content := []byte("fake-video-bytes")
+	if _, err = f.Write(content); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	_ = f.Close()
+
+	att := channel.Attachment{Type: channel.AttachmentVideo, Mime: "video/mp4", Name: "clip.mp4"}
+	file, err := resolveTelegramFile(context.Background(), "", f.Name(), "", "", "", att, "", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fb, ok := file.(tgbotapi.FileBytes)
+	if !ok {
+		t.Fatalf("expected FileBytes for local path, got %T", file)
+	}
+	if fb.Name != "clip.mp4" {
+		t.Fatalf("expected name clip.mp4, got %q", fb.Name)
+	}
+	if string(fb.Bytes) != string(content) {
+		t.Fatalf("expected %q, got %q", content, fb.Bytes)
 	}
 }
 
@@ -805,7 +836,7 @@ func TestResolveTelegramFile_ContentHash(t *testing.T) {
 
 	opener := &mockAssetOpener{data: []byte("fake-png-bytes"), mime: "image/png"}
 	att := channel.Attachment{Type: channel.AttachmentImage, ContentHash: "asset-123", Name: "output.png"}
-	file, err := resolveTelegramFile(context.Background(), "", "", "", "", att, "asset-123", "bot-1", opener)
+	file, err := resolveTelegramFile(context.Background(), "", "", "", "", "", att, "asset-123", "bot-1", opener)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -826,7 +857,7 @@ func TestResolveTelegramFile_ContentHashPriorityOverURL(t *testing.T) {
 
 	opener := &mockAssetOpener{data: []byte("from-storage"), mime: "image/jpeg"}
 	att := channel.Attachment{Type: channel.AttachmentImage, ContentHash: "a1"}
-	file, err := resolveTelegramFile(context.Background(), "https://example.com/fallback.jpg", "", "", "", att, "a1", "bot-1", opener)
+	file, err := resolveTelegramFile(context.Background(), "https://example.com/fallback.jpg", "", "", "", "", att, "a1", "bot-1", opener)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -2219,16 +2219,21 @@ func parseAttachmentDelta(raw json.RawMessage) []channel.Attachment {
 	attachments := make([]channel.Attachment, 0, len(items))
 	for _, item := range items {
 		url := strings.TrimSpace(item.URL)
-		if url == "" {
-			url = strings.TrimSpace(item.Path)
-		}
+		path := strings.TrimSpace(item.Path)
 		name := strings.TrimSpace(item.Name)
-		if name == "" && url != "" && !isDataURL(url) {
-			name = filepath.Base(url)
+		if name == "" {
+			ref := url
+			if ref == "" {
+				ref = path
+			}
+			if ref != "" && !isDataURL(ref) {
+				name = filepath.Base(ref)
+			}
 		}
 		attachments = append(attachments, channel.Attachment{
 			Type:        channel.AttachmentType(strings.TrimSpace(item.Type)),
 			URL:         url,
+			Path:        path,
 			PlatformKey: strings.TrimSpace(item.PlatformKey),
 			ContentHash: strings.TrimSpace(item.ContentHash),
 			Name:        name,

--- a/internal/channel/types.go
+++ b/internal/channel/types.go
@@ -248,6 +248,7 @@ const (
 type Attachment struct {
 	Type           AttachmentType `json:"type"`
 	URL            string         `json:"url,omitempty"`
+	Path           string         `json:"path,omitempty"` // local filesystem path
 	PlatformKey    string         `json:"platform_key,omitempty"`
 	SourcePlatform string         `json:"source_platform,omitempty"`
 	ContentHash    string         `json:"content_hash,omitempty"`


### PR DESCRIPTION
Fixes #311

Telegram wasn't able to send files when only a local path was provided. Added support for the Path field on attachments so it can be used as a file source, with priority above URLs but below cached content.