### PR TITLE
Remove dead code ("reset password")

### DIFF
--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -96,14 +96,6 @@
                 </FormControl>
               </FormItem>
             </FormField>
-            <div class="flex">
-              <a
-                href="#"
-                class="ml-auto inline-block text-xs underline mt-2"
-              >
-                {{ $t('auth.forgotPassword') }}
-              </a>
-            </div>
           </CardContent>
 
           <CardFooter>


### PR DESCRIPTION
Remove dead code ("reset password")

currently, "forgot password" is unusable.

no button is always better than an ususable button.

and since you only have the id and the pw (no email, phone, 2fa, or something), there is no meaningful way to "forget password" safely.

just like your os, which does not allow you to reset password generally.

in the long term, i doubt if there is the need to have a password,

- "multi user" means the bot can interact with many. it might not imply there is the need to have many admins.
- if it's supposed to have only one admin, there is no need to set an id. by default, most ppl dont wanna mess up with pw i guess. just like telegram, do you enter a pw when opening it? well, you can, like 2fa auth apps. it's just a security lock.
- idk if currently you could register many admins. if not, it's redundant at once.

ive not tested it. make sure there is no layout shift rm it.

fix part of issue 396 (mine).