### PR TITLE
fix: exclude expired token adjustments from usage stats

### DIFF
--- a/db/queries/token_usage.sql
+++ b/db/queries/token_usage.sql
@@ -1,40 +1,80 @@
 -- name: GetTokenUsageByDayAndType :many
+WITH usage_rows AS (
+  SELECT
+    m.session_id,
+    m.model_id,
+    m.created_at,
+    COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens,
+    COALESCE((m.usage->>'outputTokens')::bigint, 0)::bigint AS output_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint, 0)::bigint AS cache_write_tokens,
+    COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
+  FROM bot_history_messages m
+  WHERE m.bot_id = sqlc.arg(bot_id)
+    AND m.usage IS NOT NULL
+    AND m.created_at >= sqlc.arg(from_time)
+    AND m.created_at < sqlc.arg(to_time)
+    AND (sqlc.narg(model_id)::uuid IS NULL OR m.model_id = sqlc.narg(model_id)::uuid)
+), non_negative_usage_rows AS (
+  -- Exclude expired-token adjustment rows, which are stored as negative deltas.
+  SELECT *
+  FROM usage_rows
+  WHERE input_tokens >= 0
+    AND output_tokens >= 0
+    AND cache_read_tokens >= 0
+    AND cache_write_tokens >= 0
+    AND reasoning_tokens >= 0
+)
 SELECT
   COALESCE(
     CASE WHEN s.type = 'subagent' THEN COALESCE(ps.type, 'chat') ELSE s.type END,
     'chat'
   )::text AS session_type,
   date_trunc('day', m.created_at)::date AS day,
-  COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
-  COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens,
-  COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens,
-  COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint), 0)::bigint AS cache_write_tokens,
-  COALESCE(SUM((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint), 0)::bigint AS reasoning_tokens
-FROM bot_history_messages m
+  COALESCE(SUM(m.input_tokens), 0)::bigint AS input_tokens,
+  COALESCE(SUM(m.output_tokens), 0)::bigint AS output_tokens,
+  COALESCE(SUM(m.cache_read_tokens), 0)::bigint AS cache_read_tokens,
+  COALESCE(SUM(m.cache_write_tokens), 0)::bigint AS cache_write_tokens,
+  COALESCE(SUM(m.reasoning_tokens), 0)::bigint AS reasoning_tokens
+FROM non_negative_usage_rows m
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
-  AND m.usage IS NOT NULL
-  AND m.created_at >= sqlc.arg(from_time)
-  AND m.created_at < sqlc.arg(to_time)
-  AND (sqlc.narg(model_id)::uuid IS NULL OR m.model_id = sqlc.narg(model_id)::uuid)
 GROUP BY session_type, day
 ORDER BY day, session_type;
 
 -- name: GetTokenUsageByModel :many
+WITH usage_rows AS (
+  SELECT
+    m.model_id,
+    COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens,
+    COALESCE((m.usage->>'outputTokens')::bigint, 0)::bigint AS output_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint, 0)::bigint AS cache_write_tokens,
+    COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
+  FROM bot_history_messages m
+  WHERE m.bot_id = sqlc.arg(bot_id)
+    AND m.usage IS NOT NULL
+    AND m.created_at >= sqlc.arg(from_time)
+    AND m.created_at < sqlc.arg(to_time)
+), non_negative_usage_rows AS (
+  -- Exclude expired-token adjustment rows, which are stored as negative deltas.
+  SELECT *
+  FROM usage_rows
+  WHERE input_tokens >= 0
+    AND output_tokens >= 0
+    AND cache_read_tokens >= 0
+    AND cache_write_tokens >= 0
+    AND reasoning_tokens >= 0
+)
 SELECT
   m.model_id,
   COALESCE(mo.model_id, 'unknown') AS model_slug,
   COALESCE(mo.name, 'Unknown') AS model_name,
   COALESCE(lp.name, 'Unknown') AS provider_name,
-  COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
-  COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens
-FROM bot_history_messages m
+  COALESCE(SUM(m.input_tokens), 0)::bigint AS input_tokens,
+  COALESCE(SUM(m.output_tokens), 0)::bigint AS output_tokens
+FROM non_negative_usage_rows m
 LEFT JOIN models mo ON mo.id = m.model_id
 LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = sqlc.arg(bot_id)
-  AND m.usage IS NOT NULL
-  AND m.created_at >= sqlc.arg(from_time)
-  AND m.created_at < sqlc.arg(to_time)
 GROUP BY m.model_id, mo.model_id, mo.name, lp.name
 ORDER BY input_tokens DESC;

--- a/internal/db/sqlc/token_usage.sql.go
+++ b/internal/db/sqlc/token_usage.sql.go
@@ -12,25 +12,46 @@ import (
 )
 
 const getTokenUsageByDayAndType = `-- name: GetTokenUsageByDayAndType :many
+WITH usage_rows AS (
+  SELECT
+    m.session_id,
+    m.model_id,
+    m.created_at,
+    COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens,
+    COALESCE((m.usage->>'outputTokens')::bigint, 0)::bigint AS output_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint, 0)::bigint AS cache_write_tokens,
+    COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
+  FROM bot_history_messages m
+  WHERE m.bot_id = $1
+    AND m.usage IS NOT NULL
+    AND m.created_at >= $2
+    AND m.created_at < $3
+    AND ($4::uuid IS NULL OR m.model_id = $4::uuid)
+), non_negative_usage_rows AS (
+  -- Exclude expired-token adjustment rows, which are stored as negative deltas.
+  SELECT session_id, model_id, created_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens
+  FROM usage_rows
+  WHERE input_tokens >= 0
+    AND output_tokens >= 0
+    AND cache_read_tokens >= 0
+    AND cache_write_tokens >= 0
+    AND reasoning_tokens >= 0
+)
 SELECT
   COALESCE(
     CASE WHEN s.type = 'subagent' THEN COALESCE(ps.type, 'chat') ELSE s.type END,
     'chat'
   )::text AS session_type,
   date_trunc('day', m.created_at)::date AS day,
-  COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
-  COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens,
-  COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens,
-  COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint), 0)::bigint AS cache_write_tokens,
-  COALESCE(SUM((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint), 0)::bigint AS reasoning_tokens
-FROM bot_history_messages m
+  COALESCE(SUM(m.input_tokens), 0)::bigint AS input_tokens,
+  COALESCE(SUM(m.output_tokens), 0)::bigint AS output_tokens,
+  COALESCE(SUM(m.cache_read_tokens), 0)::bigint AS cache_read_tokens,
+  COALESCE(SUM(m.cache_write_tokens), 0)::bigint AS cache_write_tokens,
+  COALESCE(SUM(m.reasoning_tokens), 0)::bigint AS reasoning_tokens
+FROM non_negative_usage_rows m
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = $1
-  AND m.usage IS NOT NULL
-  AND m.created_at >= $2
-  AND m.created_at < $3
-  AND ($4::uuid IS NULL OR m.model_id = $4::uuid)
 GROUP BY session_type, day
 ORDER BY day, session_type
 `
@@ -86,20 +107,39 @@ func (q *Queries) GetTokenUsageByDayAndType(ctx context.Context, arg GetTokenUsa
 }
 
 const getTokenUsageByModel = `-- name: GetTokenUsageByModel :many
+WITH usage_rows AS (
+  SELECT
+    m.model_id,
+    COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens,
+    COALESCE((m.usage->>'outputTokens')::bigint, 0)::bigint AS output_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
+    COALESCE((m.usage->'inputTokenDetails'->>'cacheWriteTokens')::bigint, 0)::bigint AS cache_write_tokens,
+    COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
+  FROM bot_history_messages m
+  WHERE m.bot_id = $1
+    AND m.usage IS NOT NULL
+    AND m.created_at >= $2
+    AND m.created_at < $3
+), non_negative_usage_rows AS (
+  -- Exclude expired-token adjustment rows, which are stored as negative deltas.
+  SELECT model_id, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens
+  FROM usage_rows
+  WHERE input_tokens >= 0
+    AND output_tokens >= 0
+    AND cache_read_tokens >= 0
+    AND cache_write_tokens >= 0
+    AND reasoning_tokens >= 0
+)
 SELECT
   m.model_id,
   COALESCE(mo.model_id, 'unknown') AS model_slug,
   COALESCE(mo.name, 'Unknown') AS model_name,
   COALESCE(lp.name, 'Unknown') AS provider_name,
-  COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
-  COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens
-FROM bot_history_messages m
+  COALESCE(SUM(m.input_tokens), 0)::bigint AS input_tokens,
+  COALESCE(SUM(m.output_tokens), 0)::bigint AS output_tokens
+FROM non_negative_usage_rows m
 LEFT JOIN models mo ON mo.id = m.model_id
 LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = $1
-  AND m.usage IS NOT NULL
-  AND m.created_at >= $2
-  AND m.created_at < $3
 GROUP BY m.model_id, mo.model_id, mo.name, lp.name
 ORDER BY input_tokens DESC
 `


### PR DESCRIPTION
## What
- exclude negative token usage rows from daily usage aggregation
- exclude negative token usage rows from by-model usage aggregation
- keep expired token adjustment rows out of the frontend usage response

## Validation
- `mise run sqlc-generate`
- `go test ./internal/handlers ./internal/command ./internal/db/sqlc`
- manual PostgreSQL verification with one positive usage row and one negative expired-adjustment row; the aggregated result kept only the positive row