### PR TITLE
fix(web): table legend, dialog time alignment, chat image fallback, instant scroll on thread switch

### DIFF
--- a/apps/web/src/components/sidebar/bot-item.vue
+++ b/apps/web/src/components/sidebar/bot-item.vue
@@ -18,10 +18,16 @@
     >
       <div class="size-6.5 shrink-0 rounded-full border border-border bg-accent overflow-hidden p-px group-data-[collapsible=icon]:mx-auto">
         <img
-          v-if="bot.avatar_url"
+          v-if="bot.avatar_url&&!isError"
           :src="bot.avatar_url"
           :alt="bot.display_name || bot.id"
-          class="size-full rounded-full object-cover"
+          class="size-full rounded-full object-cover "
+          @error="() => {
+            isError = true;
+          }"
+          @load="() => { 
+            isError = false
+          }"
         >
         <span
           v-else
@@ -88,6 +94,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@memohai/ui'
+import { ref } from 'vue'
 
 const props = defineProps<{ bot: BotsBot }>()
 
@@ -101,6 +108,7 @@ const avatarFallback = useAvatarInitials(() => displayName.value, 'B')
 
 const isActive = computed(() => currentBotId.value === props.bot.id)
 const pinned = computed(() => isPinned(props.bot.id ?? ''))
+const isError=ref(false)
 
 function handleSelect() {
   if (props.bot.status === 'error') return

--- a/apps/web/src/pages/bots/components/bot-container.vue
+++ b/apps/web/src/pages/bots/components/bot-container.vue
@@ -1064,9 +1064,7 @@ watch([activeTab, botId], ([tab]) => {
           class="hidden"
           @change="handleImportData"
         >
-
         <Separator />
-
         <div class="space-y-3">
           <div class="space-y-1">
             <h4 class="text-xs font-medium text-destructive">

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -279,6 +279,7 @@ const {
   overrideReasoningEffort,
 } = storeToRefs(chatStore)
 
+
 const { data: modelData } = useQuery({
   key: ['all-models'],
   query: async () => {
@@ -404,14 +405,23 @@ const isInstant = ref(false)
 const { y, directions, arrivedState } = useScroll(scrollEl, { behavior: computed(() => isAutoScroll.value && isInstant.value ? 'smooth' : 'instant') })
 const { height, bottom } = useElementBounding(descEl)
 
+watch(activeSession, async () => {
+  isInstant.value = false
+  y.value=height.value  
+},{immediate:true,deep:true})
+
+
 watchEffect(() => {
   if (directions.top) {
     isAutoScroll.value = false
+     isInstant.value=true
   }
   if (arrivedState.bottom) {
     isAutoScroll.value = true
+    isInstant.value=true
   }
-})
+},{flush:'post'})
+
 
 watchEffect(() => {
   if (isAutoScroll.value) {

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -159,8 +159,8 @@
           :on-open-media="onOpenMedia"
         />
         <p
-          class="text-xs text-muted-foreground/80 mt-1"
-          :title="fullTimestamp"
+          class="text-xs text-muted-foreground/80 mt-1 text-right"
+          :title="fullTimestamp" 
         >
           {{ relativeTimestamp }}
         </p>

--- a/apps/web/src/pages/usage/index.vue
+++ b/apps/web/src/pages/usage/index.vue
@@ -710,7 +710,15 @@ const modelPieOption = computed(() => {
     legend: {
       orient: 'vertical' as const,
       right: 10,
-      top: 'center',
+      top: 0,
+      fontSize: 10,     
+      textStyle: {
+        overflow: 'truncate',
+        width: 150,        
+      },
+      tooltip: {
+        show:true
+      }
     },
     series: [
       {
@@ -738,7 +746,7 @@ const modelBarOption = computed(() => {
   const names = models.map(m => modelLabel(m))
   return {
     tooltip: { trigger: 'axis' as const },
-    legend: { data: [t('usage.inputTokens'), t('usage.outputTokens')] },
+    legend: { data: [t('usage.inputTokens'), t('usage.outputTokens')],top: 0, },
     grid: { left: 60, right: 20, bottom: 60, top: 40 },
     xAxis: {
       type: 'category' as const,
@@ -763,8 +771,12 @@ const modelBarOption = computed(() => {
   }
 })
 
-const modelChartOption = computed(() =>
-  modelChartType.value === 'bar' ? modelBarOption.value : modelPieOption.value,
+const modelChartOption = computed(() => ({
+  ...(modelChartType.value === 'bar' ? modelBarOption.value : modelPieOption.value),
+  // legend: {
+  //   fontSize: 10,
+  // }
+}),
 )
 
 const dailyTokensOption = computed(() => {


### PR DESCRIPTION
1. 对话框时间对齐
<img width="409" height="609" alt="截屏2026-04-29 下午4 16 21" src="https://github.com/user-attachments/assets/7993a808-2b03-424f-9785-b16ba49a3a64" />
改成
<img width="363" height="624" alt="image" src="https://github.com/user-attachments/assets/837bb40b-0af7-4682-af0f-9ea0f4b9ffdc" />


2. bot的img src如果是错误的时候，应该显示后备内容 
<img width="217" height="94" alt="image" src="https://github.com/user-attachments/assets/e803bd72-02b3-4dda-926a-5cd7a1f9487b" />
改成
<img width="215" height="154" alt="image" src="https://github.com/user-attachments/assets/97183df4-b9f8-4655-8f8a-aac3ad40aaa0" />


3. 图表的显示异常
<img width="655" height="432" alt="image" src="https://github.com/user-attachments/assets/e0addf4d-e638-4ab2-905c-264885f8f337" />
改成
<img width="647" height="450" alt="image" src="https://github.com/user-attachments/assets/1aca0b18-7bb2-463d-959b-bf835c8eb283" />


4. chat在对话框在session或者bot切换的时候，滚动到最底部不应该有过渡
