### PR TITLE
fix(agent): tool loop guard race

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -99,7 +100,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	var textLoopGuard *TextLoopGuard
 	var textLoopProbeBuffer *TextLoopProbeBuffer
 	var toolLoopGuard *ToolLoopGuard
-	toolLoopAbortCallIDs := make(map[string]struct{})
+	toolLoopAbortCallIDs := newToolAbortRegistry()
 	if cfg.LoopDetection.Enabled {
 		textLoopGuard = NewTextLoopGuard(LoopDetectedStreakThreshold, LoopDetectedMinNewGramsPerChunk, SentialOptions{})
 		textLoopProbeBuffer = NewTextLoopProbeBuffer(LoopDetectedProbeChars, func(text string) {
@@ -314,11 +315,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			}
 
 		case *sdk.StreamToolResultPart:
-			shouldAbort := false
-			if _, ok := toolLoopAbortCallIDs[p.ToolCallID]; ok {
-				delete(toolLoopAbortCallIDs, p.ToolCallID)
-				shouldAbort = true
-			}
+			shouldAbort := toolLoopAbortCallIDs.Take(p.ToolCallID)
 			stepNumber++
 			if !sendEvent(ctx, ch, StreamEvent{
 				Type:       EventToolCallEnd,
@@ -440,7 +437,10 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult, error) {
 	// Collecting emitter: tools push side-effect events here during generation.
 	var collected []tools.ToolStreamEvent
+	var collectedMu sync.Mutex
 	collectEmitter := tools.StreamEmitter(func(evt tools.ToolStreamEvent) {
+		collectedMu.Lock()
+		defer collectedMu.Unlock()
 		collected = append(collected, evt)
 	})
 
@@ -456,7 +456,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 
 	var toolLoopGuard *ToolLoopGuard
 	var textLoopGuard *TextLoopGuard
-	toolLoopAbortCallIDs := make(map[string]struct{})
+	toolLoopAbortCallIDs := newToolAbortRegistry()
 	if cfg.LoopDetection.Enabled {
 		toolLoopGuard = NewToolLoopGuard(ToolLoopRepeatThreshold, ToolLoopWarningsBeforeAbort)
 		textLoopGuard = NewTextLoopGuard(LoopDetectedStreakThreshold, LoopDetectedMinNewGramsPerChunk, SentialOptions{})
@@ -490,7 +490,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 	opts = append(opts,
 		sdk.WithOnStep(func(step *sdk.StepResult) *sdk.GenerateParams {
 			if cfg.LoopDetection.Enabled {
-				if len(toolLoopAbortCallIDs) > 0 {
+				if toolLoopAbortCallIDs.Any() {
 					return nil // stop
 				}
 				if textLoopGuard != nil && isNonEmptyString(step.Text) {
@@ -701,7 +701,7 @@ func drainBackgroundNotifications(
 	return p
 }
 
-func wrapToolsWithLoopGuard(tools []sdk.Tool, guard *ToolLoopGuard, abortCallIDs map[string]struct{}) []sdk.Tool {
+func wrapToolsWithLoopGuard(tools []sdk.Tool, guard *ToolLoopGuard, abortCallIDs *toolAbortRegistry) []sdk.Tool {
 	wrapped := make([]sdk.Tool, len(tools))
 	for i, tool := range tools {
 		originalExecute := tool.Execute
@@ -710,7 +710,7 @@ func wrapToolsWithLoopGuard(tools []sdk.Tool, guard *ToolLoopGuard, abortCallIDs
 		wrapped[i].Execute = func(ctx *sdk.ToolExecContext, input any) (any, error) {
 			warn, abort := guard.Guard(toolName, input)
 			if abort {
-				abortCallIDs[ctx.ToolCallID] = struct{}{}
+				abortCallIDs.Add(ctx.ToolCallID)
 				return map[string]any{
 					"isError": true,
 					"content": []map[string]any{{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -435,6 +435,10 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 }
 
 func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult, error) {
+	genCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	loopAbort := newLoopAbortState()
+
 	// Collecting emitter: tools push side-effect events here during generation.
 	var collected []tools.ToolStreamEvent
 	var collectedMu sync.Mutex
@@ -447,7 +451,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 	var sdkTools []sdk.Tool
 	if cfg.SupportsToolCall {
 		var err error
-		sdkTools, err = a.assembleTools(ctx, cfg, collectEmitter)
+		sdkTools, err = a.assembleTools(genCtx, cfg, collectEmitter)
 		if err != nil {
 			return nil, fmt.Errorf("assemble tools: %w", err)
 		}
@@ -491,12 +495,16 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 		sdk.WithOnStep(func(step *sdk.StepResult) *sdk.GenerateParams {
 			if cfg.LoopDetection.Enabled {
 				if toolLoopAbortCallIDs.Any() {
-					return nil // stop
+					loopAbort.Set(ErrToolLoopDetected)
+					cancel(ErrToolLoopDetected)
+					return nil
 				}
 				if textLoopGuard != nil && isNonEmptyString(step.Text) {
 					result := textLoopGuard.Inspect(step.Text)
 					if result.Abort {
-						return nil // stop
+						loopAbort.Set(ErrTextLoopDetected)
+						cancel(ErrTextLoopDetected)
+						return nil
 					}
 				}
 			}
@@ -504,9 +512,15 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 		}),
 	)
 
-	genResult, err := a.client.GenerateTextResult(ctx, opts...)
+	genResult, err := a.client.GenerateTextResult(genCtx, opts...)
 	if err != nil {
+		if loopErr := detectGenerateLoopAbort(genCtx, err); loopErr != nil {
+			return nil, loopErr
+		}
 		return nil, fmt.Errorf("generate: %w", err)
+	}
+	if loopErr := loopAbort.Err(); loopErr != nil {
+		return nil, loopErr
 	}
 
 	// Drain collected tool-emitted side effects into the result.
@@ -717,7 +731,7 @@ func wrapToolsWithLoopGuard(tools []sdk.Tool, guard *ToolLoopGuard, abortCallIDs
 						"type": "text",
 						"text": ToolLoopDetectedAbortMessage,
 					}},
-				}, errors.New(ToolLoopDetectedAbortMessage)
+				}, ErrToolLoopDetected
 			}
 			if warn {
 				return map[string]any{
@@ -978,4 +992,51 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func detectGenerateLoopAbort(ctx context.Context, err error) error {
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+
+	cause := context.Cause(ctx)
+	switch {
+	case errors.Is(cause, ErrToolLoopDetected):
+		return ErrToolLoopDetected
+	case errors.Is(cause, ErrTextLoopDetected):
+		return ErrTextLoopDetected
+	default:
+		return nil
+	}
+}
+
+type loopAbortState struct {
+	mu  sync.Mutex
+	err error
+}
+
+func newLoopAbortState() *loopAbortState {
+	return &loopAbortState{}
+}
+
+func (s *loopAbortState) Set(err error) {
+	if s == nil || err == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err == nil {
+		s.err = err
+	}
+}
+
+func (s *loopAbortState) Err() error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
 }

--- a/internal/agent/generate_loop_test.go
+++ b/internal/agent/generate_loop_test.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	agenttools "github.com/memohai/memoh/internal/agent/tools"
+)
+
+type staticToolProvider struct {
+	tools []sdk.Tool
+}
+
+func (p staticToolProvider) Tools(context.Context, agenttools.SessionContext) ([]sdk.Tool, error) {
+	return p.tools, nil
+}
+
+func TestAgentGenerateStopsOnToolLoopAbort(t *testing.T) {
+	t.Parallel()
+
+	modelProvider := &agentReadMediaMockProvider{
+		handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+			return &sdk.GenerateResult{
+				FinishReason: sdk.FinishReasonToolCalls,
+				ToolCalls: []sdk.ToolCall{{
+					ToolCallID: "call-same",
+					ToolName:   "loop_tool",
+					Input:      map[string]any{"query": "same"},
+				}},
+			}, nil
+		},
+	}
+
+	a := New(Deps{})
+	a.SetToolProviders([]agenttools.ToolProvider{
+		staticToolProvider{
+			tools: []sdk.Tool{{
+				Name:       "loop_tool",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+					return map[string]any{"ok": true}, nil
+				},
+			}},
+		},
+	})
+
+	_, err := a.Generate(context.Background(), RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: modelProvider},
+		Messages:         []sdk.Message{sdk.UserMessage("loop")},
+		SupportsToolCall: true,
+		Identity:         SessionContext{BotID: "bot-1"},
+		LoopDetection:    LoopDetectionConfig{Enabled: true},
+	})
+	if !errors.Is(err, ErrToolLoopDetected) {
+		t.Fatalf("expected ErrToolLoopDetected, got %v", err)
+	}
+	if modelProvider.calls >= 20 {
+		t.Fatalf("expected tool loop to stop generation, got %d provider calls", modelProvider.calls)
+	}
+}
+
+func TestAgentGenerateStopsOnTextLoopAbort(t *testing.T) {
+	t.Parallel()
+
+	repeatedText := "abcdefghijklmnopqrstuvwxyz0123456789 repeated text chunk for loop detection"
+	modelProvider := &agentReadMediaMockProvider{
+		handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+			return &sdk.GenerateResult{
+				Text:         repeatedText,
+				FinishReason: sdk.FinishReasonToolCalls,
+				ToolCalls: []sdk.ToolCall{{
+					ToolCallID: "call-text",
+					ToolName:   "noop_tool",
+					Input:      map[string]any{"step": call},
+				}},
+			}, nil
+		},
+	}
+
+	a := New(Deps{})
+	a.SetToolProviders([]agenttools.ToolProvider{
+		staticToolProvider{
+			tools: []sdk.Tool{{
+				Name:       "noop_tool",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+					return map[string]any{"ok": true}, nil
+				},
+			}},
+		},
+	})
+
+	_, err := a.Generate(context.Background(), RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: modelProvider},
+		Messages:         []sdk.Message{sdk.UserMessage("loop text")},
+		SupportsToolCall: true,
+		Identity:         SessionContext{BotID: "bot-1"},
+		LoopDetection:    LoopDetectionConfig{Enabled: true},
+	})
+	if !errors.Is(err, ErrTextLoopDetected) {
+		t.Fatalf("expected ErrTextLoopDetected, got %v", err)
+	}
+	if modelProvider.calls >= 10 {
+		t.Fatalf("expected text loop to stop generation, got %d provider calls", modelProvider.calls)
+	}
+}
+
+func TestAgentGenerateStopsOnTerminalTextLoopAbort(t *testing.T) {
+	t.Parallel()
+
+	repeatedText := "abcdefghijklmnopqrstuvwxyz0123456789 repeated text chunk for loop detection"
+	modelProvider := &agentReadMediaMockProvider{
+		handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+			finishReason := sdk.FinishReasonToolCalls
+			var toolCalls []sdk.ToolCall
+			if call < 4 {
+				toolCalls = []sdk.ToolCall{{
+					ToolCallID: "call-terminal",
+					ToolName:   "noop_tool",
+					Input:      map[string]any{"step": call},
+				}}
+			} else {
+				finishReason = sdk.FinishReasonStop
+			}
+			return &sdk.GenerateResult{
+				Text:         repeatedText,
+				FinishReason: finishReason,
+				ToolCalls:    toolCalls,
+			}, nil
+		},
+	}
+
+	a := New(Deps{})
+	a.SetToolProviders([]agenttools.ToolProvider{
+		staticToolProvider{
+			tools: []sdk.Tool{{
+				Name:       "noop_tool",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+					return map[string]any{"ok": true}, nil
+				},
+			}},
+		},
+	})
+
+	_, err := a.Generate(context.Background(), RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: modelProvider},
+		Messages:         []sdk.Message{sdk.UserMessage("loop text terminal")},
+		SupportsToolCall: true,
+		Identity:         SessionContext{BotID: "bot-1"},
+		LoopDetection:    LoopDetectionConfig{Enabled: true},
+	})
+	if !errors.Is(err, ErrTextLoopDetected) {
+		t.Fatalf("expected ErrTextLoopDetected, got %v", err)
+	}
+	if modelProvider.calls != 4 {
+		t.Fatalf("expected terminal text loop to abort on final step, got %d provider calls", modelProvider.calls)
+	}
+}

--- a/internal/agent/generate_loop_test.go
+++ b/internal/agent/generate_loop_test.go
@@ -23,7 +23,7 @@ func TestAgentGenerateStopsOnToolLoopAbort(t *testing.T) {
 	t.Parallel()
 
 	modelProvider := &agentReadMediaMockProvider{
-		handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		handler: func(_ int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
 			return &sdk.GenerateResult{
 				FinishReason: sdk.FinishReasonToolCalls,
 				ToolCalls: []sdk.ToolCall{{
@@ -41,7 +41,7 @@ func TestAgentGenerateStopsOnToolLoopAbort(t *testing.T) {
 			tools: []sdk.Tool{{
 				Name:       "loop_tool",
 				Parameters: &jsonschema.Schema{Type: "object"},
-				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
 					return map[string]any{"ok": true}, nil
 				},
 			}},
@@ -87,7 +87,7 @@ func TestAgentGenerateStopsOnTextLoopAbort(t *testing.T) {
 			tools: []sdk.Tool{{
 				Name:       "noop_tool",
 				Parameters: &jsonschema.Schema{Type: "object"},
-				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
 					return map[string]any{"ok": true}, nil
 				},
 			}},
@@ -140,7 +140,7 @@ func TestAgentGenerateStopsOnTerminalTextLoopAbort(t *testing.T) {
 			tools: []sdk.Tool{{
 				Name:       "noop_tool",
 				Parameters: &jsonschema.Schema{Type: "object"},
-				Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
 					return map[string]any{"ok": true}, nil
 				},
 			}},

--- a/internal/agent/guard_state.go
+++ b/internal/agent/guard_state.go
@@ -1,0 +1,48 @@
+package agent
+
+import "sync"
+
+type toolAbortRegistry struct {
+	mu  sync.Mutex
+	ids map[string]struct{}
+}
+
+func newToolAbortRegistry() *toolAbortRegistry {
+	return &toolAbortRegistry{
+		ids: make(map[string]struct{}),
+	}
+}
+
+func (r *toolAbortRegistry) Add(toolCallID string) {
+	if r == nil || toolCallID == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ids[toolCallID] = struct{}{}
+}
+
+func (r *toolAbortRegistry) Take(toolCallID string) bool {
+	if r == nil || toolCallID == "" {
+		return false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.ids[toolCallID]; !ok {
+		return false
+	}
+	delete(r.ids, toolCallID)
+	return true
+}
+
+func (r *toolAbortRegistry) Any() bool {
+	if r == nil {
+		return false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.ids) > 0
+}

--- a/internal/agent/guard_state_test.go
+++ b/internal/agent/guard_state_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestToolAbortRegistryConcurrentAccess(t *testing.T) {
+	registry := newToolAbortRegistry()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("call-%d", i)
+			registry.Add(id)
+			if !registry.Any() {
+				t.Error("expected registry to report pending aborts")
+			}
+			if !registry.Take(id) {
+				t.Errorf("expected to take %s", id)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if registry.Any() {
+		t.Fatal("expected registry to be empty")
+	}
+}

--- a/internal/agent/sential.go
+++ b/internal/agent/sential.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -29,6 +30,11 @@ const (
 	defaultOverlapThreshold    = 0.75
 	defaultConsecutiveHits     = 10
 	defaultMinNewGramsPerChunk = 1
+)
+
+var (
+	ErrTextLoopDetected = errors.New(LoopDetectedAbortMessage)
+	ErrToolLoopDetected = errors.New(ToolLoopDetectedAbortMessage)
 )
 
 // --- Sential: n-gram overlap detector ---

--- a/internal/agent/sential.go
+++ b/internal/agent/sential.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -322,6 +323,7 @@ type ToolLoopResult struct {
 
 // ToolLoopGuard detects repeated identical tool calls.
 type ToolLoopGuard struct {
+	mu                  sync.Mutex
 	repeatThreshold     int
 	warningsBeforeAbort int
 	volatileKeySet      map[string]struct{}
@@ -352,7 +354,16 @@ func NewToolLoopGuard(repeatThreshold, warningsBeforeAbort int) *ToolLoopGuard {
 
 // Inspect checks a tool call for repetition.
 func (g *ToolLoopGuard) Inspect(input ToolLoopInput) ToolLoopResult {
+	if g == nil {
+		return ToolLoopResult{
+			Hash: computeToolLoopHash(input, nil),
+		}
+	}
+
 	hash := computeToolLoopHash(input, g.volatileKeySet)
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
 
 	if hash == g.lastHash {
 		g.repeatCount++
@@ -391,6 +402,13 @@ func (g *ToolLoopGuard) Inspect(input ToolLoopInput) ToolLoopResult {
 
 // Reset clears the guard state.
 func (g *ToolLoopGuard) Reset() {
+	if g == nil {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	g.lastHash = ""
 	g.repeatCount = 0
 	g.breachCount = 0

--- a/internal/agent/sential_test.go
+++ b/internal/agent/sential_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestToolLoopGuardNilReceiver(t *testing.T) {
+	var guard *ToolLoopGuard
+
+	result := guard.Inspect(ToolLoopInput{
+		ToolName: "search",
+		Input: map[string]any{
+			"query": "memoh",
+		},
+	})
+
+	if result.Hash == "" {
+		t.Fatal("expected hash for nil receiver")
+	}
+	if result.Warn {
+		t.Fatal("did not expect warning for nil receiver")
+	}
+	if result.Abort {
+		t.Fatal("did not expect abort for nil receiver")
+	}
+}
+
+func TestToolLoopGuardConcurrentInspectAndReset(t *testing.T) {
+	guard := NewToolLoopGuard(2, 1)
+	input := ToolLoopInput{
+		ToolName: "web_search",
+		Input: map[string]any{
+			"query":     "memoh logs",
+			"requestId": "volatile",
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				result := guard.Inspect(input)
+				if result.Hash == "" {
+					t.Error("expected non-empty hash")
+					return
+				}
+				if (i+j)%25 == 0 {
+					guard.Reset()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
 ## Summary

fixes agent loop-guard races and restores correct abort behavior in non-streaming generation.

## Changes

- make ToolLoopGuard state concurrency-safe
- replace shared tool-abort map with a mutex-protected registry
- protect non-streaming tool side-effect collection from concurrent append
- fix Generate() loop abort handling to use real cancellation instead of relying on WithOnStep(...)=nil
- preserve terminal text-loop aborts in non-streaming generation
- add focused tests for concurrent guard access, abort registry behavior, and generate loop-abort scenarios