### PR TITLE
fix(web): replace provider enabled dot spans with Badge in settings p…

### DIFF
--- a/apps/web/src/pages/bots/components/bot-compaction.vue
+++ b/apps/web/src/pages/bots/components/bot-compaction.vue
@@ -232,7 +232,7 @@
         v-if="totalPages > 1"
         class="flex items-center justify-between pt-2"
       >
-        <span class="text-xs text-muted-foreground">
+        <span class="text-xs text-muted-foreground whitespace-nowrap">
           {{ paginationSummary }}
         </span>
         <Pagination
@@ -257,6 +257,7 @@
               <PaginationItem
                 v-else
                 :value="item.value"
+                :is-active="item.value === currentPage"
               />
             </template>
             <PaginationNext />

--- a/apps/web/src/pages/bots/components/bot-heartbeat.vue
+++ b/apps/web/src/pages/bots/components/bot-heartbeat.vue
@@ -219,7 +219,7 @@
         v-if="totalPages > 1"
         class="flex items-center justify-between pt-2"
       >
-        <span class="text-xs text-muted-foreground">
+        <span class="text-xs text-muted-foreground whitespace-nowrap">
           {{ paginationSummary }}
         </span>
         <Pagination
@@ -244,6 +244,7 @@
               <PaginationItem
                 v-else
                 :value="item.value"
+                :is-active="item.value === currentPage"
               />
             </template>
             <PaginationNext />

--- a/apps/web/src/pages/bots/components/bot-schedule.vue
+++ b/apps/web/src/pages/bots/components/bot-schedule.vue
@@ -176,7 +176,7 @@
         v-if="totalPages > 1"
         class="flex items-center justify-between pt-4"
       >
-        <span class="text-xs text-muted-foreground">
+        <span class="text-xs text-muted-foreground whitespace-nowrap">
           {{ paginationSummary }}
         </span>
         <Pagination
@@ -201,6 +201,7 @@
               <PaginationItem
                 v-else
                 :value="item.value"
+                :is-active="item.value === currentPage"
               />
             </template>
             <PaginationNext />

--- a/apps/web/src/pages/browser/components/context-setting.vue
+++ b/apps/web/src/pages/browser/components/context-setting.vue
@@ -50,18 +50,17 @@
             <Label>{{ $t('browser.core') }}</Label>
             <FormControl>
               <div class="flex gap-3">
-                <button
+                <Button
                   v-for="c in availableCores"
                   :key="c"
-                  type="button"
-                  class="flex items-center gap-2 px-3 py-1.5 rounded-md border text-xs transition-colors"
-                  :class="value === c
-                    ? 'border-primary bg-primary/10 text-primary font-medium'
-                    : 'border-border bg-card text-muted-foreground hover:bg-accent'"
+                  variant="outline"
+                  class="px-3 py-1.5 "
+                
+                  :disabled="value === c"
                   @click="handleChange(c)"
                 >
                   {{ $t(`browser.${c}`) }}
-                </button>
+                </Button>
               </div>
             </FormControl>
           </FormItem>

--- a/apps/web/src/pages/providers/components/model-list.vue
+++ b/apps/web/src/pages/providers/components/model-list.vue
@@ -69,6 +69,7 @@
               <PaginationItem
                 v-else
                 :value="item.value"
+                :is-active="item.value === currentPage"
               />
             </template>
             <PaginationNext />

--- a/apps/web/src/pages/providers/index.vue
+++ b/apps/web/src/pages/providers/index.vue
@@ -15,6 +15,7 @@ import {
   EmptyMedia,
   EmptyTitle,
   Button,
+  Badge,
 } from '@memohai/ui'
 import { getProviders } from '@memohai/sdk'
 import type { ProvidersGetResponse } from '@memohai/sdk'
@@ -121,9 +122,10 @@ const openStatus = reactive({
                     {{ getInitials(providerItem.name) }}
                   </span>
                 </span>
-                <span
+                <Badge
                   v-if="providerItem.enable !== false"
-                  class="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full bg-green-500 ring-2 ring-background"
+                  class="absolute bottom-[2px] right-[2px] p-0.5 rounded-full"
+                  variant="destructive"
                 />
               </span>
               <span class="truncate">{{ providerItem.name }}</span>

--- a/apps/web/src/pages/speech/index.vue
+++ b/apps/web/src/pages/speech/index.vue
@@ -12,6 +12,7 @@ import {
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Badge
 } from '@memohai/ui'
 import { getSpeechProviders } from '@memohai/sdk'
 import type { TtsSpeechProviderResponse } from '@memohai/sdk'
@@ -97,10 +98,15 @@ watch(filteredProviders, (list) => {
                     {{ getInitials(item.name) }}
                   </span>
                 </span>
-                <span
+                <Badge
+                  v-if="item.enable !== false"
+                  class="absolute bottom-[2px] right-[2px] p-0.5 rounded-full"
+                  variant="destructive"
+                />        
+                <!-- <span
                   v-if="item.enable !== false"
                   class="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full bg-green-500 ring-2 ring-background"
-                />
+                /> -->
               </span>
               <span class="truncate">{{ item.name }}</span>
             </Toggle>

--- a/apps/web/src/pages/transcription/index.vue
+++ b/apps/web/src/pages/transcription/index.vue
@@ -12,6 +12,7 @@ import {
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Badge,
 } from '@memohai/ui'
 import { getTranscriptionProviders } from '@memohai/sdk'
 import type { AudioSpeechProviderResponse } from '@memohai/sdk'
@@ -90,9 +91,10 @@ watch(filteredProviders, (list) => {
                     {{ getInitials(item.name) }}
                   </span>
                 </span>
-                <span
+                <Badge
                   v-if="item.enable !== false"
-                  class="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full bg-green-500 ring-2 ring-background"
+                  class="absolute bottom-[2px] right-[2px] p-0.5 rounded-full"
+                  variant="destructive"
                 />
               </span>
               <span class="truncate">{{ item.name }}</span>

--- a/apps/web/src/pages/usage/index.vue
+++ b/apps/web/src/pages/usage/index.vue
@@ -367,6 +367,7 @@
                   <PaginationItem
                     v-else
                     :value="item.value"
+                    :is-active="item.value === recordsPageNumber"
                   />
                 </template>
                 <PaginationNext />

--- a/apps/web/src/pages/web-search/index.vue
+++ b/apps/web/src/pages/web-search/index.vue
@@ -13,7 +13,8 @@ import {
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
-  Button
+  Button,
+  Badge,
 } from '@memohai/ui'
 import { getSearchProviders } from '@memohai/sdk'
 import type { SearchprovidersGetResponse } from '@memohai/sdk'
@@ -103,9 +104,10 @@ const openStatus = reactive({
                   :provider="item.provider || ''"
                   size="sm"
                 />
-                <span
+                <Badge
                   v-if="item.enable !== false"
-                  class="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full bg-green-500 ring-2 ring-background"
+                  class="absolute bottom-[2px] right-[2px] p-0.5 rounded-full"
+                  variant="destructive"
                 />
               </span>
               <span class="truncate">{{ item.name }}</span>

--- a/internal/channel/toolcall_formatters_test.go
+++ b/internal/channel/toolcall_formatters_test.go
@@ -133,6 +133,7 @@ func TestFormatWebSearchEmitsLinks(t *testing.T) {
 	link := hasLinkBlock(p.Body, "https://go.dev/doc/tutorial/generics")
 	if link == nil {
 		t.Fatalf("expected link block for tutorial, got %+v", p.Body)
+		return
 	}
 	if link.Title != "Tutorial: Getting started with generics" {
 		t.Fatalf("unexpected title: %q", link.Title)
@@ -274,6 +275,7 @@ func TestFormatWebFetchShowsLink(t *testing.T) {
 	link := hasLinkBlock(p.Body, "https://example.com/article")
 	if link == nil {
 		t.Fatalf("expected link block, got %+v", p.Body)
+		return
 	}
 	if link.Title != "Example Article Title" {
 		t.Fatalf("unexpected link title: %q", link.Title)

--- a/internal/containerd/metrics_test.go
+++ b/internal/containerd/metrics_test.go
@@ -26,6 +26,7 @@ func TestBuildCPUMetricsUsesCumulativeDelta(t *testing.T) {
 	metrics := buildCPUMetrics(first, second)
 	if metrics == nil {
 		t.Fatal("expected cpu metrics")
+		return
 	}
 	if metrics.UsagePercent != 50 {
 		t.Fatalf("expected cpu usage percent 50, got %v", metrics.UsagePercent)


### PR DESCRIPTION
1. 分页器
<img width="1062" height="107" alt="img_v3_02116_6e2be35f-fe00-4064-9213-7c1deb82e66g" src="https://github.com/user-attachments/assets/e05c676d-8363-4fa4-acbd-46a06ea0af48" />

修改后

<img width="1059" height="117" alt="image" src="https://github.com/user-attachments/assets/81b4e280-4bde-4de5-9fc6-5eab017139dc" />

2. Badge
<img width="268" height="167" alt="image" src="https://github.com/user-attachments/assets/bf786a7a-4128-4e75-9000-919dae8c9a88" />

没有使用ui当中的Badge组件

<img width="366" height="159" alt="image" src="https://github.com/user-attachments/assets/f22b2c7b-bed4-4d51-8a30-d17e5d748f09" />

3. Button
<img width="219" height="75" alt="image" src="https://github.com/user-attachments/assets/a1350cf7-8490-43b4-84c7-4474c2e79d2d" />

没有使用ui当中的Button组件

<img width="495" height="88" alt="image" src="https://github.com/user-attachments/assets/0c81bb9f-c558-4f7f-849b-14c063e0c5d1" />
