### PR TITLE
fix(sqlc): cast optional scalar settings args

### DIFF
--- a/db/queries/settings.sql
+++ b/db/queries/settings.sql
@@ -46,7 +46,7 @@ WITH updated AS (
       compaction_enabled = sqlc.arg(compaction_enabled),
       compaction_threshold = sqlc.arg(compaction_threshold),
       compaction_ratio = sqlc.arg(compaction_ratio),
-      timezone = COALESCE(sqlc.narg(timezone), bots.timezone),
+      timezone = COALESCE(sqlc.narg(timezone)::text, bots.timezone),
       chat_model_id = COALESCE(sqlc.narg(chat_model_id)::uuid, bots.chat_model_id),
       heartbeat_model_id = COALESCE(sqlc.narg(heartbeat_model_id)::uuid, bots.heartbeat_model_id),
       compaction_model_id = COALESCE(sqlc.narg(compaction_model_id)::uuid, bots.compaction_model_id),
@@ -56,7 +56,7 @@ WITH updated AS (
       image_model_id = COALESCE(sqlc.narg(image_model_id)::uuid, bots.image_model_id),
       tts_model_id = COALESCE(sqlc.narg(tts_model_id)::uuid, bots.tts_model_id),
       browser_context_id = COALESCE(sqlc.narg(browser_context_id)::uuid, bots.browser_context_id),
-      context_token_budget = COALESCE(sqlc.narg(context_token_budget), bots.context_token_budget),
+      context_token_budget = COALESCE(sqlc.narg(context_token_budget)::integer, bots.context_token_budget),
       persist_full_tool_results = sqlc.arg(persist_full_tool_results),
       updated_at = now()
   WHERE bots.id = sqlc.arg(id)

--- a/internal/db/sqlc/conversations.sql.go
+++ b/internal/db/sqlc/conversations.sql.go
@@ -511,7 +511,7 @@ WITH updated AS (
   SET display_name = $1,
       updated_at = now()
   WHERE bots.id = $2
-  RETURNING id, owner_user_id, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, title_model_id, image_model_id, discuss_probe_model_id, tts_model_id, browser_context_id, metadata, created_at, updated_at, acl_default_effect
+  RETURNING id, owner_user_id, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, title_model_id, image_model_id, discuss_probe_model_id, tts_model_id, browser_context_id, context_token_budget, persist_full_tool_results, metadata, created_at, updated_at, acl_default_effect
 )
 SELECT
   updated.id AS id,

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -9,36 +9,38 @@ import (
 )
 
 type Bot struct {
-	ID                  pgtype.UUID        `json:"id"`
-	OwnerUserID         pgtype.UUID        `json:"owner_user_id"`
-	DisplayName         pgtype.Text        `json:"display_name"`
-	AvatarUrl           pgtype.Text        `json:"avatar_url"`
-	Timezone            pgtype.Text        `json:"timezone"`
-	IsActive            bool               `json:"is_active"`
-	Status              string             `json:"status"`
-	Language            string             `json:"language"`
-	ReasoningEnabled    bool               `json:"reasoning_enabled"`
-	ReasoningEffort     string             `json:"reasoning_effort"`
-	ChatModelID         pgtype.UUID        `json:"chat_model_id"`
-	SearchProviderID    pgtype.UUID        `json:"search_provider_id"`
-	MemoryProviderID    pgtype.UUID        `json:"memory_provider_id"`
-	HeartbeatEnabled    bool               `json:"heartbeat_enabled"`
-	HeartbeatInterval   int32              `json:"heartbeat_interval"`
-	HeartbeatPrompt     string             `json:"heartbeat_prompt"`
-	HeartbeatModelID    pgtype.UUID        `json:"heartbeat_model_id"`
-	CompactionEnabled   bool               `json:"compaction_enabled"`
-	CompactionThreshold int32              `json:"compaction_threshold"`
-	CompactionRatio     int32              `json:"compaction_ratio"`
-	CompactionModelID   pgtype.UUID        `json:"compaction_model_id"`
-	TitleModelID        pgtype.UUID        `json:"title_model_id"`
-	ImageModelID        pgtype.UUID        `json:"image_model_id"`
-	DiscussProbeModelID pgtype.UUID        `json:"discuss_probe_model_id"`
-	TtsModelID          pgtype.UUID        `json:"tts_model_id"`
-	BrowserContextID    pgtype.UUID        `json:"browser_context_id"`
-	Metadata            []byte             `json:"metadata"`
-	CreatedAt           pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
-	AclDefaultEffect    string             `json:"acl_default_effect"`
+	ID                     pgtype.UUID        `json:"id"`
+	OwnerUserID            pgtype.UUID        `json:"owner_user_id"`
+	DisplayName            pgtype.Text        `json:"display_name"`
+	AvatarUrl              pgtype.Text        `json:"avatar_url"`
+	Timezone               pgtype.Text        `json:"timezone"`
+	IsActive               bool               `json:"is_active"`
+	Status                 string             `json:"status"`
+	Language               string             `json:"language"`
+	ReasoningEnabled       bool               `json:"reasoning_enabled"`
+	ReasoningEffort        string             `json:"reasoning_effort"`
+	ChatModelID            pgtype.UUID        `json:"chat_model_id"`
+	SearchProviderID       pgtype.UUID        `json:"search_provider_id"`
+	MemoryProviderID       pgtype.UUID        `json:"memory_provider_id"`
+	HeartbeatEnabled       bool               `json:"heartbeat_enabled"`
+	HeartbeatInterval      int32              `json:"heartbeat_interval"`
+	HeartbeatPrompt        string             `json:"heartbeat_prompt"`
+	HeartbeatModelID       pgtype.UUID        `json:"heartbeat_model_id"`
+	CompactionEnabled      bool               `json:"compaction_enabled"`
+	CompactionThreshold    int32              `json:"compaction_threshold"`
+	CompactionRatio        int32              `json:"compaction_ratio"`
+	CompactionModelID      pgtype.UUID        `json:"compaction_model_id"`
+	TitleModelID           pgtype.UUID        `json:"title_model_id"`
+	ImageModelID           pgtype.UUID        `json:"image_model_id"`
+	DiscussProbeModelID    pgtype.UUID        `json:"discuss_probe_model_id"`
+	TtsModelID             pgtype.UUID        `json:"tts_model_id"`
+	BrowserContextID       pgtype.UUID        `json:"browser_context_id"`
+	ContextTokenBudget     pgtype.Int4        `json:"context_token_budget"`
+	PersistFullToolResults bool               `json:"persist_full_tool_results"`
+	Metadata               []byte             `json:"metadata"`
+	CreatedAt              pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
+	AclDefaultEffect       string             `json:"acl_default_effect"`
 }
 
 type BotAclRule struct {
@@ -468,6 +470,18 @@ type StorageProvider struct {
 	Config    []byte             `json:"config"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
+type Task struct {
+	ID        string             `json:"id"`
+	BotID     string             `json:"bot_id"`
+	Name      string             `json:"name"`
+	Command   string             `json:"command"`
+	Status    string             `json:"status"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	ExecID    pgtype.Text        `json:"exec_id"`
+	Pid       pgtype.Int4        `json:"pid"`
 }
 
 type TtsModel struct {

--- a/internal/db/sqlc/settings.sql.go
+++ b/internal/db/sqlc/settings.sql.go
@@ -146,7 +146,7 @@ WITH updated AS (
       compaction_enabled = $7,
       compaction_threshold = $8,
       compaction_ratio = $9,
-      timezone = COALESCE($10, bots.timezone),
+      timezone = COALESCE($10::text, bots.timezone),
       chat_model_id = COALESCE($11::uuid, bots.chat_model_id),
       heartbeat_model_id = COALESCE($12::uuid, bots.heartbeat_model_id),
       compaction_model_id = COALESCE($13::uuid, bots.compaction_model_id),
@@ -156,7 +156,7 @@ WITH updated AS (
       image_model_id = COALESCE($17::uuid, bots.image_model_id),
       tts_model_id = COALESCE($18::uuid, bots.tts_model_id),
       browser_context_id = COALESCE($19::uuid, bots.browser_context_id),
-      context_token_budget = COALESCE($20, bots.context_token_budget),
+      context_token_budget = COALESCE($20::integer, bots.context_token_budget),
       persist_full_tool_results = $21,
       updated_at = now()
   WHERE bots.id = $22


### PR DESCRIPTION
## Summary
- add explicit casts for optional `timezone` and `context_token_budget` args in `UpsertBotSettings` so `sqlc generate` can resolve their types again
- regenerate sqlc output after the query fix
- sync the stale generated bot/query structs updated by the successful regeneration

## Test plan
- [x] `sqlc generate`
- [x] `go test ./internal/settings ./internal/bots ./internal/handlers`