### PR TITLE
refactor(channel): extract composable AttachmentResolver with sentinel error fallback

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -72,6 +72,7 @@ type AttachmentPayload struct {
 // AttachmentResolver resolves attachment references (for example platform_key)
 // into readable bytes for persistence or transformation pipelines.
 type AttachmentResolver interface {
+	CanResolve(cfg ChannelConfig, attachment Attachment) bool
 	ResolveAttachment(ctx context.Context, cfg ChannelConfig, attachment Attachment) (AttachmentPayload, error)
 }
 

--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -8,6 +8,11 @@ import (
 	"sync/atomic"
 )
 
+// ErrAttachmentNotResolvable is returned by an AttachmentResolver when the
+// given attachment is not within its responsibility. Composite resolvers use
+// this sentinel to fall back to the next resolver in the chain.
+var ErrAttachmentNotResolvable = errors.New("attachment not resolvable by this resolver")
+
 // ErrStopNotSupported is returned when a connection does not support graceful shutdown.
 var ErrStopNotSupported = errors.New("channel connection stop not supported")
 
@@ -72,7 +77,6 @@ type AttachmentPayload struct {
 // AttachmentResolver resolves attachment references (for example platform_key)
 // into readable bytes for persistence or transformation pipelines.
 type AttachmentResolver interface {
-	CanResolve(cfg ChannelConfig, attachment Attachment) bool
 	ResolveAttachment(ctx context.Context, cfg ChannelConfig, attachment Attachment) (AttachmentPayload, error)
 }
 

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -314,6 +314,10 @@ func dingtalkMediaType(att channel.PreparedAttachment) string {
 	}
 }
 
+func (*DingTalkAdapter) CanResolve(_ channel.ChannelConfig, att channel.Attachment) bool {
+	return strings.TrimSpace(att.PlatformKey) != ""
+}
+
 // ResolveAttachment implements channel.AttachmentResolver. It downloads a file
 // received by the bot (identified by its downloadCode stored in PlatformKey)
 // via the DingTalk OpenAPI and returns a readable payload.

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -314,17 +314,13 @@ func dingtalkMediaType(att channel.PreparedAttachment) string {
 	}
 }
 
-func (*DingTalkAdapter) CanResolve(_ channel.ChannelConfig, att channel.Attachment) bool {
-	return strings.TrimSpace(att.PlatformKey) != ""
-}
-
 // ResolveAttachment implements channel.AttachmentResolver. It downloads a file
 // received by the bot (identified by its downloadCode stored in PlatformKey)
 // via the DingTalk OpenAPI and returns a readable payload.
 func (a *DingTalkAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, att channel.Attachment) (channel.AttachmentPayload, error) {
 	downloadCode := strings.TrimSpace(att.PlatformKey)
 	if downloadCode == "" {
-		return channel.AttachmentPayload{}, errors.New("dingtalk: attachment has no downloadCode (platform_key)")
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
 	}
 	parsed, err := parseConfig(cfg.Credentials)
 	if err != nil {

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -764,6 +764,10 @@ func resolveAttachmentUploadReader(ctx context.Context, att channel.PreparedAtta
 // User-sent resources must be fetched via the message-resource API which
 // requires both message_id and file_key. The message_id is expected in
 // attachment.Metadata["message_id"].
+func (*FeishuAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	return strings.TrimSpace(attachment.PlatformKey) != ""
+}
+
 func (*FeishuAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	platformKey := strings.TrimSpace(attachment.PlatformKey)
 	if platformKey == "" {

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -764,14 +764,10 @@ func resolveAttachmentUploadReader(ctx context.Context, att channel.PreparedAtta
 // User-sent resources must be fetched via the message-resource API which
 // requires both message_id and file_key. The message_id is expected in
 // attachment.Metadata["message_id"].
-func (*FeishuAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	return strings.TrimSpace(attachment.PlatformKey) != ""
-}
-
 func (*FeishuAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	platformKey := strings.TrimSpace(attachment.PlatformKey)
 	if platformKey == "" {
-		return channel.AttachmentPayload{}, errors.New("feishu attachment platform_key is required")
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
 	}
 	messageID := ""
 	if attachment.Metadata != nil {

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -251,11 +251,8 @@ func TestFeishuResolveAttachmentRequiresPlatformKey(t *testing.T) {
 
 	adapter := NewFeishuAdapter(nil)
 	_, err := adapter.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{})
-	if err == nil {
-		t.Fatal("expected error when platform_key is missing")
-	}
-	if !strings.Contains(err.Error(), "platform_key") {
-		t.Fatalf("expected platform_key error, got: %v", err)
+	if !errors.Is(err, channel.ErrAttachmentNotResolvable) {
+		t.Fatalf("expected ErrAttachmentNotResolvable, got: %v", err)
 	}
 }
 

--- a/internal/channel/adapters/matrix/matrix.go
+++ b/internal/channel/adapters/matrix/matrix.go
@@ -1568,24 +1568,13 @@ func (a *MatrixAdapter) joinRoom(ctx context.Context, cfg Config, roomID string)
 	return a.doJSON(ctx, cfg, http.MethodPost, path, nil, nil)
 }
 
-func (*MatrixAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	contentURI := strings.TrimSpace(attachment.PlatformKey)
-	if contentURI == "" {
-		contentURI = strings.TrimSpace(attachment.URL)
-	}
-	return isMatrixContentURI(contentURI)
-}
-
 func (a *MatrixAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	contentURI := strings.TrimSpace(attachment.PlatformKey)
 	if contentURI == "" {
 		contentURI = strings.TrimSpace(attachment.URL)
 	}
-	if contentURI == "" {
-		return channel.AttachmentPayload{}, errors.New("matrix attachment requires platform_key or url")
-	}
 	if !isMatrixContentURI(contentURI) {
-		return channel.AttachmentPayload{}, errors.New("matrix attachment reference must be mxc://")
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
 	}
 	parsed, err := parseConfig(cfg.Credentials)
 	if err != nil {

--- a/internal/channel/adapters/matrix/matrix.go
+++ b/internal/channel/adapters/matrix/matrix.go
@@ -1568,6 +1568,14 @@ func (a *MatrixAdapter) joinRoom(ctx context.Context, cfg Config, roomID string)
 	return a.doJSON(ctx, cfg, http.MethodPost, path, nil, nil)
 }
 
+func (*MatrixAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	contentURI := strings.TrimSpace(attachment.PlatformKey)
+	if contentURI == "" {
+		contentURI = strings.TrimSpace(attachment.URL)
+	}
+	return isMatrixContentURI(contentURI)
+}
+
 func (a *MatrixAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	contentURI := strings.TrimSpace(attachment.PlatformKey)
 	if contentURI == "" {

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -1345,15 +1345,11 @@ func (a *TelegramAdapter) buildTelegramAttachment(bot *tgbotapi.BotAPI, attType 
 
 // ResolveAttachment resolves a Telegram attachment reference to a byte stream.
 // It supports platform_key-based references and URL fallback.
-func (*TelegramAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	return strings.TrimSpace(attachment.PlatformKey) != "" ||
-		(strings.EqualFold(strings.TrimSpace(attachment.SourcePlatform), Type.String()) && strings.TrimSpace(attachment.URL) != "")
-}
-
 func (a *TelegramAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	fileID := strings.TrimSpace(attachment.PlatformKey)
-	if fileID == "" && strings.TrimSpace(attachment.URL) == "" {
-		return channel.AttachmentPayload{}, errors.New("telegram attachment requires platform_key or url")
+	hasPlatformURL := strings.EqualFold(strings.TrimSpace(attachment.SourcePlatform), Type.String()) && strings.TrimSpace(attachment.URL) != ""
+	if fileID == "" && !hasPlatformURL {
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
 	}
 	telegramCfg, err := parseConfig(cfg.Credentials)
 	if err != nil {

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -1345,6 +1345,11 @@ func (a *TelegramAdapter) buildTelegramAttachment(bot *tgbotapi.BotAPI, attType 
 
 // ResolveAttachment resolves a Telegram attachment reference to a byte stream.
 // It supports platform_key-based references and URL fallback.
+func (*TelegramAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	return strings.TrimSpace(attachment.PlatformKey) != "" ||
+		(strings.EqualFold(strings.TrimSpace(attachment.SourcePlatform), Type.String()) && strings.TrimSpace(attachment.URL) != "")
+}
+
 func (a *TelegramAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	fileID := strings.TrimSpace(attachment.PlatformKey)
 	if fileID == "" && strings.TrimSpace(attachment.URL) == "" {

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -132,11 +132,8 @@ func TestTelegramResolveAttachmentRequiresReference(t *testing.T) {
 
 	adapter := NewTelegramAdapter(nil)
 	_, err := adapter.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{})
-	if err == nil {
-		t.Fatal("expected error when attachment has no platform_key/url")
-	}
-	if !strings.Contains(err.Error(), "platform_key") {
-		t.Fatalf("expected platform_key error, got: %v", err)
+	if !errors.Is(err, channel.ErrAttachmentNotResolvable) {
+		t.Fatalf("expected ErrAttachmentNotResolvable, got: %v", err)
 	}
 }
 

--- a/internal/channel/adapters/wecom/outbound.go
+++ b/internal/channel/adapters/wecom/outbound.go
@@ -14,6 +14,10 @@ import (
 	"github.com/memohai/memoh/internal/media"
 )
 
+func (*WeComAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	return strings.TrimSpace(attachment.URL) != ""
+}
+
 func (a *WeComAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	_ = cfg
 	if a.http == nil {

--- a/internal/channel/adapters/wecom/outbound.go
+++ b/internal/channel/adapters/wecom/outbound.go
@@ -14,18 +14,14 @@ import (
 	"github.com/memohai/memoh/internal/media"
 )
 
-func (*WeComAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	return strings.TrimSpace(attachment.URL) != ""
-}
-
 func (a *WeComAdapter) ResolveAttachment(ctx context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	_ = cfg
-	if a.http == nil {
-		return channel.AttachmentPayload{}, errors.New("wecom http client not configured")
-	}
 	url := strings.TrimSpace(attachment.URL)
 	if url == "" {
-		return channel.AttachmentPayload{}, errors.New("wecom attachment url is required")
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
+	}
+	if a.http == nil {
+		return channel.AttachmentPayload{}, errors.New("wecom http client not configured")
 	}
 	aesKey := ""
 	if attachment.Metadata != nil {

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -338,24 +338,7 @@ func openAttachment(ctx context.Context, att channel.PreparedAttachment) (io.Rea
 
 // -- AttachmentResolver (for inbound media download/decrypt) --
 
-func (*WeixinAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	if strings.TrimSpace(attachment.PlatformKey) != "" {
-		return true
-	}
-	if attachment.Metadata != nil {
-		if value, ok := attachment.Metadata["encrypt_query_param"].(string); ok && strings.TrimSpace(value) != "" {
-			return true
-		}
-	}
-	return false
-}
-
 func (*WeixinAdapter) ResolveAttachment(_ context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
-	parsed, err := parseConfig(cfg.Credentials)
-	if err != nil {
-		return channel.AttachmentPayload{}, err
-	}
-
 	encryptedQP := ""
 	aesKey := ""
 	if attachment.Metadata != nil {
@@ -370,7 +353,12 @@ func (*WeixinAdapter) ResolveAttachment(_ context.Context, cfg channel.ChannelCo
 		encryptedQP = strings.TrimSpace(attachment.PlatformKey)
 	}
 	if encryptedQP == "" {
-		return channel.AttachmentPayload{}, errors.New("weixin: no encrypt_query_param for attachment")
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
+	}
+
+	parsed, err := parseConfig(cfg.Credentials)
+	if err != nil {
+		return channel.AttachmentPayload{}, err
 	}
 
 	var data []byte

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -338,6 +338,18 @@ func openAttachment(ctx context.Context, att channel.PreparedAttachment) (io.Rea
 
 // -- AttachmentResolver (for inbound media download/decrypt) --
 
+func (*WeixinAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	if strings.TrimSpace(attachment.PlatformKey) != "" {
+		return true
+	}
+	if attachment.Metadata != nil {
+		if value, ok := attachment.Metadata["encrypt_query_param"].(string); ok && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (*WeixinAdapter) ResolveAttachment(_ context.Context, cfg channel.ChannelConfig, attachment channel.Attachment) (channel.AttachmentPayload, error) {
 	parsed, err := parseConfig(cfg.Credentials)
 	if err != nil {

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -1,6 +1,8 @@
 package weixin
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/memohai/memoh/internal/channel"
@@ -68,18 +70,11 @@ func TestWeixinAdapter_Interfaces(_ *testing.T) {
 	var _ channel.ProcessingStatusNotifier = adapter
 }
 
-func TestWeixinCanResolveRejectsURLOnlyAttachment(t *testing.T) {
+func TestWeixinResolveAttachmentRejectsURLOnlyAttachment(t *testing.T) {
 	adapter := NewWeixinAdapter(nil)
 
-	if adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{URL: "https://example.com/file.jpg"}) {
-		t.Fatal("expected URL-only attachment to fall back to generic resolver")
-	}
-	if !adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{PlatformKey: "enc-param"}) {
-		t.Fatal("expected platform_key attachment to use weixin resolver")
-	}
-	if !adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{
-		Metadata: map[string]any{"encrypt_query_param": "enc-param"},
-	}) {
-		t.Fatal("expected encrypt_query_param attachment to use weixin resolver")
+	_, err := adapter.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{URL: "https://example.com/file.jpg"})
+	if !errors.Is(err, channel.ErrAttachmentNotResolvable) {
+		t.Fatalf("expected ErrAttachmentNotResolvable for URL-only attachment, got %v", err)
 	}
 }

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -67,3 +67,19 @@ func TestWeixinAdapter_Interfaces(_ *testing.T) {
 	// ProcessingStatusNotifier
 	var _ channel.ProcessingStatusNotifier = adapter
 }
+
+func TestWeixinCanResolveRejectsURLOnlyAttachment(t *testing.T) {
+	adapter := NewWeixinAdapter(nil)
+
+	if adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{URL: "https://example.com/file.jpg"}) {
+		t.Fatal("expected URL-only attachment to fall back to generic resolver")
+	}
+	if !adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{PlatformKey: "enc-param"}) {
+		t.Fatal("expected platform_key attachment to use weixin resolver")
+	}
+	if !adapter.CanResolve(channel.ChannelConfig{}, channel.Attachment{
+		Metadata: map[string]any{"encrypt_query_param": "enc-param"},
+	}) {
+		t.Fatal("expected encrypt_query_param attachment to use weixin resolver")
+	}
+}

--- a/internal/channel/attachment_resolver.go
+++ b/internal/channel/attachment_resolver.go
@@ -29,31 +29,24 @@ func newEffectiveAttachmentResolver(platform AttachmentResolver) AttachmentResol
 	}
 }
 
-func (r effectiveAttachmentResolver) CanResolve(cfg ChannelConfig, attachment Attachment) bool {
-	if r.platform != nil && r.platform.CanResolve(cfg, attachment) {
-		return true
-	}
-	return r.fallback != nil && r.fallback.CanResolve(cfg, attachment)
-}
-
 func (r effectiveAttachmentResolver) ResolveAttachment(ctx context.Context, cfg ChannelConfig, attachment Attachment) (AttachmentPayload, error) {
-	if r.platform != nil && r.platform.CanResolve(cfg, attachment) {
-		return r.platform.ResolveAttachment(ctx, cfg, attachment)
+	if r.platform != nil {
+		result, err := r.platform.ResolveAttachment(ctx, cfg, attachment)
+		if !errors.Is(err, ErrAttachmentNotResolvable) {
+			return result, err
+		}
 	}
-	if r.fallback != nil && r.fallback.CanResolve(cfg, attachment) {
+	if r.fallback != nil {
 		return r.fallback.ResolveAttachment(ctx, cfg, attachment)
 	}
-	return AttachmentPayload{}, errors.New("attachment has no supported resolver")
-}
-
-func (defaultAttachmentResolver) CanResolve(_ ChannelConfig, attachment Attachment) bool {
-	if strings.TrimSpace(attachment.Base64) != "" {
-		return true
-	}
-	return isHTTPURL(strings.TrimSpace(attachment.URL))
+	return AttachmentPayload{}, ErrAttachmentNotResolvable
 }
 
 func (defaultAttachmentResolver) ResolveAttachment(ctx context.Context, _ ChannelConfig, attachment Attachment) (AttachmentPayload, error) {
+	if strings.TrimSpace(attachment.Base64) == "" && !isHTTPURL(strings.TrimSpace(attachment.URL)) {
+		return AttachmentPayload{}, ErrAttachmentNotResolvable
+	}
+
 	rawBase64 := strings.TrimSpace(attachment.Base64)
 	if rawBase64 != "" {
 		decoded, err := attachmentpkg.DecodeBase64(rawBase64, media.MaxAssetBytes)
@@ -73,7 +66,7 @@ func (defaultAttachmentResolver) ResolveAttachment(ctx context.Context, _ Channe
 
 	rawURL := strings.TrimSpace(attachment.URL)
 	if !isHTTPURL(rawURL) {
-		return AttachmentPayload{}, errors.New("attachment has no default-resolvable payload")
+		return AttachmentPayload{}, ErrAttachmentNotResolvable
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)

--- a/internal/channel/attachment_resolver.go
+++ b/internal/channel/attachment_resolver.go
@@ -1,0 +1,184 @@
+package channel
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	attachmentpkg "github.com/memohai/memoh/internal/attachment"
+	"github.com/memohai/memoh/internal/media"
+)
+
+type defaultAttachmentResolver struct{}
+
+type effectiveAttachmentResolver struct {
+	platform AttachmentResolver
+	fallback AttachmentResolver
+}
+
+func newEffectiveAttachmentResolver(platform AttachmentResolver) AttachmentResolver {
+	return effectiveAttachmentResolver{
+		platform: platform,
+		fallback: defaultAttachmentResolver{},
+	}
+}
+
+func (r effectiveAttachmentResolver) CanResolve(cfg ChannelConfig, attachment Attachment) bool {
+	if r.platform != nil && r.platform.CanResolve(cfg, attachment) {
+		return true
+	}
+	return r.fallback != nil && r.fallback.CanResolve(cfg, attachment)
+}
+
+func (r effectiveAttachmentResolver) ResolveAttachment(ctx context.Context, cfg ChannelConfig, attachment Attachment) (AttachmentPayload, error) {
+	if r.platform != nil && r.platform.CanResolve(cfg, attachment) {
+		return r.platform.ResolveAttachment(ctx, cfg, attachment)
+	}
+	if r.fallback != nil && r.fallback.CanResolve(cfg, attachment) {
+		return r.fallback.ResolveAttachment(ctx, cfg, attachment)
+	}
+	return AttachmentPayload{}, errors.New("attachment has no supported resolver")
+}
+
+func (defaultAttachmentResolver) CanResolve(_ ChannelConfig, attachment Attachment) bool {
+	if strings.TrimSpace(attachment.Base64) != "" {
+		return true
+	}
+	return isHTTPURL(strings.TrimSpace(attachment.URL))
+}
+
+func (defaultAttachmentResolver) ResolveAttachment(ctx context.Context, _ ChannelConfig, attachment Attachment) (AttachmentPayload, error) {
+	rawBase64 := strings.TrimSpace(attachment.Base64)
+	if rawBase64 != "" {
+		decoded, err := attachmentpkg.DecodeBase64(rawBase64, media.MaxAssetBytes)
+		if err != nil {
+			return AttachmentPayload{}, fmt.Errorf("decode attachment base64: %w", err)
+		}
+		mimeType := strings.TrimSpace(attachment.Mime)
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(attachmentpkg.MimeFromDataURL(rawBase64))
+		}
+		return AttachmentPayload{
+			Reader: io.NopCloser(decoded),
+			Mime:   mimeType,
+			Name:   strings.TrimSpace(attachment.Name),
+		}, nil
+	}
+
+	rawURL := strings.TrimSpace(attachment.URL)
+	if !isHTTPURL(rawURL) {
+		return AttachmentPayload{}, errors.New("attachment has no default-resolvable payload")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return AttachmentPayload{}, fmt.Errorf("build request: %w", err)
+	}
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is an operator/user provided public attachment URL
+	if err != nil {
+		return AttachmentPayload{}, fmt.Errorf("download attachment: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_ = resp.Body.Close()
+		return AttachmentPayload{}, fmt.Errorf("download attachment status: %d", resp.StatusCode)
+	}
+	if resp.ContentLength > media.MaxAssetBytes {
+		_ = resp.Body.Close()
+		return AttachmentPayload{}, fmt.Errorf("%w: max %d bytes", media.ErrAssetTooLarge, media.MaxAssetBytes)
+	}
+
+	head, body, sniffed, err := readAttachmentBody(resp.Body, media.MaxAssetBytes)
+	if err != nil {
+		return AttachmentPayload{}, err
+	}
+	mime := normalizeResponseMime(resp.Header.Get("Content-Type"))
+	if mime == "" {
+		mime = sniffed
+	}
+	if looksLikeUnexpectedHTML(attachment, mime, sniffed, head) {
+		_ = body.Close()
+		return AttachmentPayload{}, errors.New("download attachment returned html instead of binary payload")
+	}
+
+	size := attachment.Size
+	if size <= 0 && resp.ContentLength > 0 {
+		size = resp.ContentLength
+	}
+	return AttachmentPayload{
+		Reader: body,
+		Mime:   mime,
+		Name:   strings.TrimSpace(attachment.Name),
+		Size:   size,
+	}, nil
+}
+
+func readAttachmentBody(body io.ReadCloser, maxBytes int64) ([]byte, io.ReadCloser, string, error) {
+	limited := io.LimitReader(body, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	_ = body.Close()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("read attachment body: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, nil, "", fmt.Errorf("%w: max %d bytes", media.ErrAssetTooLarge, maxBytes)
+	}
+	head := data
+	if len(head) > 512 {
+		head = head[:512]
+	}
+	sniffed := strings.TrimSpace(http.DetectContentType(head))
+	return head, io.NopCloser(bytes.NewReader(data)), sniffed, nil
+}
+
+func normalizeResponseMime(raw string) string {
+	mime := strings.TrimSpace(raw)
+	if idx := strings.Index(mime, ";"); idx >= 0 {
+		mime = strings.TrimSpace(mime[:idx])
+	}
+	return mime
+}
+
+func looksLikeUnexpectedHTML(att Attachment, headerMime, sniffedMime string, head []byte) bool {
+	if !attachmentExpectsBinary(att) {
+		return false
+	}
+	headerMime = strings.ToLower(strings.TrimSpace(headerMime))
+	sniffedMime = strings.ToLower(strings.TrimSpace(sniffedMime))
+	if headerMime == "text/html" || sniffedMime == "text/html" {
+		return true
+	}
+	trimmed := strings.TrimSpace(strings.ToLower(string(head)))
+	return strings.HasPrefix(trimmed, "<!doctype html") || strings.HasPrefix(trimmed, "<html")
+}
+
+func attachmentExpectsBinary(att Attachment) bool {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(att.Mime)), "image/") {
+		return true
+	}
+	switch att.Type {
+	case AttachmentImage, AttachmentVideo, AttachmentAudio, AttachmentGIF:
+		return true
+	default:
+		return false
+	}
+}
+
+func isHTTPURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+		return parsed.Host != ""
+	default:
+		return false
+	}
+}

--- a/internal/channel/attachment_resolver.go
+++ b/internal/channel/attachment_resolver.go
@@ -182,9 +182,6 @@ func (r *maxBytesReader) Read(p []byte) (int, error) {
 	}
 
 	allowed := int(r.maxBytes - r.emitted)
-	if allowed <= 0 {
-		return r.probeOverflow()
-	}
 	if len(p) > allowed {
 		p = p[:allowed]
 	}

--- a/internal/channel/attachment_resolver.go
+++ b/internal/channel/attachment_resolver.go
@@ -15,6 +15,8 @@ import (
 	"github.com/memohai/memoh/internal/media"
 )
 
+const attachmentSniffBytes = 512
+
 type defaultAttachmentResolver struct{}
 
 type effectiveAttachmentResolver struct {
@@ -113,21 +115,95 @@ func (defaultAttachmentResolver) ResolveAttachment(ctx context.Context, _ Channe
 }
 
 func readAttachmentBody(body io.ReadCloser, maxBytes int64) ([]byte, io.ReadCloser, string, error) {
-	limited := io.LimitReader(body, maxBytes+1)
-	data, err := io.ReadAll(limited)
-	_ = body.Close()
-	if err != nil {
+	if body == nil {
+		return nil, nil, "", errors.New("attachment body is required")
+	}
+	if maxBytes <= 0 {
+		_ = body.Close()
+		return nil, nil, "", errors.New("max bytes must be greater than 0")
+	}
+
+	limited := &io.LimitedReader{R: body, N: maxBytes + 1}
+	sniffBytes := attachmentSniffBytes
+	if remaining := int(maxBytes + 1); remaining < sniffBytes {
+		sniffBytes = remaining
+	}
+	head := make([]byte, sniffBytes)
+	n, err := io.ReadFull(limited, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		_ = body.Close()
 		return nil, nil, "", fmt.Errorf("read attachment body: %w", err)
 	}
-	if int64(len(data)) > maxBytes {
+	head = head[:n]
+	if int64(len(head)) > maxBytes {
+		_ = body.Close()
 		return nil, nil, "", fmt.Errorf("%w: max %d bytes", media.ErrAssetTooLarge, maxBytes)
 	}
-	head := data
-	if len(head) > 512 {
-		head = head[:512]
-	}
 	sniffed := strings.TrimSpace(http.DetectContentType(head))
-	return head, io.NopCloser(bytes.NewReader(data)), sniffed, nil
+	stream := &attachmentStreamReadCloser{
+		reader: io.MultiReader(
+			bytes.NewReader(head),
+			&maxBytesReader{
+				reader:   limited,
+				maxBytes: maxBytes,
+				emitted:  int64(len(head)),
+			},
+		),
+		closer: body,
+	}
+	return head, stream, sniffed, nil
+}
+
+type attachmentStreamReadCloser struct {
+	reader io.Reader
+	closer io.Closer
+}
+
+func (r *attachmentStreamReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *attachmentStreamReadCloser) Close() error {
+	if r.closer == nil {
+		return nil
+	}
+	return r.closer.Close()
+}
+
+type maxBytesReader struct {
+	reader   io.Reader
+	maxBytes int64
+	emitted  int64
+}
+
+func (r *maxBytesReader) Read(p []byte) (int, error) {
+	if r.emitted >= r.maxBytes {
+		return r.probeOverflow()
+	}
+
+	allowed := int(r.maxBytes - r.emitted)
+	if allowed <= 0 {
+		return r.probeOverflow()
+	}
+	if len(p) > allowed {
+		p = p[:allowed]
+	}
+
+	n, err := r.reader.Read(p)
+	r.emitted += int64(n)
+	return n, err
+}
+
+func (r *maxBytesReader) probeOverflow() (int, error) {
+	var probe [1]byte
+	n, err := r.reader.Read(probe[:])
+	if n > 0 {
+		return 0, fmt.Errorf("%w: max %d bytes", media.ErrAssetTooLarge, r.maxBytes)
+	}
+	if err != nil {
+		return 0, err
+	}
+	return 0, io.EOF
 }
 
 func normalizeResponseMime(raw string) string {

--- a/internal/channel/attachment_resolver_test.go
+++ b/internal/channel/attachment_resolver_test.go
@@ -1,0 +1,56 @@
+package channel
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/memohai/memoh/internal/media"
+)
+
+func TestReadAttachmentBodyStreamsPayload(t *testing.T) {
+	t.Parallel()
+
+	src := bytes.Repeat([]byte("a"), 2048)
+	head, body, sniffed, err := readAttachmentBody(io.NopCloser(bytes.NewReader(src)), media.MaxAssetBytes)
+	if err != nil {
+		t.Fatalf("readAttachmentBody: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	if len(head) != attachmentSniffBytes {
+		t.Fatalf("expected %d sniff bytes, got %d", attachmentSniffBytes, len(head))
+	}
+	if sniffed != http.DetectContentType(head) {
+		t.Fatalf("unexpected sniffed mime: %q", sniffed)
+	}
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("streamed payload did not match source")
+	}
+}
+
+func TestReadAttachmentBodyReturnsTooLargeDuringStream(t *testing.T) {
+	t.Parallel()
+
+	src := bytes.Repeat([]byte("b"), 600)
+	_, body, _, err := readAttachmentBody(io.NopCloser(bytes.NewReader(src)), 550)
+	if err != nil {
+		t.Fatalf("readAttachmentBody: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	got, err := io.ReadAll(body)
+	if !errors.Is(err, media.ErrAssetTooLarge) {
+		t.Fatalf("expected ErrAssetTooLarge, got %v", err)
+	}
+	if len(got) != 550 {
+		t.Fatalf("expected 550 bytes before limit error, got %d", len(got))
+	}
+}

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -1865,37 +1864,6 @@ func (p *ChannelInboundProcessor) loadInboundAttachmentPayload(
 		size:   resolved.Size,
 	}, nil
 }
-
-func openInboundAttachmentURL(ctx context.Context, rawURL string) (inboundAttachmentPayload, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return inboundAttachmentPayload{}, fmt.Errorf("build request: %w", err)
-	}
-	client := &http.Client{Timeout: 20 * time.Second}
-	resp, err := client.Do(req) //nolint:gosec // G704: URL is an attachment URL provided by the inbound channel adapter
-	if err != nil {
-		return inboundAttachmentPayload{}, fmt.Errorf("download attachment: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		_ = resp.Body.Close()
-		return inboundAttachmentPayload{}, fmt.Errorf("download attachment status: %d", resp.StatusCode)
-	}
-	maxBytes := media.MaxAssetBytes
-	if resp.ContentLength > maxBytes {
-		_ = resp.Body.Close()
-		return inboundAttachmentPayload{}, fmt.Errorf("%w: max %d bytes", media.ErrAssetTooLarge, maxBytes)
-	}
-	mime := strings.TrimSpace(resp.Header.Get("Content-Type"))
-	if idx := strings.Index(mime, ";"); idx >= 0 {
-		mime = strings.TrimSpace(mime[:idx])
-	}
-	return inboundAttachmentPayload{
-		reader: resp.Body,
-		mime:   mime,
-		size:   resp.ContentLength,
-	}, nil
-}
-
 func (p *ChannelInboundProcessor) resolveAttachmentResolver(channelType channel.ChannelType) channel.AttachmentResolver {
 	if p == nil {
 		return nil

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -1840,10 +1840,10 @@ func (p *ChannelInboundProcessor) loadInboundAttachmentPayload(
 	if resolver == nil {
 		return inboundAttachmentPayload{}, errors.New("attachment resolver is not configured")
 	}
-	if !resolver.CanResolve(cfg, att) {
+	resolved, err := resolver.ResolveAttachment(ctx, cfg, att)
+	if errors.Is(err, channel.ErrAttachmentNotResolvable) {
 		return inboundAttachmentPayload{}, errors.New("attachment has no ingestible payload")
 	}
-	resolved, err := resolver.ResolveAttachment(ctx, cfg, att)
 	if err != nil {
 		return inboundAttachmentPayload{}, fmt.Errorf("resolve attachment payload: %w", err)
 	}

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -1836,50 +1836,16 @@ func (p *ChannelInboundProcessor) loadInboundAttachmentPayload(
 	msg channel.InboundMessage,
 	att channel.Attachment,
 ) (inboundAttachmentPayload, error) {
-	rawURL := strings.TrimSpace(att.URL)
-	if rawURL != "" {
-		payload, err := openInboundAttachmentURL(ctx, rawURL)
-		if err == nil {
-			if strings.TrimSpace(att.Mime) != "" {
-				payload.mime = strings.TrimSpace(att.Mime)
-			}
-			if strings.TrimSpace(payload.name) == "" {
-				payload.name = strings.TrimSpace(att.Name)
-			}
-			return payload, nil
-		}
-		// When URL download fails and no other source exists, return URL error.
-		if strings.TrimSpace(att.PlatformKey) == "" && strings.TrimSpace(att.Base64) == "" {
-			return inboundAttachmentPayload{}, err
-		}
-	}
-	rawBase64 := strings.TrimSpace(att.Base64)
-	if rawBase64 != "" {
-		decoded, err := attachment.DecodeBase64(rawBase64, media.MaxAssetBytes)
-		if err != nil {
-			return inboundAttachmentPayload{}, fmt.Errorf("decode attachment base64: %w", err)
-		}
-		mimeType := strings.TrimSpace(att.Mime)
-		if mimeType == "" {
-			mimeType = strings.TrimSpace(attachment.MimeFromDataURL(rawBase64))
-		}
-		return inboundAttachmentPayload{
-			reader: io.NopCloser(decoded),
-			mime:   mimeType,
-			name:   strings.TrimSpace(att.Name),
-		}, nil
-	}
-	platformKey := strings.TrimSpace(att.PlatformKey)
-	if platformKey == "" {
-		return inboundAttachmentPayload{}, errors.New("attachment has no ingestible payload")
-	}
 	resolver := p.resolveAttachmentResolver(msg.Channel)
 	if resolver == nil {
-		return inboundAttachmentPayload{}, fmt.Errorf("attachment resolver not supported for channel: %s", msg.Channel.String())
+		return inboundAttachmentPayload{}, errors.New("attachment resolver is not configured")
+	}
+	if !resolver.CanResolve(cfg, att) {
+		return inboundAttachmentPayload{}, errors.New("attachment has no ingestible payload")
 	}
 	resolved, err := resolver.ResolveAttachment(ctx, cfg, att)
 	if err != nil {
-		return inboundAttachmentPayload{}, fmt.Errorf("resolve attachment by platform key: %w", err)
+		return inboundAttachmentPayload{}, fmt.Errorf("resolve attachment payload: %w", err)
 	}
 	if resolved.Reader == nil {
 		return inboundAttachmentPayload{}, errors.New("resolved attachment reader is nil")
@@ -1931,14 +1897,13 @@ func openInboundAttachmentURL(ctx context.Context, rawURL string) (inboundAttach
 }
 
 func (p *ChannelInboundProcessor) resolveAttachmentResolver(channelType channel.ChannelType) channel.AttachmentResolver {
-	if p == nil || p.registry == nil {
+	if p == nil {
 		return nil
 	}
-	resolver, ok := p.registry.GetAttachmentResolver(channelType)
-	if !ok {
-		return nil
+	if p.registry == nil {
+		return channel.NewRegistry().EffectiveAttachmentResolver(channelType)
 	}
-	return resolver
+	return p.registry.EffectiveAttachmentResolver(channelType)
 }
 
 // ingestOutboundAttachments persists LLM-generated attachment data URLs via the

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -1864,6 +1864,7 @@ func (p *ChannelInboundProcessor) loadInboundAttachmentPayload(
 		size:   resolved.Size,
 	}, nil
 }
+
 func (p *ChannelInboundProcessor) resolveAttachmentResolver(channelType channel.ChannelType) channel.AttachmentResolver {
 	if p == nil {
 		return nil

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -393,11 +393,10 @@ func (f *fakeResolverAdapter) Descriptor() channel.Descriptor {
 	}
 }
 
-func (*fakeResolverAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
-	return strings.TrimSpace(attachment.PlatformKey) != "" || strings.TrimSpace(attachment.SourcePlatform) != ""
-}
-
-func (f *fakeResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+func (f *fakeResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, att channel.Attachment) (channel.AttachmentPayload, error) {
+	if strings.TrimSpace(att.PlatformKey) == "" && strings.TrimSpace(att.SourcePlatform) == "" {
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
+	}
 	if f != nil {
 		f.calls++
 	}

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -369,19 +369,20 @@ func (*fakeStorageProvider) AccessPath(key string) string {
 	return "/data/media/" + key
 }
 
-type fakeAttachmentResolverAdapter struct {
+type fakeResolverAdapter struct {
 	typ     channel.ChannelType
 	payload channel.AttachmentPayload
+	calls   int
 }
 
-func (f *fakeAttachmentResolverAdapter) Type() channel.ChannelType {
+func (f *fakeResolverAdapter) Type() channel.ChannelType {
 	if f != nil && strings.TrimSpace(f.typ.String()) != "" {
 		return f.typ
 	}
 	return channel.ChannelType("resolver-test")
 }
 
-func (f *fakeAttachmentResolverAdapter) Descriptor() channel.Descriptor {
+func (f *fakeResolverAdapter) Descriptor() channel.Descriptor {
 	return channel.Descriptor{
 		Type:        f.Type(),
 		DisplayName: "ResolverTest",
@@ -392,7 +393,14 @@ func (f *fakeAttachmentResolverAdapter) Descriptor() channel.Descriptor {
 	}
 }
 
-func (f *fakeAttachmentResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+func (*fakeResolverAdapter) CanResolve(_ channel.ChannelConfig, attachment channel.Attachment) bool {
+	return strings.TrimSpace(attachment.PlatformKey) != "" || strings.TrimSpace(attachment.SourcePlatform) != ""
+}
+
+func (f *fakeResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+	if f != nil {
+		f.calls++
+	}
 	if f != nil && f.payload.Reader != nil {
 		return f.payload, nil
 	}
@@ -1042,7 +1050,7 @@ func TestChannelInboundProcessorIngestsPlatformKeyWithResolver(t *testing.T) {
 		},
 	}
 	registry := channel.NewRegistry()
-	registry.MustRegister(&fakeAttachmentResolverAdapter{})
+	registry.MustRegister(&fakeResolverAdapter{})
 	processor := NewChannelInboundProcessor(slog.Default(), registry, chatSvc, chatSvc, gateway, channelIdentitySvc, policySvc, nil, "", 0)
 	mediaSvc := &fakeMediaIngestor{nextID: "asset-resolved-1", nextMime: "application/octet-stream"}
 	processor.SetMediaService(mediaSvc)
@@ -1171,7 +1179,7 @@ func TestChannelInboundProcessorIngestsQQFileAttachmentKeepsOriginalExtWhenMimeG
 		},
 	}
 	registry := channel.NewRegistry()
-	registry.MustRegister(&fakeAttachmentResolverAdapter{
+	registry.MustRegister(&fakeResolverAdapter{
 		typ: channel.ChannelType("qq"),
 		payload: channel.AttachmentPayload{
 			Reader: io.NopCloser(bytes.NewReader([]byte{0x00, 0x01, 0x02, 0x03, 0x04})),
@@ -1297,6 +1305,76 @@ func TestChannelInboundProcessorPipelineUsesResolvedAttachments(t *testing.T) {
 	}
 	if strings.Contains(atts[0].FilePath, "api.telegram.org") {
 		t.Fatalf("expected pipeline attachment path to avoid telegram url, got %q", atts[0].FilePath)
+	}
+}
+
+func TestChannelInboundProcessorUsesPlatformResolver(t *testing.T) {
+	channelIdentitySvc := &fakeChannelIdentityService{channelIdentity: identities.ChannelIdentity{ID: "cid-platform"}}
+	policySvc := &fakePolicyService{}
+	chatSvc := &fakeChatService{resolveResult: route.ResolveConversationResult{ChatID: "chat-platform", RouteID: "route-platform"}}
+	gateway := &fakeChatGateway{
+		resp: conversation.ChatResponse{
+			Messages: []conversation.ModelMessage{
+				{Role: "assistant", Content: conversation.NewTextContent("ok")},
+			},
+		},
+	}
+	resolver := &fakeResolverAdapter{
+		typ: channel.ChannelType("resolver-test"),
+		payload: channel.AttachmentPayload{
+			Reader: io.NopCloser(strings.NewReader("resolver-image-bytes")),
+			Mime:   "image/png",
+			Name:   "resolver.png",
+			Size:   int64(len("resolver-image-bytes")),
+		},
+	}
+	registry := channel.NewRegistry()
+	registry.MustRegister(resolver)
+	processor := NewChannelInboundProcessor(slog.Default(), registry, chatSvc, chatSvc, gateway, channelIdentitySvc, policySvc, nil, "", 0)
+	mediaSvc := &fakeMediaIngestor{nextID: "asset-platform-1", nextMime: "image/png"}
+	processor.SetMediaService(mediaSvc)
+	sender := &fakeReplySender{}
+
+	cfg := channel.ChannelConfig{ID: "cfg-platform", BotID: "bot-1", ChannelType: channel.ChannelType("resolver-test")}
+	msg := channel.InboundMessage{
+		BotID:   "bot-1",
+		Channel: channel.ChannelType("resolver-test"),
+		Message: channel.Message{
+			ID:   "msg-platform-1",
+			Text: "platform test",
+			Attachments: []channel.Attachment{
+				{
+					Type:           channel.AttachmentImage,
+					URL:            "https://files.slack.test/files-pri/T1-F1/image.png",
+					PlatformKey:    "F1",
+					SourcePlatform: "resolver-test",
+					Name:           "image.png",
+					Mime:           "image/png",
+				},
+			},
+		},
+		ReplyTarget: "rt-platform",
+		Sender:      channel.Identity{SubjectID: "user-platform"},
+		Conversation: channel.Conversation{
+			ID:   "conv-platform",
+			Type: channel.ConversationTypePrivate,
+		},
+	}
+
+	if err := processor.HandleInbound(context.Background(), cfg, msg, sender); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("expected platform resolver to be called once, got %d", resolver.calls)
+	}
+	if len(mediaSvc.payloads) != 1 || string(mediaSvc.payloads[0]) != "resolver-image-bytes" {
+		t.Fatalf("unexpected ingested payload: %+v", mediaSvc.payloads)
+	}
+	if len(gateway.gotReq.Attachments) != 1 {
+		t.Fatalf("expected one gateway attachment, got %d", len(gateway.gotReq.Attachments))
+	}
+	if got := gateway.gotReq.Attachments[0].ContentHash; got != "asset-platform-1" {
+		t.Fatalf("expected resolved asset id, got %q", got)
 	}
 }
 

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -1648,25 +1646,6 @@ func TestChannelInboundProcessorProcessingFailedNotifyErrorDoesNotOverrideChatEr
 	}
 	if len(notifier.events) != 2 || notifier.events[0] != "started" || notifier.events[1] != "failed" {
 		t.Fatalf("unexpected processing status lifecycle: %+v", notifier.events)
-	}
-}
-
-func TestDownloadInboundAttachmentURLTooLarge(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.Header().Set("Content-Length", "999999999")
-		_, _ = w.Write([]byte("x"))
-	}))
-	defer server.Close()
-
-	_, err := openInboundAttachmentURL(context.Background(), server.URL)
-	if err == nil {
-		t.Fatalf("expected too-large error")
-	}
-	if !errors.Is(err, media.ErrAssetTooLarge) {
-		t.Fatalf("expected ErrAssetTooLarge, got %v", err)
 	}
 }
 

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -369,20 +369,20 @@ func (*fakeStorageProvider) AccessPath(key string) string {
 	return "/data/media/" + key
 }
 
-type fakeResolverAdapter struct {
+type fakeAttachmentResolverAdapter struct {
 	typ     channel.ChannelType
 	payload channel.AttachmentPayload
 	calls   int
 }
 
-func (f *fakeResolverAdapter) Type() channel.ChannelType {
+func (f *fakeAttachmentResolverAdapter) Type() channel.ChannelType {
 	if f != nil && strings.TrimSpace(f.typ.String()) != "" {
 		return f.typ
 	}
 	return channel.ChannelType("resolver-test")
 }
 
-func (f *fakeResolverAdapter) Descriptor() channel.Descriptor {
+func (f *fakeAttachmentResolverAdapter) Descriptor() channel.Descriptor {
 	return channel.Descriptor{
 		Type:        f.Type(),
 		DisplayName: "ResolverTest",
@@ -393,7 +393,7 @@ func (f *fakeResolverAdapter) Descriptor() channel.Descriptor {
 	}
 }
 
-func (f *fakeResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, att channel.Attachment) (channel.AttachmentPayload, error) {
+func (f *fakeAttachmentResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, att channel.Attachment) (channel.AttachmentPayload, error) {
 	if strings.TrimSpace(att.PlatformKey) == "" && strings.TrimSpace(att.SourcePlatform) == "" {
 		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
 	}
@@ -1049,7 +1049,7 @@ func TestChannelInboundProcessorIngestsPlatformKeyWithResolver(t *testing.T) {
 		},
 	}
 	registry := channel.NewRegistry()
-	registry.MustRegister(&fakeResolverAdapter{})
+	registry.MustRegister(&fakeAttachmentResolverAdapter{})
 	processor := NewChannelInboundProcessor(slog.Default(), registry, chatSvc, chatSvc, gateway, channelIdentitySvc, policySvc, nil, "", 0)
 	mediaSvc := &fakeMediaIngestor{nextID: "asset-resolved-1", nextMime: "application/octet-stream"}
 	processor.SetMediaService(mediaSvc)
@@ -1178,7 +1178,7 @@ func TestChannelInboundProcessorIngestsQQFileAttachmentKeepsOriginalExtWhenMimeG
 		},
 	}
 	registry := channel.NewRegistry()
-	registry.MustRegister(&fakeResolverAdapter{
+	registry.MustRegister(&fakeAttachmentResolverAdapter{
 		typ: channel.ChannelType("qq"),
 		payload: channel.AttachmentPayload{
 			Reader: io.NopCloser(bytes.NewReader([]byte{0x00, 0x01, 0x02, 0x03, 0x04})),
@@ -1318,7 +1318,7 @@ func TestChannelInboundProcessorUsesPlatformResolver(t *testing.T) {
 			},
 		},
 	}
-	resolver := &fakeResolverAdapter{
+	resolver := &fakeAttachmentResolverAdapter{
 		typ: channel.ChannelType("resolver-test"),
 		payload: channel.AttachmentPayload{
 			Reader: io.NopCloser(strings.NewReader("resolver-image-bytes")),

--- a/internal/channel/registry.go
+++ b/internal/channel/registry.go
@@ -268,6 +268,19 @@ func (r *Registry) GetAttachmentResolver(channelType ChannelType) (AttachmentRes
 	return resolver, ok
 }
 
+// EffectiveAttachmentResolver returns a composed attachment resolver for the
+// given channel type. Platform-specific resolvers take precedence; the default
+// resolver handles base64 and public URLs.
+func (r *Registry) EffectiveAttachmentResolver(channelType ChannelType) AttachmentResolver {
+	var platform AttachmentResolver
+	if r != nil {
+		if resolver, ok := r.GetAttachmentResolver(channelType); ok {
+			platform = resolver
+		}
+	}
+	return newEffectiveAttachmentResolver(platform)
+}
+
 // DiscoverSelf calls the SelfDiscoverer for the given channel type if supported.
 func (r *Registry) DiscoverSelf(ctx context.Context, channelType ChannelType, credentials map[string]any) (map[string]any, string, error) {
 	adapter, ok := r.Get(channelType)

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -2,7 +2,9 @@ package channel_test
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -64,17 +66,21 @@ func TestDirectoryAdapter_UnknownType(t *testing.T) {
 	}
 }
 
-type attachmentResolverMockAdapter struct{}
+type attachmentResolverAdapter struct{}
 
-func (*attachmentResolverMockAdapter) Type() channel.ChannelType {
+func (*attachmentResolverAdapter) Type() channel.ChannelType {
 	return channel.ChannelType("attachment-test")
 }
 
-func (*attachmentResolverMockAdapter) Descriptor() channel.Descriptor {
+func (*attachmentResolverAdapter) Descriptor() channel.Descriptor {
 	return channel.Descriptor{Type: channel.ChannelType("attachment-test"), DisplayName: "AttachmentTest"}
 }
 
-func (*attachmentResolverMockAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+func (*attachmentResolverAdapter) CanResolve(_ channel.ChannelConfig, _ channel.Attachment) bool {
+	return true
+}
+
+func (*attachmentResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
 	return channel.AttachmentPayload{
 		Reader: io.NopCloser(strings.NewReader("payload")),
 		Mime:   "text/plain",
@@ -83,10 +89,28 @@ func (*attachmentResolverMockAdapter) ResolveAttachment(_ context.Context, _ cha
 	}, nil
 }
 
+type failingResolverAdapter struct{}
+
+func (*failingResolverAdapter) Type() channel.ChannelType {
+	return channel.ChannelType("failing-attachment-test")
+}
+
+func (*failingResolverAdapter) Descriptor() channel.Descriptor {
+	return channel.Descriptor{Type: channel.ChannelType("failing-attachment-test"), DisplayName: "FailingAttachmentTest"}
+}
+
+func (*failingResolverAdapter) CanResolve(_ channel.ChannelConfig, att channel.Attachment) bool {
+	return strings.TrimSpace(att.PlatformKey) != ""
+}
+
+func (*failingResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+	return channel.AttachmentPayload{}, errors.New("platform API error")
+}
+
 func TestGetAttachmentResolver_Supported(t *testing.T) {
 	t.Parallel()
 	reg := channel.NewRegistry()
-	reg.MustRegister(&attachmentResolverMockAdapter{})
+	reg.MustRegister(&attachmentResolverAdapter{})
 	resolver, ok := reg.GetAttachmentResolver(channel.ChannelType("attachment-test"))
 	if !ok || resolver == nil {
 		t.Fatalf("GetAttachmentResolver should return resolver for supported adapter")
@@ -100,4 +124,196 @@ func TestGetAttachmentResolver_Unsupported(t *testing.T) {
 	if ok || resolver != nil {
 		t.Fatalf("GetAttachmentResolver(test) = (%v, %v), want (nil, false)", resolver, ok)
 	}
+}
+
+func TestEffectiveResolver_PublicURL(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://public.example.test/cat.png" {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"image/png"}},
+			Body:       io.NopCloser(strings.NewReader("png-bytes")),
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := newTestConfigRegistry()
+	resolver := reg.EffectiveAttachmentResolver(testChannelType)
+	if !resolver.CanResolve(channel.ChannelConfig{}, channel.Attachment{URL: "https://public.example.test/cat.png"}) {
+		t.Fatal("expected effective resolver to handle public URL")
+	}
+	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{
+		Type: channel.AttachmentImage,
+		URL:  "https://public.example.test/cat.png",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAttachment: %v", err)
+	}
+	defer func() { _ = payload.Reader.Close() }()
+	data, err := io.ReadAll(payload.Reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(data) != "png-bytes" {
+		t.Fatalf("unexpected payload: %q", string(data))
+	}
+}
+
+func TestEffectiveResolver_URLWithPlatformKey(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://cdn.discordapp.com/attachments/file.png" {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"image/png"}},
+			Body:       io.NopCloser(strings.NewReader("discord-bytes")),
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := newTestConfigRegistry()
+	resolver := reg.EffectiveAttachmentResolver(testChannelType)
+	att := channel.Attachment{
+		Type:        channel.AttachmentImage,
+		URL:         "https://cdn.discordapp.com/attachments/file.png",
+		PlatformKey: "discord-file-id",
+	}
+	if !resolver.CanResolve(channel.ChannelConfig{}, att) {
+		t.Fatal("expected effective resolver to handle URL attachment with platform key")
+	}
+	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
+	if err != nil {
+		t.Fatalf("ResolveAttachment: %v", err)
+	}
+	defer func() { _ = payload.Reader.Close() }()
+	data, err := io.ReadAll(payload.Reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(data) != "discord-bytes" {
+		t.Fatalf("unexpected payload: %q", string(data))
+	}
+}
+
+func TestEffectiveResolver_URLWithSourcePlatform(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://qq.example.test/files/image.jpg" {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"image/jpeg"}},
+			Body:       io.NopCloser(strings.NewReader("qq-bytes")),
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := newTestConfigRegistry()
+	resolver := reg.EffectiveAttachmentResolver(testChannelType)
+	att := channel.Attachment{
+		Type:           channel.AttachmentImage,
+		URL:            "https://qq.example.test/files/image.jpg",
+		SourcePlatform: "qq",
+	}
+	if !resolver.CanResolve(channel.ChannelConfig{}, att) {
+		t.Fatal("expected effective resolver to handle URL attachment with source platform")
+	}
+	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
+	if err != nil {
+		t.Fatalf("ResolveAttachment: %v", err)
+	}
+	defer func() { _ = payload.Reader.Close() }()
+	data, err := io.ReadAll(payload.Reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(data) != "qq-bytes" {
+		t.Fatalf("unexpected payload: %q", string(data))
+	}
+}
+
+func TestEffectiveResolver_RejectsHTMLImage(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://public.example.test/login.html" {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/html"}},
+			Body:       io.NopCloser(strings.NewReader("<html>login</html>")),
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := newTestConfigRegistry()
+	resolver := reg.EffectiveAttachmentResolver(testChannelType)
+	_, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{
+		Type: channel.AttachmentImage,
+		URL:  "https://public.example.test/login.html",
+	})
+	if err == nil || !strings.Contains(err.Error(), "html") {
+		t.Fatalf("expected html rejection error, got %v", err)
+	}
+}
+
+func TestEffectiveResolver_PlatformError(t *testing.T) {
+	reg := channel.NewRegistry()
+	reg.MustRegister(&failingResolverAdapter{})
+	resolver := reg.EffectiveAttachmentResolver(channel.ChannelType("failing-attachment-test"))
+
+	att := channel.Attachment{
+		Type:        channel.AttachmentFile,
+		PlatformKey: "F123",
+	}
+
+	_, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
+	if err == nil {
+		t.Fatal("expected error when platform fails and no fallback is viable")
+	}
+	if !strings.Contains(err.Error(), "platform API error") {
+		t.Fatalf("expected platform error to propagate, got: %v", err)
+	}
+}
+
+// Platform-owned attachments must not fall back to anonymous URL download.
+func TestEffectiveResolver_PlatformOwnsURL(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("default resolver must not be attempted when platform resolver owns the attachment")
+		return nil, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := channel.NewRegistry()
+	reg.MustRegister(&failingResolverAdapter{})
+	resolver := reg.EffectiveAttachmentResolver(channel.ChannelType("failing-attachment-test"))
+
+	att := channel.Attachment{
+		Type:        channel.AttachmentFile,
+		URL:         "https://files.slack.test/private/doc.pdf",
+		PlatformKey: "F123",
+		Name:        "doc.pdf",
+		Mime:        "application/pdf",
+	}
+
+	_, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
+	if err == nil {
+		t.Fatal("expected platform error to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), "platform API error") {
+		t.Fatalf("expected platform error, got: %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -76,10 +76,6 @@ func (*attachmentResolverAdapter) Descriptor() channel.Descriptor {
 	return channel.Descriptor{Type: channel.ChannelType("attachment-test"), DisplayName: "AttachmentTest"}
 }
 
-func (*attachmentResolverAdapter) CanResolve(_ channel.ChannelConfig, _ channel.Attachment) bool {
-	return true
-}
-
 func (*attachmentResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
 	return channel.AttachmentPayload{
 		Reader: io.NopCloser(strings.NewReader("payload")),
@@ -99,11 +95,10 @@ func (*failingResolverAdapter) Descriptor() channel.Descriptor {
 	return channel.Descriptor{Type: channel.ChannelType("failing-attachment-test"), DisplayName: "FailingAttachmentTest"}
 }
 
-func (*failingResolverAdapter) CanResolve(_ channel.ChannelConfig, att channel.Attachment) bool {
-	return strings.TrimSpace(att.PlatformKey) != ""
-}
-
-func (*failingResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, _ channel.Attachment) (channel.AttachmentPayload, error) {
+func (*failingResolverAdapter) ResolveAttachment(_ context.Context, _ channel.ChannelConfig, att channel.Attachment) (channel.AttachmentPayload, error) {
+	if strings.TrimSpace(att.PlatformKey) == "" {
+		return channel.AttachmentPayload{}, channel.ErrAttachmentNotResolvable
+	}
 	return channel.AttachmentPayload{}, errors.New("platform API error")
 }
 
@@ -142,9 +137,6 @@ func TestEffectiveResolver_PublicURL(t *testing.T) {
 
 	reg := newTestConfigRegistry()
 	resolver := reg.EffectiveAttachmentResolver(testChannelType)
-	if !resolver.CanResolve(channel.ChannelConfig{}, channel.Attachment{URL: "https://public.example.test/cat.png"}) {
-		t.Fatal("expected effective resolver to handle public URL")
-	}
 	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{
 		Type: channel.AttachmentImage,
 		URL:  "https://public.example.test/cat.png",
@@ -183,9 +175,6 @@ func TestEffectiveResolver_URLWithPlatformKey(t *testing.T) {
 		URL:         "https://cdn.discordapp.com/attachments/file.png",
 		PlatformKey: "discord-file-id",
 	}
-	if !resolver.CanResolve(channel.ChannelConfig{}, att) {
-		t.Fatal("expected effective resolver to handle URL attachment with platform key")
-	}
 	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
 	if err != nil {
 		t.Fatalf("ResolveAttachment: %v", err)
@@ -220,9 +209,6 @@ func TestEffectiveResolver_URLWithSourcePlatform(t *testing.T) {
 		Type:           channel.AttachmentImage,
 		URL:            "https://qq.example.test/files/image.jpg",
 		SourcePlatform: "qq",
-	}
-	if !resolver.CanResolve(channel.ChannelConfig{}, att) {
-		t.Fatal("expected effective resolver to handle URL attachment with source platform")
 	}
 	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, att)
 	if err != nil {

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -1,6 +1,7 @@
 package channel_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -249,6 +250,46 @@ func TestEffectiveResolver_RejectsHTMLImage(t *testing.T) {
 	}
 }
 
+func TestEffectiveResolver_URLDoesNotEagerlyBufferBody(t *testing.T) {
+	body := &limitedResolveBody{
+		data:       bytes.Repeat([]byte("z"), 2048),
+		readBudget: 512,
+		enforce:    true,
+	}
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://public.example.test/stream.bin" {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+			Body:       body,
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	reg := newTestConfigRegistry()
+	resolver := reg.EffectiveAttachmentResolver(testChannelType)
+	payload, err := resolver.ResolveAttachment(context.Background(), channel.ChannelConfig{}, channel.Attachment{
+		Type: channel.AttachmentFile,
+		URL:  "https://public.example.test/stream.bin",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAttachment: %v", err)
+	}
+	defer func() { _ = payload.Reader.Close() }()
+
+	body.enforce = false
+	data, err := io.ReadAll(payload.Reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(data) != 2048 {
+		t.Fatalf("expected 2048 bytes, got %d", len(data))
+	}
+}
+
 func TestEffectiveResolver_PlatformError(t *testing.T) {
 	reg := channel.NewRegistry()
 	reg.MustRegister(&failingResolverAdapter{})
@@ -302,4 +343,41 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+type limitedResolveBody struct {
+	data       []byte
+	offset     int
+	readBudget int
+	enforce    bool
+}
+
+func (r *limitedResolveBody) Read(p []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.enforce && r.offset >= r.readBudget {
+		return 0, errors.New("resolver eagerly buffered attachment body")
+	}
+
+	allowed := len(p)
+	if r.enforce {
+		remaining := r.readBudget - r.offset
+		if remaining < allowed {
+			allowed = remaining
+		}
+	}
+	if remaining := len(r.data) - r.offset; remaining < allowed {
+		allowed = remaining
+	}
+	copy(p, r.data[r.offset:r.offset+allowed])
+	r.offset += allowed
+	if r.offset >= len(r.data) {
+		return allowed, io.EOF
+	}
+	return allowed, nil
+}
+
+func (*limitedResolveBody) Close() error {
+	return nil
 }


### PR DESCRIPTION
## Summary

Extracts the inline attachment resolution logic from `loadInboundAttachmentPayload` into a composable `effectiveAttachmentResolver` chain, using a sentinel error pattern for clean fallback control.

### Problem

The old `loadInboundAttachmentPayload` contained ~40 lines of tightly-coupled inline logic that tried URL download → Base64 decode → PlatformKey resolution in sequence. Adding a new platform adapter (e.g. Slack) required understanding this monolithic function and its implicit priority rules. Each adapter's `ResolveAttachment` also had no way to signal "this isn't mine" — it could only return a generic error, making it impossible to distinguish "I can't handle this" from "I tried and failed".

### Solution

- **`ErrAttachmentNotResolvable` sentinel** — Each adapter returns this when an attachment is outside its responsibility (e.g. Feishu gets an attachment without `PlatformKey`). This is more idiomatic Go than a separate `CanResolve` predicate and avoids duplicating guard logic across two methods.

- **`effectiveAttachmentResolver`** (new, `attachment_resolver.go`) — A composite resolver that tries the platform-specific resolver first; if it returns the sentinel, falls back to a `defaultAttachmentResolver` that handles Base64 and public HTTP URLs. Real errors (API failures, auth issues) are never swallowed — they propagate immediately without fallback.

- **`Registry.EffectiveAttachmentResolver()`** — Convenience method that composes the platform resolver (if any) with the default fallback.

- **`loadInboundAttachmentPayload` simplified** — Reduced from ~50 lines to ~10 lines: get resolver → call → check sentinel → done.

### Key design invariant

**Platform-owned attachments never fall back to anonymous URL download.** When a platform resolver claims an attachment (doesn't return sentinel) but fails with a real error, the error propagates directly. This prevents silent security/correctness issues where private platform URLs would be anonymously re-downloaded (potentially hitting login pages or wrong content).

## Changed files

| File | Change |
|------|--------|
| `adapter.go` | Add `ErrAttachmentNotResolvable` sentinel |
| `attachment_resolver.go` | **New** — `effectiveAttachmentResolver`, `defaultAttachmentResolver`, HTML sniffing |
| `registry.go` | Add `EffectiveAttachmentResolver()` |
| `inbound/channel.go` | Replace inline logic with single resolver call |
| `dingtalk`, `feishu`, `matrix`, `telegram`, `wecom`, `weixin` | Return sentinel on ownership rejection |
| `registry_test.go` | 7 new tests: public URL, platform key, source platform, HTML rejection, platform error, platform ownership |
| `inbound/channel_test.go` | Update mocks to sentinel pattern, add `TestUsesPlatformResolver` |
| `weixin_test.go` | Add `TestResolveAttachmentRejectsURLOnlyAttachment` |

## Test plan

- [x] `go vet ./internal/channel/...` passes
- [x] All 33 related tests pass (`go test ./internal/channel/ ./internal/channel/inbound/ ./internal/channel/adapters/weixin/`)
- [ ] Manual smoke test with untest platform (Feishu,QQ, Wecom, dingtalk, matrix) to verify attachment ingestion