### PR TITLE
fix(web): decouple model display label from override state

### DIFF
--- a/apps/web/src/pages/home/components/chat-area.vue
+++ b/apps/web/src/pages/home/components/chat-area.vue
@@ -565,6 +565,8 @@ const { data: botSettings } = useQuery({
 const models = computed<ModelsGetResponse[]>(() => modelData.value ?? [])
 const providers = computed<ProvidersGetResponse[]>(() => providerData.value ?? [])
 
+// activeModel resolves the effective model for capability checks:
+// user override takes priority, falling back to the bot's default.
 const activeModel = computed(() => {
   const id = overrideModelId.value || botSettings.value?.chat_model_id || ''
   return models.value.find((m) => m.id === id)
@@ -580,14 +582,22 @@ const availableReasoningEfforts = computed(() => {
   return efforts.length > 0 ? efforts : ['low', 'medium', 'high']
 })
 
+// selectedModelLabel shows the user-chosen override name, or the bot default
+// name as a hint. overrideModelId itself stays empty until the user explicitly
+// picks a model, so the backend uses its own default when no override is sent.
 const selectedModelLabel = computed(() => {
-  const m = models.value.find((m) => m.id === overrideModelId.value)
+  if (overrideModelId.value) {
+    const m = models.value.find((m) => m.id === overrideModelId.value)
+    return m?.name || m?.model_id || t('chat.modelDefault')
+  }
+  const defaultId = botSettings.value?.chat_model_id || ''
+  const m = models.value.find((m) => m.id === defaultId)
   return m?.name || m?.model_id || t('chat.modelDefault')
 })
 
 const selectedReasoningLabel = computed(() => {
   const v = overrideReasoningEffort.value
-  if (v === 'off') return t('chat.reasoningOff')
+  if (!v || v === 'off') return t('chat.reasoningOff')
   return t(EFFORT_LABELS[v] ?? 'chat.modelDefault')
 })
 
@@ -595,21 +605,16 @@ const reasoningTriggerOpacity = computed(() =>
   EFFORT_OPACITY[overrideReasoningEffort.value] ?? 0.5,
 )
 
-function initFromBotSettings() {
-  if (!botSettings.value) return
-  if (!overrideModelId.value) {
-    overrideModelId.value = botSettings.value.chat_model_id ?? ''
-  }
-  if (!overrideReasoningEffort.value) {
-    if (botSettings.value.reasoning_enabled && botSettings.value.reasoning_effort) {
-      overrideReasoningEffort.value = botSettings.value.reasoning_effort
-    } else {
-      overrideReasoningEffort.value = 'off'
-    }
+function initReasoningFromBotSettings() {
+  if (!botSettings.value || overrideReasoningEffort.value) return
+  if (botSettings.value.reasoning_enabled && botSettings.value.reasoning_effort) {
+    overrideReasoningEffort.value = botSettings.value.reasoning_effort
+  } else {
+    overrideReasoningEffort.value = 'off'
   }
 }
 
-watch(botSettings, () => initFromBotSettings(), { immediate: true })
+watch(botSettings, () => initReasoningFromBotSettings(), { immediate: true })
 
 watch(currentBotId, () => {
   overrideModelId.value = ''


### PR DESCRIPTION
## Summary

Closes #353
Related to #354 (already merged — backend fix: respect model override in `buildBaseRunConfig`)

## Problem

`initFromBotSettings()` always wrote `botSettings.chat_model_id` into `overrideModelId` on page load, so every message was sent to the backend with an explicit `model_id` override — even when the user had never touched the model selector.

This caused two issues:
- After a bot's model was changed in settings, existing web chat sessions silently kept using the old model until the user manually switched bots or refreshed
- `overrideModelId` never reflected "user made no choice"; it always carried the bot default, making it impossible to distinguish intent

## Fix

- **Remove** `chat_model_id → overrideModelId` initialization. `overrideModelId` now starts empty and is only set when the user explicitly picks a model from the selector
- **`selectedModelLabel`** falls back to displaying the bot's default model name without touching `overrideModelId`, so the backend receives no `model_id` unless the user has made an explicit override
- **Rename** `initFromBotSettings → initReasoningFromBotSettings` to reflect its reduced scope (reasoning effort only)
- Fix `selectedReasoningLabel` to also handle the initial empty-string state

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| User sends message without touching model selector | Sends `model_id = bot default` (always override) | Sends no `model_id` (backend uses its own default) |
| User explicitly selects a model | Sends `model_id = selected` | Sends `model_id = selected` ✓ |
| Bot default model is changed in settings | Old model still used until refresh | New model used immediately ✓ |
| Model name shown in input bar | Bot default (correct) | Bot default (correct) ✓ |