### PR TITLE
fix(web): show attachment messages immediately

### DIFF
--- a/apps/web/src/composables/api/useChat.message-api.ts
+++ b/apps/web/src/composables/api/useChat.message-api.ts
@@ -54,6 +54,36 @@ export interface SendMessageOverrides {
   reasoningEffort?: string
 }
 
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ''))
+    reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`))
+    reader.readAsDataURL(file)
+  })
+}
+
+export async function materializeChatAttachments(
+  attachments?: ChatAttachment[],
+): Promise<ChatAttachment[] | undefined> {
+  if (!attachments?.length) return attachments
+
+  return Promise.all(attachments.map(async (item) => {
+    const base64 = String(item.base64 ?? '').trim() || (item.file ? await readFileAsDataUrl(item.file) : '')
+    if (!base64) {
+      const label = item.name?.trim() || 'attachment'
+      throw new Error(`Missing attachment payload: ${label}`)
+    }
+
+    return {
+      type: item.type,
+      base64,
+      mime: item.mime ?? '',
+      name: item.name ?? '',
+    } satisfies ChatAttachment
+  }))
+}
+
 export async function sendLocalChannelMessage(
   botId: string,
   text: string,
@@ -62,13 +92,14 @@ export async function sendLocalChannelMessage(
 ): Promise<void> {
   const msg: ChannelMessage = {}
   const trimmedText = text.trim()
+  const resolvedAttachments = await materializeChatAttachments(attachments)
   if (trimmedText) {
     msg.text = trimmedText
   }
-  if (attachments?.length) {
-    msg.attachments = attachments.map((item): ChannelAttachment => ({
+  if (resolvedAttachments?.length) {
+    msg.attachments = resolvedAttachments.map((item): ChannelAttachment => ({
       type: item.type as ChannelAttachment['type'],
-      base64: item.base64,
+      base64: item.base64 ?? '',
       mime: item.mime ?? '',
       name: item.name ?? '',
     }))

--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -85,9 +85,11 @@ export interface FetchMessagesOptions {
 
 export interface ChatAttachment {
   type: string
-  base64: string
+  base64?: string
   mime?: string
   name?: string
+  previewUrl?: string
+  file?: File
 }
 
 export interface UIAttachment {

--- a/apps/web/src/pages/home/components/chat-area.vue
+++ b/apps/web/src/pages/home/components/chat-area.vue
@@ -736,20 +736,14 @@ function handlePaste(e: ClipboardEvent) {
   }
 }
 
-async function fileToAttachment(file: File): Promise<ChatAttachment> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      resolve({
-        type: file.type.startsWith('image/') ? 'image' : 'file',
-        base64: reader.result as string,
-        mime: file.type || 'application/octet-stream',
-        name: file.name,
-      })
-    }
-    reader.onerror = () => reject(new Error('Failed to read file'))
-    reader.readAsDataURL(file)
-  })
+function fileToAttachment(file: File): ChatAttachment {
+  return {
+    type: file.type.startsWith('image/') ? 'image' : 'file',
+    mime: file.type || 'application/octet-stream',
+    name: file.name,
+    previewUrl: URL.createObjectURL(file),
+    file,
+  }
 }
 
 async function handleSend() {
@@ -761,11 +755,8 @@ async function handleSend() {
   inputText.value = ''
   pendingFiles.value = []
 
-  let attachments: ChatAttachment[] | undefined
-  if (files.length) {
-    attachments = await Promise.all(files.map(fileToAttachment))
-  }
+  const attachments = files.length ? files.map(fileToAttachment) : undefined
 
-  chatStore.sendMessage(text, attachments)
+  void chatStore.sendMessage(text, attachments)
 }
 </script>

--- a/apps/web/src/pages/home/composables/useMediaGallery.ts
+++ b/apps/web/src/pages/home/composables/useMediaGallery.ts
@@ -13,7 +13,7 @@ function isMediaType(att: Record<string, unknown>): boolean {
 function isBrowserAccessibleUrl(url: string): boolean {
   if (!url) return false
   const lower = url.toLowerCase()
-  return lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('data:')
+  return lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('data:') || lower.startsWith('blob:')
 }
 
 function resolveBotId(att: Record<string, unknown>): string {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -24,6 +24,7 @@ import {
   type UIStreamEvent,
   fetchBots,
   fetchMessagesUI,
+  materializeChatAttachments,
   sendLocalChannelMessage,
   streamMessageEvents,
   connectWebSocket,
@@ -226,6 +227,7 @@ export const useChatStore = defineStore('chat', () => {
 
   function replaceMessages(items: UITurn[]) {
     const normalized = items.map(normalizeTurn)
+    revokeMessagePreviewUrls(messages)
     messages.splice(0, messages.length, ...normalized)
     updateSinceFromMessages(normalized)
   }
@@ -258,7 +260,7 @@ export const useChatStore = defineStore('chat', () => {
       text,
       attachments: (attachments ?? []).map((attachment) => ({
         type: attachment.type,
-        url: attachment.base64,
+        url: resolveAttachmentPreviewUrl(attachment),
         base64: attachment.base64,
         name: attachment.name ?? '',
         mime: attachment.mime ?? '',
@@ -285,6 +287,44 @@ export const useChatStore = defineStore('chat', () => {
     session.done = true
     pendingAssistantStream = null
     session.reject(err)
+  }
+
+  function resolveAttachmentPreviewUrl(attachment: ChatAttachment): string {
+    const previewUrl = String(attachment.previewUrl ?? '').trim()
+    if (previewUrl) return previewUrl
+    return String(attachment.base64 ?? '').trim()
+  }
+
+  function revokeObjectUrl(value?: string) {
+    const url = String(value ?? '').trim()
+    if (!url.startsWith('blob:')) return
+    URL.revokeObjectURL(url)
+  }
+
+  function revokeAttachmentPreviewUrls(attachments?: ChatAttachment[]) {
+    for (const attachment of attachments ?? []) {
+      revokeObjectUrl(attachment.previewUrl)
+    }
+  }
+
+  function revokeMessagePreviewUrls(items: ChatMessage[]) {
+    for (const item of items) {
+      if (item.role === 'user') {
+        for (const attachment of item.attachments) {
+          revokeObjectUrl(attachment.url)
+          revokeObjectUrl(attachment.base64)
+        }
+        continue
+      }
+
+      for (const block of item.messages) {
+        if (block.type !== 'attachments') continue
+        for (const attachment of block.attachments) {
+          revokeObjectUrl(String(attachment.url ?? ''))
+          revokeObjectUrl(String(attachment.base64 ?? ''))
+        }
+      }
+    }
   }
 
   function ensureDiscussStream(): PendingAssistantStream {
@@ -657,6 +697,7 @@ export const useChatStore = defineStore('chat', () => {
       const modelId = overrideModelId.value || undefined
       const effort = overrideReasoningEffort.value
       const reasoningEffort = effort && effort !== 'off' ? effort : undefined
+      const resolvedAttachments = await materializeChatAttachments(attachments)
 
       const ws = ensureWebSocket(bid)
       if (ws) {
@@ -671,7 +712,7 @@ export const useChatStore = defineStore('chat', () => {
           type: 'message',
           text: trimmed,
           session_id: sid,
-          attachments,
+          attachments: resolvedAttachments,
           model_id: modelId,
           reasoning_effort: reasoningEffort,
         })
@@ -679,7 +720,7 @@ export const useChatStore = defineStore('chat', () => {
         await refreshCurrentSession(bid, sid)
       } else {
         void createCompletionForAssistantTurn(assistantTurn).catch(() => {})
-        await sendLocalChannelMessage(bid, trimmed, attachments, { modelId, reasoningEffort })
+        await sendLocalChannelMessage(bid, trimmed, resolvedAttachments, { modelId, reasoningEffort })
         await refreshCurrentSession(bid, sid)
       }
 
@@ -688,7 +729,9 @@ export const useChatStore = defineStore('chat', () => {
       loading.value = false
       abortFn = null
       touchSession(sid)
+      revokeAttachmentPreviewUrls(attachments)
     } catch (error) {
+      revokeAttachmentPreviewUrls(attachments)
       const isAbort = error instanceof Error && error.name === 'AbortError'
       const reason = error instanceof Error ? error.message : 'Unknown error'
       if (!isAbort && assistantTurn) {
@@ -759,4 +802,3 @@ export const useChatStore = defineStore('chat', () => {
     abort,
   }
 })
-

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -327,6 +327,20 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  function removeMessageById(targetId?: string | null) {
+    const id = String(targetId ?? '').trim()
+    if (!id) return
+    const index = messages.findIndex(message => message.id === id)
+    if (index >= 0) {
+      messages.splice(index, 1)
+    }
+  }
+
+  function removeOptimisticSend(userTurn?: ChatUserTurn | null, assistantTurn?: ChatAssistantTurn | null) {
+    removeMessageById(assistantTurn?.id)
+    removeMessageById(userTurn?.id)
+  }
+
   function ensureDiscussStream(): PendingAssistantStream {
     if (pendingAssistantStream && !pendingAssistantStream.done) {
       return pendingAssistantStream
@@ -681,7 +695,9 @@ export const useChatStore = defineStore('chat', () => {
     if ((!trimmed && !attachments?.length) || streaming.value || !currentBotId.value) return
 
     loading.value = true
+    let userTurn: ChatUserTurn | null = null
     let assistantTurn: ChatAssistantTurn | null = null
+    let messageDispatched = false
 
     try {
       await ensureActiveSession()
@@ -690,7 +706,8 @@ export const useChatStore = defineStore('chat', () => {
       const sid = sessionId.value!
       streamingSessionId.value = sid
 
-      messages.push(createOptimisticUserTurn(trimmed, attachments))
+      userTurn = createOptimisticUserTurn(trimmed, attachments)
+      messages.push(userTurn)
       messages.push(createOptimisticAssistantTurn())
       assistantTurn = messages[messages.length - 1] as ChatAssistantTurn
 
@@ -716,11 +733,13 @@ export const useChatStore = defineStore('chat', () => {
           model_id: modelId,
           reasoning_effort: reasoningEffort,
         })
+        messageDispatched = true
         await completion
         await refreshCurrentSession(bid, sid)
       } else {
         void createCompletionForAssistantTurn(assistantTurn).catch(() => {})
         await sendLocalChannelMessage(bid, trimmed, resolvedAttachments, { modelId, reasoningEffort })
+        messageDispatched = true
         await refreshCurrentSession(bid, sid)
       }
 
@@ -729,12 +748,23 @@ export const useChatStore = defineStore('chat', () => {
       loading.value = false
       abortFn = null
       touchSession(sid)
-      revokeAttachmentPreviewUrls(attachments)
     } catch (error) {
-      revokeAttachmentPreviewUrls(attachments)
-      const isAbort = error instanceof Error && error.name === 'AbortError'
-      const reason = error instanceof Error ? error.message : 'Unknown error'
-      if (!isAbort && assistantTurn) {
+      const failure = error instanceof Error ? error : new Error('Unknown error')
+      const isAbort = failure.name === 'AbortError'
+      const reason = failure.message || 'Unknown error'
+
+      if (!isAbort && pendingAssistantStream) {
+        rejectPendingAssistantStream(failure)
+      }
+
+      if (!messageDispatched) {
+        removeOptimisticSend(userTurn, assistantTurn)
+        revokeAttachmentPreviewUrls(attachments)
+        assistantTurn = null
+        userTurn = null
+      }
+
+      if (!isAbort && messageDispatched && assistantTurn) {
         assistantTurn.messages = [{
           id: 0,
           type: 'text',


### PR DESCRIPTION
## Summary
- move attachment file reading out of the pre-send path so the optimistic user turn renders immediately
- use blob preview URLs for optimistic attachment rendering and resolve the real base64 payload right before transport
- revoke temporary blob URLs after refresh/send completion and allow blob URLs in the media gallery

## Testing
- corepack pnpm exec eslint apps/web/src/composables/api/useChat.message-api.ts apps/web/src/composables/api/useChat.types.ts apps/web/src/pages/home/components/chat-area.vue apps/web/src/pages/home/composables/useMediaGallery.ts apps/web/src/store/chat-list.ts
- corepack pnpm --filter @memohai/web exec vue-tsc --noEmit -p tsconfig.json
- corepack pnpm --filter @memohai/web build
- manual validation on a minimachine Safari session against a mock Memoh server; injected a 3s FileReader delay and confirmed the message text plus attachment appeared in 0.52s after clicking send
