### PR TITLE
fix(channel): avoid Telegram stop panics

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 	"sync/atomic"
 )
 
@@ -167,6 +168,7 @@ type BaseConnection struct {
 	botID       string
 	channelType ChannelType
 	stop        func(ctx context.Context) error
+	stopMu      sync.Mutex
 	running     atomic.Bool
 }
 
@@ -199,6 +201,11 @@ func (c *BaseConnection) ChannelType() ChannelType {
 
 // Stop gracefully shuts down the connection.
 func (c *BaseConnection) Stop(ctx context.Context) error {
+	c.stopMu.Lock()
+	defer c.stopMu.Unlock()
+	if !c.running.Load() {
+		return nil
+	}
 	if c.stop == nil {
 		return ErrStopNotSupported
 	}

--- a/internal/channel/adapter_test.go
+++ b/internal/channel/adapter_test.go
@@ -1,0 +1,30 @@
+package channel
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBaseConnectionStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var stops atomic.Int32
+	conn := NewConnection(ChannelConfig{ID: "cfg-1", BotID: "bot-1", ChannelType: ChannelType("test")}, func(context.Context) error {
+		stops.Add(1)
+		return nil
+	})
+
+	if err := conn.Stop(context.Background()); err != nil {
+		t.Fatalf("first stop failed: %v", err)
+	}
+	if err := conn.Stop(context.Background()); err != nil {
+		t.Fatalf("second stop failed: %v", err)
+	}
+	if got := stops.Load(); got != 1 {
+		t.Fatalf("expected stop func to run once, got %d", got)
+	}
+	if conn.Running() {
+		t.Fatal("expected connection to be stopped")
+	}
+}

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -94,11 +94,29 @@ func (a *TelegramAdapter) SetAssetOpener(opener assetOpener) {
 
 var getOrCreateBotForTest func(a *TelegramAdapter, token, configID string) (*tgbotapi.BotAPI, error)
 
-func (a *TelegramAdapter) getOrCreateBot(cfg Config, configID string) (*tgbotapi.BotAPI, error) {
+func (a *TelegramAdapter) newBot(cfg Config, configID string) (*tgbotapi.BotAPI, error) {
 	channel.SetIMErrorSecrets("telegram:"+configID, cfg.BotToken)
 	if getOrCreateBotForTest != nil {
 		return getOrCreateBotForTest(a, cfg.BotToken, configID)
 	}
+	httpClient, err := common.NewHTTPClient(30*time.Second, cfg.HTTPProxy)
+	if err != nil {
+		if a.logger != nil {
+			a.logger.Error("create bot http client failed", slog.String("config_id", configID), slog.Any("error", err))
+		}
+		return nil, err
+	}
+	bot, err := tgbotapi.NewBotAPIWithClient(cfg.BotToken, cfg.apiEndpoint(), httpClient)
+	if err != nil {
+		if a.logger != nil {
+			a.logger.Error("create bot failed", slog.String("config_id", configID), slog.Any("error", err))
+		}
+		return nil, err
+	}
+	return bot, nil
+}
+
+func (a *TelegramAdapter) getOrCreateBot(cfg Config, configID string) (*tgbotapi.BotAPI, error) {
 	cacheKey := strings.Join([]string{
 		cfg.BotToken,
 		cfg.baseURL(),
@@ -115,18 +133,9 @@ func (a *TelegramAdapter) getOrCreateBot(cfg Config, configID string) (*tgbotapi
 	if bot, ok := a.bots[cacheKey]; ok {
 		return bot, nil
 	}
-	httpClient, err := common.NewHTTPClient(30*time.Second, cfg.HTTPProxy)
+	var err error
+	bot, err = a.newBot(cfg, configID)
 	if err != nil {
-		if a.logger != nil {
-			a.logger.Error("create bot http client failed", slog.String("config_id", configID), slog.Any("error", err))
-		}
-		return nil, err
-	}
-	bot, err = tgbotapi.NewBotAPIWithClient(cfg.BotToken, cfg.apiEndpoint(), httpClient)
-	if err != nil {
-		if a.logger != nil {
-			a.logger.Error("create bot failed", slog.String("config_id", configID), slog.Any("error", err))
-		}
 		return nil, err
 	}
 	a.bots[cacheKey] = bot
@@ -270,7 +279,10 @@ func (a *TelegramAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig
 		}
 		return nil, err
 	}
-	bot, err := a.getOrCreateBot(telegramCfg, cfg.ID)
+	// Long-polling uses a dedicated BotAPI instance because the Telegram SDK
+	// closes an internal shutdown channel on StopReceivingUpdates, making the
+	// instance unsafe to reuse across reconnects.
+	bot, err := a.newBot(telegramCfg, cfg.ID)
 	if err != nil {
 		if a.logger != nil {
 			a.logger.Error("create bot failed", slog.String("config_id", cfg.ID), slog.Any("error", err))

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -114,6 +114,50 @@ func TestBuildTelegramAttachmentIncludesPlatformReference(t *testing.T) {
 	}
 }
 
+func TestTelegramNewBotDoesNotReusePollingInstance(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewTelegramAdapter(nil)
+	cfg := Config{BotToken: "token"}
+
+	origGetBot := getOrCreateBotForTest
+	var created int
+	getOrCreateBotForTest = func(_ *TelegramAdapter, _, _ string) (*tgbotapi.BotAPI, error) {
+		created++
+		return &tgbotapi.BotAPI{Token: fmt.Sprintf("token-%d", created)}, nil
+	}
+	defer func() {
+		getOrCreateBotForTest = origGetBot
+	}()
+
+	cached1, err := adapter.getOrCreateBot(cfg, "cfg-1")
+	if err != nil {
+		t.Fatalf("getOrCreateBot first call: %v", err)
+	}
+	cached2, err := adapter.getOrCreateBot(cfg, "cfg-1")
+	if err != nil {
+		t.Fatalf("getOrCreateBot second call: %v", err)
+	}
+	if cached1 != cached2 {
+		t.Fatal("expected cached bot instance to be reused")
+	}
+
+	poll1, err := adapter.newBot(cfg, "cfg-1")
+	if err != nil {
+		t.Fatalf("newBot first call: %v", err)
+	}
+	poll2, err := adapter.newBot(cfg, "cfg-1")
+	if err != nil {
+		t.Fatalf("newBot second call: %v", err)
+	}
+	if poll1 == poll2 {
+		t.Fatal("expected polling bot instances to be distinct")
+	}
+	if got := len(adapter.bots); got != 1 {
+		t.Fatalf("expected one cached bot instance, got %d", got)
+	}
+}
+
 func TestBuildTelegramAttachmentInfersTypeFromMime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- make channel connection shutdown idempotent so duplicate stop paths do not re-close adapter resources
- use a dedicated Telegram long-polling bot instance instead of reusing cached BotAPI clients whose shutdown channel has already been closed
- add regression coverage for repeated stop calls and Telegram polling bot reuse

## Testing
- go test ./internal/channel/...

## Log
```
time=2026-04-18T01:19:42.695+08:00 level=INFO msg=request method=HEAD uri=/health status=200 latency=0s remote_ip=127.0.0.1
time=2026-04-18T01:19:46.172+08:00 level=INFO msg="adapter stop" component=channel bot_id=f35f1f0d-e14d-4ac7-958c-600ec04ebf41 channel=telegram config_id=ce29ba14-515d-460d-b3f7-3319460ce906
time=2026-04-18T01:19:46.172+08:00 level=INFO msg=stop adapter=telegram config_id=ce29ba14-515d-460d-b3f7-3319460ce906
panic: close of closed channel

goroutine 787 [running]:
github.com/go-telegram-bot-api/telegram-bot-api/v5.(*BotAPI).StopReceivingUpdates(...)
        /go/pkg/mod/github.com/go-telegram-bot-api/telegram-bot-api/v5@v5.5.1/bot.go:469
github.com/memohai/memoh/internal/channel/adapters/telegram.(*TelegramAdapter).Connect.func6({0x0?, 0x39762a0?})
        /workspace/internal/channel/adapters/telegram/telegram.go:404 +0x16a
github.com/memohai/memoh/internal/channel.(*BaseConnection).Stop(0xc001404680, {0x269a350?, 0xc0005d60f0?})
        /workspace/internal/channel/adapter.go:205 +0x35
github.com/memohai/memoh/internal/channel.(*Manager).reconcile(0xc0001969c0, {0x269a350, 0xc0005d60f0}, {0xc000431088, 0x4, 0xc000681008?})
        /workspace/internal/channel/connection.go:74 +0x863
github.com/memohai/memoh/internal/channel.(*Manager).refresh(0xc0001969c0, {0x269a350, 0xc0005d60f0})
        /workspace/internal/channel/connection.go:35 +0x3d8
github.com/memohai/memoh/internal/channel.(*Manager).Start.func1()
        /workspace/internal/channel/manager.go:226 +0x9e
created by github.com/memohai/memoh/internal/channel.(*Manager).Start in goroutine 57
        /workspace/internal/channel/manager.go:213 +0xc5
```