### PR TITLE
fix(web): constrain skills editor dialog layout

### DIFF
--- a/apps/web/src/pages/bots/components/bot-skills.vue
+++ b/apps/web/src/pages/bots/components/bot-skills.vue
@@ -108,18 +108,20 @@
 
     <!-- Edit Dialog -->
     <Dialog v-model:open="isDialogOpen">
-      <DialogContent class="sm:max-w-2xl">
-        <DialogHeader>
+      <DialogContent class="sm:max-w-2xl max-h-[calc(100dvh-2rem)] flex flex-col overflow-hidden">
+        <DialogHeader class="shrink-0">
           <DialogTitle>{{ isEditing ? $t('common.edit') : $t('bots.skills.addSkill') }}</DialogTitle>
         </DialogHeader>
-        <div class="py-4 h-[400px]">
-          <MonacoEditor
-            v-model="draftRaw"
-            language="markdown"
-            :readonly="isSaving"
-          />
+        <div class="basis-[400px] flex-1 min-h-0 py-4">
+          <div class="h-full rounded-md border overflow-hidden">
+            <MonacoEditor
+              v-model="draftRaw"
+              language="markdown"
+              :readonly="isSaving"
+            />
+          </div>
         </div>
-        <DialogFooter>
+        <DialogFooter class="shrink-0">
           <DialogClose as-child>
             <Button
               variant="outline"


### PR DESCRIPTION
Fix #362 Skills editor dialog layout when editing long markdown content.

The dialog previously let the Monaco editor overflow the modal layout, which could cause the editor area to visually collide with the footer and modal bounds when opening large skill definitions.

<img width="736" height="596" alt="image" src="https://github.com/user-attachments/assets/31e5d308-7a12-4c08-8fb3-739d58cf3512" />

 ## Root Cause

`bot-skills.vue` used a fixed-height editor container without the same modal height and overflow constraints used by other Monaco-based dialogs in the app.