### PR TITLE
feat: add desktop local workspace runtime

### DIFF
--- a/.github/workflows/electron-ci.yml
+++ b/.github/workflows/electron-ci.yml
@@ -52,6 +52,11 @@ jobs:
           node-version: lts/*
           cache: pnpm
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
 

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -10,6 +10,9 @@ dist
 # bundle assets (icons etc.) — root .gitignore has `build/`, re-include here.
 !build/
 !build/**
+resources/config/
+resources/runtime/
+resources/server/
 
 # editor
 .vscode/*

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -13,6 +13,13 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asarUnpack:
   - resources/**
+extraResources:
+  - from: resources/server
+    to: server
+  - from: resources/runtime
+    to: runtime
+  - from: resources/config
+    to: config
 mac:
   category: public.app-category.productivity
   target:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -20,6 +20,8 @@ extraResources:
     to: runtime
   - from: resources/config
     to: config
+  - from: resources/providers
+    to: providers
 mac:
   category: public.app-category.productivity
   target:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,12 +13,13 @@
   "scripts": {
     "dev": "electron-vite dev",
     "start": "electron-vite preview",
-    "build": "electron-vite build && electron-builder --publish never",
-    "build:dir": "electron-vite build && electron-builder --dir --publish never",
-    "build:unpack": "electron-vite build && electron-builder --dir --publish never",
-    "build:mac": "electron-vite build && electron-builder --mac --publish never",
-    "build:linux": "electron-vite build && electron-builder --linux --publish never",
-    "build:win": "electron-vite build && electron-builder --win --publish never",
+    "prepare:local-server": "node scripts/prepare-local-server.mjs",
+    "build": "pnpm run prepare:local-server && electron-vite build && electron-builder --publish never",
+    "build:dir": "pnpm run prepare:local-server && electron-vite build && electron-builder --dir --publish never",
+    "build:unpack": "pnpm run prepare:local-server && electron-vite build && electron-builder --dir --publish never",
+    "build:mac": "pnpm run prepare:local-server && electron-vite build && electron-builder --mac --publish never",
+    "build:linux": "pnpm run prepare:local-server && electron-vite build && electron-builder --linux --publish never",
+    "build:win": "pnpm run prepare:local-server && electron-vite build && electron-builder --win --publish never",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
@@ -30,7 +31,11 @@
     "@memohai/icon": "workspace:*",
     "@memohai/sdk": "workspace:*",
     "@memohai/ui": "workspace:*",
-    "@memohai/web": "workspace:*"
+    "@memohai/web": "workspace:*",
+    "@vee-validate/zod": "^4.15.1",
+    "lucide-vue-next": "^0.562.0",
+    "vee-validate": "^4.15.1",
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^1.0.1",

--- a/apps/desktop/scripts/prepare-local-server.mjs
+++ b/apps/desktop/scripts/prepare-local-server.mjs
@@ -1,0 +1,34 @@
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const desktopRoot = resolve(__dirname, '..')
+const repoRoot = resolve(desktopRoot, '..', '..')
+const resourcesRoot = resolve(desktopRoot, 'resources')
+const serverDir = resolve(resourcesRoot, 'server')
+const runtimeDir = resolve(resourcesRoot, 'runtime')
+const configDir = resolve(resourcesRoot, 'config')
+
+const serverName = process.platform === 'win32' ? 'memoh-server.exe' : 'memoh-server'
+
+rmSync(serverDir, { recursive: true, force: true })
+rmSync(runtimeDir, { recursive: true, force: true })
+mkdirSync(serverDir, { recursive: true })
+mkdirSync(runtimeDir, { recursive: true })
+mkdirSync(configDir, { recursive: true })
+
+execFileSync('go', ['build', '-o', resolve(serverDir, serverName), './cmd/agent'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+})
+
+execFileSync('go', ['build', '-o', resolve(runtimeDir, 'bridge'), './cmd/bridge'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+})
+
+copyFileSync(resolve(repoRoot, 'conf', 'app.local.toml'), resolve(configDir, 'app.local.toml'))
+
+console.log(`Prepared desktop local server resources in ${resourcesRoot}`)

--- a/apps/desktop/scripts/prepare-local-server.mjs
+++ b/apps/desktop/scripts/prepare-local-server.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { copyFileSync, mkdirSync, rmSync } from 'node:fs'
+import { cpSync, copyFileSync, mkdirSync, rmSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -10,14 +10,17 @@ const resourcesRoot = resolve(desktopRoot, 'resources')
 const serverDir = resolve(resourcesRoot, 'server')
 const runtimeDir = resolve(resourcesRoot, 'runtime')
 const configDir = resolve(resourcesRoot, 'config')
+const providersDir = resolve(resourcesRoot, 'providers')
 
 const serverName = process.platform === 'win32' ? 'memoh-server.exe' : 'memoh-server'
 
 rmSync(serverDir, { recursive: true, force: true })
 rmSync(runtimeDir, { recursive: true, force: true })
+rmSync(providersDir, { recursive: true, force: true })
 mkdirSync(serverDir, { recursive: true })
 mkdirSync(runtimeDir, { recursive: true })
 mkdirSync(configDir, { recursive: true })
+mkdirSync(providersDir, { recursive: true })
 
 execFileSync('go', ['build', '-o', resolve(serverDir, serverName), './cmd/agent'], {
   cwd: repoRoot,
@@ -30,5 +33,6 @@ execFileSync('go', ['build', '-o', resolve(runtimeDir, 'bridge'), './cmd/bridge'
 })
 
 copyFileSync(resolve(repoRoot, 'conf', 'app.local.toml'), resolve(configDir, 'app.local.toml'))
+cpSync(resolve(repoRoot, 'conf', 'providers'), providersDir, { recursive: true })
 
 console.log(`Prepared desktop local server resources in ${resourcesRoot}`)

--- a/apps/desktop/scripts/prepare-local-server.mjs
+++ b/apps/desktop/scripts/prepare-local-server.mjs
@@ -13,6 +13,7 @@ const configDir = resolve(resourcesRoot, 'config')
 const providersDir = resolve(resourcesRoot, 'providers')
 
 const serverName = process.platform === 'win32' ? 'memoh-server.exe' : 'memoh-server'
+const dockerBridgeArch = process.arch === 'x64' ? 'amd64' : process.arch
 
 rmSync(serverDir, { recursive: true, force: true })
 rmSync(runtimeDir, { recursive: true, force: true })
@@ -30,6 +31,11 @@ execFileSync('go', ['build', '-o', resolve(serverDir, serverName), './cmd/agent'
 execFileSync('go', ['build', '-o', resolve(runtimeDir, 'bridge'), './cmd/bridge'], {
   cwd: repoRoot,
   stdio: 'inherit',
+  env: {
+    ...process.env,
+    GOOS: 'linux',
+    GOARCH: dockerBridgeArch,
+  },
 })
 
 copyFileSync(resolve(repoRoot, 'conf', 'app.local.toml'), resolve(configDir, 'app.local.toml'))

--- a/apps/desktop/scripts/prepare-local-server.mjs
+++ b/apps/desktop/scripts/prepare-local-server.mjs
@@ -37,6 +37,7 @@ execFileSync('go', ['build', '-o', resolve(runtimeDir, 'bridge'), './cmd/bridge'
     GOARCH: dockerBridgeArch,
   },
 })
+cpSync(resolve(repoRoot, 'cmd', 'bridge', 'template'), resolve(runtimeDir, 'templates'), { recursive: true })
 
 copyFileSync(resolve(repoRoot, 'conf', 'app.local.toml'), resolve(configDir, 'app.local.toml'))
 cpSync(resolve(repoRoot, 'conf', 'providers'), providersDir, { recursive: true })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'node:path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import iconPng from '../../resources/icon.png?asset'
-import { defaultWorkspacePath, ensureLocalServer, getLocalServerStatus } from './local-server'
+import { defaultWorkspacePath, ensureLocalServer, getDesktopAuthToken, getLocalServerStatus } from './local-server'
 
 const CHAT_DEFAULTS = { width: 1280, height: 800, minWidth: 960, minHeight: 600 }
 const SETTINGS_DEFAULTS = { width: 1080, height: 720, minWidth: 880, minHeight: 560 }
@@ -100,13 +100,15 @@ function createSettingsWindow(): BrowserWindow {
     },
   })
   window.setParentWindow(null)
+  const webContentsId = window.webContents.id
 
   window.on('ready-to-show', () => {
+    if (window.isDestroyed()) return
     window.setParentWindow(null)
     window.show()
   })
   window.on('closed', () => {
-    pendingSettingsNavigate.delete(window.webContents.id)
+    pendingSettingsNavigate.delete(webContentsId)
     settingsWindow = null
   })
 
@@ -114,9 +116,10 @@ function createSettingsWindow(): BrowserWindow {
   // receive IPC messages. Reusing `did-finish-load` keeps both fresh
   // cold-starts and in-place refreshes working without extra coordination.
   window.webContents.on('did-finish-load', () => {
-    const target = pendingSettingsNavigate.get(window.webContents.id)
+    const target = pendingSettingsNavigate.get(webContentsId)
     if (!target) return
-    pendingSettingsNavigate.delete(window.webContents.id)
+    if (window.isDestroyed()) return
+    pendingSettingsNavigate.delete(webContentsId)
     window.webContents.send('settings:navigate', target)
   })
 
@@ -180,6 +183,7 @@ app.whenReady().then(async () => {
   })
   ipcMain.handle('desktop:server-status', () => getLocalServerStatus())
   ipcMain.handle('desktop:api-base-url', () => getLocalServerStatus().baseUrl)
+  ipcMain.handle('desktop:auth-token', () => getDesktopAuthToken())
   ipcMain.handle('desktop:default-workspace-path', (_event, rawDisplayName: unknown) => {
     return defaultWorkspacePath(typeof rawDisplayName === 'string' ? rawDisplayName : '')
   })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -184,6 +184,24 @@ app.whenReady().then(async () => {
     return defaultWorkspacePath(typeof rawDisplayName === 'string' ? rawDisplayName : '')
   })
 
+  // Cross-window Pinia Colada query-cache invalidation. Each renderer owns
+  // an independent in-memory cache (separate Vue/Pinia instances per
+  // BrowserWindow), so a mutation in the settings window can't directly
+  // refresh the chat window's bot list. The renderer wraps
+  // `queryCache.invalidateQueries` so that every local invalidation also
+  // posts the (serializable) filter here; we fan it back out to every other
+  // BrowserWindow's webContents, which then re-applies the same
+  // invalidation against its local cache. The sender is excluded so we
+  // don't echo back into the originating window.
+  ipcMain.handle('desktop:broadcast-invalidate', (event, payload: unknown) => {
+    const senderId = event.sender.id
+    for (const target of BrowserWindow.getAllWindows()) {
+      if (target.isDestroyed()) continue
+      if (target.webContents.id === senderId) continue
+      target.webContents.send('desktop:invalidate', payload)
+    }
+  })
+
   chatWindow = createChatWindow()
 
   app.on('activate', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'node:path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import iconPng from '../../resources/icon.png?asset'
+import { defaultWorkspacePath, ensureLocalServer, getLocalServerStatus } from './local-server'
 
 const CHAT_DEFAULTS = { width: 1280, height: 800, minWidth: 960, minHeight: 600 }
 const SETTINGS_DEFAULTS = { width: 1080, height: 720, minWidth: 880, minHeight: 560 }
@@ -153,8 +154,9 @@ function dispatchSettingsNavigate(window: BrowserWindow, target: string): void {
   window.webContents.send('settings:navigate', target)
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   electronApp.setAppUserModelId('ai.memoh.desktop')
+  await ensureLocalServer()
 
   if (process.platform === 'darwin' && app.dock) {
     app.dock.setIcon(iconPng)
@@ -175,6 +177,11 @@ app.whenReady().then(() => {
   ipcMain.handle('window:close-self', (event) => {
     const sender = BrowserWindow.fromWebContents(event.sender)
     sender?.close()
+  })
+  ipcMain.handle('desktop:server-status', () => getLocalServerStatus())
+  ipcMain.handle('desktop:api-base-url', () => getLocalServerStatus().baseUrl)
+  ipcMain.handle('desktop:default-workspace-path', (_event, rawDisplayName: unknown) => {
+    return defaultWorkspacePath(typeof rawDisplayName === 'string' ? rawDisplayName : '')
   })
 
   chatWindow = createChatWindow()

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,7 +1,7 @@
 import { app, dialog } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { appendFileSync, cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
 export const LOCAL_SERVER_PORT = 18731
@@ -54,7 +54,21 @@ function serverCommand(): { command: string, args: string[], cwd: string, config
   }
 }
 
+function logPath(): string {
+  return join(app.getPath('userData'), 'local-server.log')
+}
+
+function appendLog(message: string): void {
+  try {
+    appendFileSync(logPath(), `[${new Date().toISOString()}] ${message}\n`)
+  } catch {
+    // Logging must never block startup.
+  }
+}
+
 function prepareRuntime(command: { cwd: string }): void {
+  mkdirSync(join(command.cwd, 'data', 'local'), { recursive: true })
+  prepareProviders(command.cwd)
   const targetRuntime = join(command.cwd, 'data', 'runtime')
   mkdirSync(targetRuntime, { recursive: true })
 
@@ -76,6 +90,20 @@ function prepareRuntime(command: { cwd: string }): void {
   rmSync(targetRuntime, { recursive: true, force: true })
   mkdirSync(targetRuntime, { recursive: true })
   cpSync(bundledRuntime, targetRuntime, { recursive: true })
+}
+
+function prepareProviders(cwd: string): void {
+  if (is.dev) {
+    return
+  }
+  const bundledProviders = resourcePath('providers')
+  if (!existsSync(bundledProviders)) {
+    throw new Error(`Bundled provider templates not found: ${bundledProviders}`)
+  }
+  const targetProviders = join(cwd, 'conf', 'providers')
+  rmSync(targetProviders, { recursive: true, force: true })
+  mkdirSync(targetProviders, { recursive: true })
+  cpSync(bundledProviders, targetProviders, { recursive: true })
 }
 
 async function probeServer(): Promise<boolean> {
@@ -112,7 +140,7 @@ function spawnServer(): ChildProcess {
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,
     detached: true,
-    stdio: 'ignore',
+    stdio: is.dev ? 'ignore' : ['ignore', 'ignore', 'ignore'],
     env: {
       ...process.env,
       CONFIG_PATH: command.configPath,
@@ -123,18 +151,50 @@ function spawnServer(): ChildProcess {
 }
 
 function runMigrations(command: { command: string, cwd: string, configPath: string }): void {
-  const args = is.dev ? ['run', './cmd/agent', 'migrate', 'up'] : ['migrate', 'up']
+  const result = runServerCommand(command, ['migrate', 'up'])
+  if (result.status === 0) {
+    return
+  }
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+  if (output.includes('Dirty database version 2')) {
+    appendLog('repairing dirty database version 2')
+    const forceResult = runServerCommand(command, ['migrate', 'force', '2'])
+    if (forceResult.status === 0) {
+      const retryResult = runServerCommand(command, ['migrate', 'up'])
+      if (retryResult.status === 0) {
+        return
+      }
+      throw new Error(`local server migration failed after dirty repair: ${formatCommandFailure(retryResult)}`)
+    }
+    throw new Error(`local server migration dirty repair failed: ${formatCommandFailure(forceResult)}`)
+  }
+  throw new Error(`local server migration failed: ${formatCommandFailure(result)}`)
+}
+
+function runServerCommand(
+  command: { command: string, cwd: string, configPath: string },
+  serverArgs: string[],
+): ReturnType<typeof spawnSync> {
+  const args = is.dev ? ['run', './cmd/agent', ...serverArgs] : serverArgs
   const result = spawnSync(command.command, args, {
     cwd: command.cwd,
-    stdio: is.dev ? 'inherit' : 'ignore',
+    encoding: 'utf8',
     env: {
       ...process.env,
       CONFIG_PATH: command.configPath,
     },
   })
-  if (result.status !== 0) {
-    throw new Error('local server migration failed')
+  appendLog(`$ ${command.command} ${args.join(' ')}\nstatus=${String(result.status)} error=${result.error?.message ?? ''}\nstdout:\n${result.stdout ?? ''}\nstderr:\n${result.stderr ?? ''}`)
+  return result
+}
+
+function formatCommandFailure(result: ReturnType<typeof spawnSync>): string {
+  if (result.error) {
+    return result.error.message
   }
+  const stderr = String(result.stderr ?? '').trim()
+  const stdout = String(result.stdout ?? '').trim()
+  return stderr || stdout || `exit status ${String(result.status)}`
 }
 
 export async function ensureLocalServer(): Promise<LocalServerStatus> {
@@ -154,7 +214,7 @@ export async function ensureLocalServer(): Promise<LocalServerStatus> {
   } catch (error) {
     serverReady = false
     serverError = error instanceof Error ? error.message : String(error)
-    dialog.showErrorBox('Memoh server failed to start', serverError)
+    dialog.showErrorBox('Memoh server failed to start', `${serverError}\n\nLog: ${logPath()}`)
   }
   return getLocalServerStatus()
 }

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,7 +1,7 @@
 import { app, dialog } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { appendFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { appendFileSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
 export const LOCAL_SERVER_PORT = 18731
@@ -41,7 +41,7 @@ function serverCommand(): { command: string, args: string[], cwd: string, config
       command: 'go',
       args: ['run', './cmd/agent', 'serve'],
       cwd: root,
-      configPath: join(root, 'conf', 'app.local.toml'),
+      configPath: prepareConfig(root, join(root, 'conf', 'app.local.toml')),
     }
   }
 
@@ -51,7 +51,7 @@ function serverCommand(): { command: string, args: string[], cwd: string, config
     command: binary,
     args: ['serve'],
     cwd,
-    configPath: resourcePath('config', 'app.local.toml'),
+    configPath: prepareConfig(cwd, resourcePath('config', 'app.local.toml')),
   }
 }
 
@@ -71,6 +71,105 @@ function appendLog(message: string): void {
   }
 }
 
+function prepareConfig(cwd: string, sourcePath: string): string {
+  mkdirSync(cwd, { recursive: true })
+  const targetPath = join(cwd, 'config.toml')
+  copyFileSync(sourcePath, targetPath)
+  const home = app.getPath('home')
+  const contents = applyLocalConfigDefaults(readFileSync(targetPath, 'utf8'), cwd, home)
+  writeFileSync(targetPath, contents, { mode: 0o600 })
+  return targetPath
+}
+
+function applyLocalConfigDefaults(contents: string, cwd: string, home: string): string {
+  let next = contents.replaceAll('__HOME__', home)
+  next = setTomlString(next, 'container', 'data_root', toAbsoluteConfigPath(cwd, 'data/local'))
+  next = setTomlString(next, 'container', 'runtime_dir', toAbsoluteConfigPath(cwd, 'data/runtime'))
+  next = setTomlString(next, 'local', 'metadata_root', toAbsoluteConfigPath(cwd, 'data/local/containers'))
+  next = setTomlString(next, 'sqlite', 'path', toAbsoluteConfigPath(cwd, 'data/local/memoh.db'))
+  next = setTomlString(next, 'registry', 'providers_dir', toAbsoluteConfigPath(cwd, 'conf/providers'))
+  return setDockerHostIfEmpty(next, detectDockerHost(home))
+}
+
+function toAbsoluteConfigPath(cwd: string, value: string): string {
+  if (value.startsWith('/')) {
+    return value
+  }
+  return join(cwd, value)
+}
+
+function detectDockerHost(home: string): string {
+  const envHost = process.env.DOCKER_HOST?.trim()
+  if (envHost) {
+    return envHost
+  }
+  const candidates = [
+    join(home, '.docker', 'run', 'docker.sock'),
+    '/var/run/docker.sock',
+  ]
+  for (const socketPath of candidates) {
+    if (existsSync(socketPath)) {
+      return `unix://${socketPath}`
+    }
+  }
+  return ''
+}
+
+function setDockerHostIfEmpty(contents: string, dockerHost: string): string {
+  if (!dockerHost) {
+    return contents
+  }
+  const lines = contents.split(/\r?\n/)
+  let inDocker = false
+  let updated = false
+  const next = lines.map((line) => {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      inDocker = trimmed === '[docker]'
+      return line
+    }
+    if (!inDocker) {
+      return line
+    }
+    const match = line.match(/^(\s*host\s*=\s*)"([^"]*)"(.*)$/)
+    if (!match || match[2].trim() !== '') {
+      return line
+    }
+    updated = true
+    return `${match[1]}"${dockerHost}"${match[3]}`
+  })
+  if (updated) {
+    appendLog(`detected Docker host: ${dockerHost}`)
+  }
+  return next.join('\n')
+}
+
+function setTomlString(contents: string, sectionName: string, key: string, value: string): string {
+  const lines = contents.split(/\r?\n/)
+  let inSection = false
+  let updated = false
+  const next = lines.map((line) => {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      inSection = trimmed === `[${sectionName}]`
+      return line
+    }
+    if (!inSection) {
+      return line
+    }
+    const match = line.match(new RegExp(`^(\\s*${key}\\s*=\\s*)"([^"]*)"(.*)$`))
+    if (!match) {
+      return line
+    }
+    updated = true
+    return `${match[1]}"${value}"${match[3]}`
+  })
+  if (!updated) {
+    appendLog(`config key not found: [${sectionName}].${key}`)
+  }
+  return next.join('\n')
+}
+
 function prepareRuntime(command: { cwd: string }): void {
   mkdirSync(join(command.cwd, 'data', 'local'), { recursive: true })
   prepareProviders(command.cwd)
@@ -81,6 +180,11 @@ function prepareRuntime(command: { cwd: string }): void {
     const result = spawnSync('go', ['build', '-o', join(targetRuntime, 'bridge'), './cmd/bridge'], {
       cwd: command.cwd,
       stdio: 'inherit',
+      env: {
+        ...process.env,
+        GOOS: 'linux',
+        GOARCH: dockerBridgeArch(),
+      },
     })
     if (result.status !== 0) {
       throw new Error('failed to build bridge runtime for local desktop server')
@@ -95,6 +199,17 @@ function prepareRuntime(command: { cwd: string }): void {
   rmSync(targetRuntime, { recursive: true, force: true })
   mkdirSync(targetRuntime, { recursive: true })
   cpSync(bundledRuntime, targetRuntime, { recursive: true })
+}
+
+function dockerBridgeArch(): string {
+  switch (process.arch) {
+    case 'arm64':
+      return 'arm64'
+    case 'x64':
+      return 'amd64'
+    default:
+      return process.arch
+  }
 }
 
 function prepareProviders(cwd: string): void {

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,7 +1,7 @@
 import { app, dialog } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { appendFileSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
 export const LOCAL_SERVER_PORT = 18731
@@ -17,6 +17,21 @@ export interface LocalServerStatus {
   ready: boolean
   managed: boolean
   error?: string
+}
+
+interface ServerIdentity {
+  version: string
+  commitHash: string
+}
+
+interface PingPayload extends ServerIdentity {
+  status?: string
+}
+
+interface ManagedServerPid {
+  pid: number
+  command: string
+  startedAt: string
 }
 
 function repoRoot(): string {
@@ -61,6 +76,10 @@ function currentServerCommand(): { command: string, args: string[], cwd: string,
 
 function logPath(): string {
   return join(app.getPath('userData'), 'local-server.log')
+}
+
+function pidPath(): string {
+  return join(app.getPath('userData'), 'local-server.pid.json')
 }
 
 function appendLog(message: string): void {
@@ -237,16 +256,21 @@ function prepareProviders(cwd: string): void {
   cpSync(bundledProviders, targetProviders, { recursive: true })
 }
 
-async function probeServer(): Promise<boolean> {
+async function probeServer(): Promise<PingPayload | null> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 1000)
   try {
     const response = await fetch(`${LOCAL_SERVER_BASE_URL}/ping`, { signal: controller.signal })
-    if (!response.ok) return false
-    const payload = await response.json() as { status?: string, version?: string }
-    return payload.status === 'ok' && typeof payload.version === 'string'
+    if (!response.ok) return null
+    const payload = await response.json() as { status?: string, version?: string, commit_hash?: string }
+    if (payload.status !== 'ok' || typeof payload.version !== 'string') return null
+    return {
+      status: payload.status,
+      version: payload.version,
+      commitHash: payload.commit_hash ?? '',
+    }
   } catch {
-    return false
+    return null
   } finally {
     clearTimeout(timeout)
   }
@@ -261,8 +285,7 @@ async function waitForServer(timeoutMs = 30_000): Promise<boolean> {
   return false
 }
 
-function spawnServer(): ChildProcess {
-  const command = serverCommand()
+function spawnServer(command = serverCommand()): ChildProcess {
   prepareRuntime(command)
   if (!is.dev && !existsSync(command.command)) {
     throw new Error(`Bundled server binary not found: ${command.command}`)
@@ -278,6 +301,13 @@ function spawnServer(): ChildProcess {
     },
   })
   child.unref()
+  if (typeof child.pid === 'number') {
+    writeManagedServerPid({
+      pid: child.pid,
+      command: `${command.command} ${command.args.join(' ')}`,
+      startedAt: new Date().toISOString(),
+    })
+  }
   return child
 }
 
@@ -328,15 +358,126 @@ function formatCommandFailure(result: ReturnType<typeof spawnSync>): string {
   return stderr || stdout || `exit status ${String(result.status)}`
 }
 
-export async function ensureLocalServer(): Promise<LocalServerStatus> {
-  if (await probeServer()) {
-    serverReady = true
-    serverError = null
-    return getLocalServerStatus()
+function bundledServerIdentity(command: { command: string, cwd: string, configPath: string }): ServerIdentity {
+  const result = runServerCommand(command, ['version'])
+  if (result.status !== 0) {
+    throw new Error(`failed to inspect bundled server version: ${formatCommandFailure(result)}`)
   }
+  return parseVersionOutput(String(result.stdout ?? ''))
+}
 
+function parseVersionOutput(output: string): ServerIdentity {
+  const line = output.trim().split(/\r?\n/).find(Boolean) ?? ''
+  const match = line.match(/^memoh-server\s+([^\s(]+)(?:\s+\(([^)]+)\))?/)
+  if (!match) {
+    return { version: '', commitHash: '' }
+  }
+  return { version: match[1] ?? '', commitHash: match[2] ?? '' }
+}
+
+function sameServerIdentity(existing: ServerIdentity, bundled: ServerIdentity): boolean {
+  if (bundled.commitHash) {
+    return existing.commitHash === bundled.commitHash
+  }
+  if (bundled.version) {
+    return existing.version === bundled.version
+  }
+  return true
+}
+
+function identityLabel(identity: ServerIdentity): string {
+  return identity.commitHash ? `${identity.version} (${identity.commitHash})` : identity.version || 'unknown'
+}
+
+function writeManagedServerPid(info: ManagedServerPid): void {
   try {
-    startedProcess = spawnServer()
+    writeFileSync(pidPath(), JSON.stringify(info, null, 2), { mode: 0o600 })
+  } catch (error) {
+    appendLog(`failed to write pid file: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function readManagedServerPid(): ManagedServerPid | null {
+  try {
+    const payload = JSON.parse(readFileSync(pidPath(), 'utf8')) as Partial<ManagedServerPid>
+    if (typeof payload.pid !== 'number' || payload.pid <= 0) return null
+    return {
+      pid: payload.pid,
+      command: typeof payload.command === 'string' ? payload.command : '',
+      startedAt: typeof payload.startedAt === 'string' ? payload.startedAt : '',
+    }
+  } catch {
+    return null
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<boolean> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (!isProcessAlive(pid)) return true
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  return false
+}
+
+async function stopManagedServer(): Promise<boolean> {
+  const info = readManagedServerPid()
+  if (!info || !isProcessAlive(info.pid)) {
+    return false
+  }
+  appendLog(`stopping managed local server pid=${info.pid}`)
+  try {
+    process.kill(info.pid, 'SIGTERM')
+  } catch (error) {
+    appendLog(`failed to terminate managed local server: ${error instanceof Error ? error.message : String(error)}`)
+    return false
+  }
+  if (!(await waitForProcessExit(info.pid))) {
+    appendLog(`managed local server did not exit after SIGTERM, killing pid=${info.pid}`)
+    try {
+      process.kill(info.pid, 'SIGKILL')
+    } catch (error) {
+      appendLog(`failed to kill managed local server: ${error instanceof Error ? error.message : String(error)}`)
+      return false
+    }
+    await waitForProcessExit(info.pid)
+  }
+  try {
+    unlinkSync(pidPath())
+  } catch {
+    // Stale pid files are harmless.
+  }
+  return true
+}
+
+export async function ensureLocalServer(): Promise<LocalServerStatus> {
+  try {
+    const command = serverCommand()
+    const bundledIdentity = bundledServerIdentity(command)
+    const existing = await probeServer()
+    if (existing) {
+      if (sameServerIdentity(existing, bundledIdentity)) {
+        serverReady = true
+        serverError = null
+        await ensureDesktopAuthToken()
+        return getLocalServerStatus()
+      }
+      appendLog(`local server version mismatch: running=${identityLabel(existing)} bundled=${identityLabel(bundledIdentity)}`)
+      if (!(await stopManagedServer())) {
+        throw new Error(`Local server on ${LOCAL_SERVER_BASE_URL} is ${identityLabel(existing)}, but this desktop bundles ${identityLabel(bundledIdentity)}. Stop the old local server and reopen Memoh.`)
+      }
+    }
+
+    startedProcess = spawnServer(command)
     if (!(await waitForServer())) {
       throw new Error(`Local server did not become ready on ${LOCAL_SERVER_BASE_URL}`)
     }

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -189,6 +189,7 @@ function prepareRuntime(command: { cwd: string }): void {
     if (result.status !== 0) {
       throw new Error('failed to build bridge runtime for local desktop server')
     }
+    syncBridgeTemplates(command.cwd, targetRuntime)
     return
   }
 
@@ -199,6 +200,16 @@ function prepareRuntime(command: { cwd: string }): void {
   rmSync(targetRuntime, { recursive: true, force: true })
   mkdirSync(targetRuntime, { recursive: true })
   cpSync(bundledRuntime, targetRuntime, { recursive: true })
+}
+
+function syncBridgeTemplates(cwd: string, targetRuntime: string): void {
+  const templateSource = join(cwd, 'cmd', 'bridge', 'template')
+  const templateTarget = join(targetRuntime, 'templates')
+  if (!existsSync(templateSource)) {
+    throw new Error(`Bridge templates not found: ${templateSource}`)
+  }
+  rmSync(templateTarget, { recursive: true, force: true })
+  cpSync(templateSource, templateTarget, { recursive: true })
 }
 
 function dockerBridgeArch(): string {

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,0 +1,175 @@
+import { app, dialog } from 'electron'
+import { is } from '@electron-toolkit/utils'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+export const LOCAL_SERVER_PORT = 18731
+export const LOCAL_SERVER_BASE_URL = `http://127.0.0.1:${LOCAL_SERVER_PORT}`
+
+let startedProcess: ChildProcess | null = null
+let serverReady = false
+let serverError: string | null = null
+
+export interface LocalServerStatus {
+  baseUrl: string
+  ready: boolean
+  managed: boolean
+  error?: string
+}
+
+function repoRoot(): string {
+  if (is.dev) {
+    return resolve(process.cwd(), '..', '..')
+  }
+  return resolve(app.getAppPath(), '..', '..')
+}
+
+function serverBinaryName(): string {
+  return process.platform === 'win32' ? 'memoh-server.exe' : 'memoh-server'
+}
+
+function resourcePath(...segments: string[]): string {
+  return join(process.resourcesPath, ...segments)
+}
+
+function serverCommand(): { command: string, args: string[], cwd: string, configPath: string } {
+  if (is.dev) {
+    const root = repoRoot()
+    return {
+      command: 'go',
+      args: ['run', './cmd/agent', 'serve'],
+      cwd: root,
+      configPath: join(root, 'conf', 'app.local.toml'),
+    }
+  }
+
+  const cwd = app.getPath('userData')
+  const binary = resourcePath('server', serverBinaryName())
+  return {
+    command: binary,
+    args: ['serve'],
+    cwd,
+    configPath: resourcePath('config', 'app.local.toml'),
+  }
+}
+
+function prepareRuntime(command: { cwd: string }): void {
+  const targetRuntime = join(command.cwd, 'data', 'runtime')
+  mkdirSync(targetRuntime, { recursive: true })
+
+  if (is.dev) {
+    const result = spawnSync('go', ['build', '-o', join(targetRuntime, 'bridge'), './cmd/bridge'], {
+      cwd: command.cwd,
+      stdio: 'inherit',
+    })
+    if (result.status !== 0) {
+      throw new Error('failed to build bridge runtime for local desktop server')
+    }
+    return
+  }
+
+  const bundledRuntime = resourcePath('runtime')
+  if (!existsSync(bundledRuntime)) {
+    throw new Error(`Bundled runtime not found: ${bundledRuntime}`)
+  }
+  rmSync(targetRuntime, { recursive: true, force: true })
+  mkdirSync(targetRuntime, { recursive: true })
+  cpSync(bundledRuntime, targetRuntime, { recursive: true })
+}
+
+async function probeServer(): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 1000)
+  try {
+    const response = await fetch(`${LOCAL_SERVER_BASE_URL}/ping`, { signal: controller.signal })
+    if (!response.ok) return false
+    const payload = await response.json() as { status?: string, version?: string }
+    return payload.status === 'ok' && typeof payload.version === 'string'
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function waitForServer(timeoutMs = 30_000): Promise<boolean> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await probeServer()) return true
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+  return false
+}
+
+function spawnServer(): ChildProcess {
+  const command = serverCommand()
+  prepareRuntime(command)
+  if (!is.dev && !existsSync(command.command)) {
+    throw new Error(`Bundled server binary not found: ${command.command}`)
+  }
+  runMigrations(command)
+  const child = spawn(command.command, command.args, {
+    cwd: command.cwd,
+    detached: true,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      CONFIG_PATH: command.configPath,
+    },
+  })
+  child.unref()
+  return child
+}
+
+function runMigrations(command: { command: string, cwd: string, configPath: string }): void {
+  const args = is.dev ? ['run', './cmd/agent', 'migrate', 'up'] : ['migrate', 'up']
+  const result = spawnSync(command.command, args, {
+    cwd: command.cwd,
+    stdio: is.dev ? 'inherit' : 'ignore',
+    env: {
+      ...process.env,
+      CONFIG_PATH: command.configPath,
+    },
+  })
+  if (result.status !== 0) {
+    throw new Error('local server migration failed')
+  }
+}
+
+export async function ensureLocalServer(): Promise<LocalServerStatus> {
+  if (await probeServer()) {
+    serverReady = true
+    serverError = null
+    return getLocalServerStatus()
+  }
+
+  try {
+    startedProcess = spawnServer()
+    if (!(await waitForServer())) {
+      throw new Error(`Local server did not become ready on ${LOCAL_SERVER_BASE_URL}`)
+    }
+    serverReady = true
+    serverError = null
+  } catch (error) {
+    serverReady = false
+    serverError = error instanceof Error ? error.message : String(error)
+    dialog.showErrorBox('Memoh server failed to start', serverError)
+  }
+  return getLocalServerStatus()
+}
+
+export function getLocalServerStatus(): LocalServerStatus {
+  return {
+    baseUrl: LOCAL_SERVER_BASE_URL,
+    ready: serverReady,
+    managed: startedProcess != null,
+    error: serverError ?? undefined,
+  }
+}
+
+export function defaultWorkspacePath(displayName: string): string {
+  const raw = displayName.trim() || 'bot'
+  const safe = raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[.-]+|[.-]+$/g, '') || 'bot'
+  return join(app.getPath('home'), '.memoh', 'workspaces', safe)
+}

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,7 +1,7 @@
 import { app, dialog } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { appendFileSync, cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { appendFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
 export const LOCAL_SERVER_PORT = 18731
@@ -10,6 +10,7 @@ export const LOCAL_SERVER_BASE_URL = `http://127.0.0.1:${LOCAL_SERVER_PORT}`
 let startedProcess: ChildProcess | null = null
 let serverReady = false
 let serverError: string | null = null
+let desktopAuthToken: string | null = null
 
 export interface LocalServerStatus {
   baseUrl: string
@@ -52,6 +53,10 @@ function serverCommand(): { command: string, args: string[], cwd: string, config
     cwd,
     configPath: resourcePath('config', 'app.local.toml'),
   }
+}
+
+function currentServerCommand(): { command: string, args: string[], cwd: string, configPath: string } {
+  return serverCommand()
 }
 
 function logPath(): string {
@@ -211,12 +216,23 @@ export async function ensureLocalServer(): Promise<LocalServerStatus> {
     }
     serverReady = true
     serverError = null
+    await ensureDesktopAuthToken()
   } catch (error) {
     serverReady = false
     serverError = error instanceof Error ? error.message : String(error)
     dialog.showErrorBox('Memoh server failed to start', `${serverError}\n\nLog: ${logPath()}`)
   }
   return getLocalServerStatus()
+}
+
+export async function getDesktopAuthToken(): Promise<string> {
+  if (!serverReady) {
+    await ensureLocalServer()
+  }
+  if (!desktopAuthToken) {
+    await ensureDesktopAuthToken()
+  }
+  return desktopAuthToken ?? ''
 }
 
 export function getLocalServerStatus(): LocalServerStatus {
@@ -232,4 +248,57 @@ export function defaultWorkspacePath(displayName: string): string {
   const raw = displayName.trim() || 'bot'
   const safe = raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[.-]+|[.-]+$/g, '') || 'bot'
   return join(app.getPath('home'), '.memoh', 'workspaces', safe)
+}
+
+async function ensureDesktopAuthToken(): Promise<void> {
+  if (desktopAuthToken) {
+    return
+  }
+  const command = currentServerCommand()
+  const admin = readAdminCredentials(command.configPath)
+  const response = await fetch(`${LOCAL_SERVER_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(admin),
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`desktop auto login failed: HTTP ${response.status} ${text}`)
+  }
+  const payload = await response.json() as { access_token?: string }
+  if (!payload.access_token) {
+    throw new Error('desktop auto login failed: response did not include access_token')
+  }
+  desktopAuthToken = payload.access_token
+}
+
+function readAdminCredentials(configPath: string): { username: string, password: string } {
+  const raw = readFileSync(configPath, 'utf8')
+  let inAdmin = false
+  let username = ''
+  let password = ''
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      inAdmin = trimmed === '[admin]'
+      continue
+    }
+    if (!inAdmin || trimmed === '' || trimmed.startsWith('#')) {
+      continue
+    }
+    const match = trimmed.match(/^([A-Za-z0-9_]+)\s*=\s*"(.*)"\s*$/)
+    if (!match) {
+      continue
+    }
+    if (match[1] === 'username') {
+      username = match[2]
+    }
+    if (match[1] === 'password') {
+      password = match[2]
+    }
+  }
+  if (!username || !password) {
+    throw new Error(`desktop auto login failed: missing [admin] username/password in ${configPath}`)
+  }
+  return { username, password }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,7 @@ const api = {
     getServerStatus: (): Promise<{ baseUrl: string, ready: boolean, managed: boolean, error?: string }> =>
       ipcRenderer.invoke('desktop:server-status'),
     apiBaseUrl: (): Promise<string> => ipcRenderer.invoke('desktop:api-base-url'),
+    authToken: (): Promise<string> => ipcRenderer.invoke('desktop:auth-token'),
     defaultWorkspacePath: (displayName: string): Promise<string> =>
       ipcRenderer.invoke('desktop:default-workspace-path', displayName),
     // Tell the main process to fan a query-cache invalidation out to every

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,6 +5,13 @@ import { electronAPI } from '@electron-toolkit/preload'
 // full security boundary between chromium renderer processes and the
 // node-privileged main process.
 const api = {
+  desktop: {
+    getServerStatus: (): Promise<{ baseUrl: string, ready: boolean, managed: boolean, error?: string }> =>
+      ipcRenderer.invoke('desktop:server-status'),
+    apiBaseUrl: (): Promise<string> => ipcRenderer.invoke('desktop:api-base-url'),
+    defaultWorkspacePath: (displayName: string): Promise<string> =>
+      ipcRenderer.invoke('desktop:default-workspace-path', displayName),
+  },
   window: {
     // Focus (or create) the settings window. When `target` is supplied —
     // e.g. `/settings/bots/<botId>?tab=mcp` resolved by the chat router —

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,19 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
+// Cross-window query-cache invalidation payload. Mirrors the subset of
+// Pinia Colada's `UseQueryEntryFilter` that survives structured-clone
+// serialization across the IPC boundary (no functions / predicates).
+export interface CrossWindowInvalidatePayload {
+  filters?: {
+    key?: unknown
+    exact?: boolean
+    stale?: boolean | null
+    status?: unknown
+  }
+  refetchActive?: boolean | 'all'
+}
+
 // Renderer-facing API surface. Keep this intentionally small — it is the
 // full security boundary between chromium renderer processes and the
 // node-privileged main process.
@@ -11,6 +24,18 @@ const api = {
     apiBaseUrl: (): Promise<string> => ipcRenderer.invoke('desktop:api-base-url'),
     defaultWorkspacePath: (displayName: string): Promise<string> =>
       ipcRenderer.invoke('desktop:default-workspace-path', displayName),
+    // Tell the main process to fan a query-cache invalidation out to every
+    // other BrowserWindow. Used by `setupCrossWindowCacheSync` to mirror
+    // mutations performed in one renderer onto siblings.
+    broadcastInvalidate: (payload: CrossWindowInvalidatePayload): Promise<void> =>
+      ipcRenderer.invoke('desktop:broadcast-invalidate', payload),
+    // Subscribe to invalidation events forwarded from sibling windows.
+    // Listener lives for the entire window lifetime.
+    onInvalidate: (cb: (payload: CrossWindowInvalidatePayload) => void): void => {
+      ipcRenderer.on('desktop:invalidate', (_event: IpcRendererEvent, payload: CrossWindowInvalidatePayload) => {
+        cb(payload)
+      })
+    },
   },
   window: {
     // Focus (or create) the settings window. When `target` is supplied —

--- a/apps/desktop/src/renderer/src/cross-window-cache-sync.ts
+++ b/apps/desktop/src/renderer/src/cross-window-cache-sync.ts
@@ -1,0 +1,79 @@
+// Cross-window Pinia Colada query-cache synchronization.
+//
+// Desktop runs chat and settings as two separate BrowserWindows, each with
+// its own Vue/Pinia/PiniaColada instance. A mutation performed in one
+// window therefore only invalidates that window's in-memory query cache —
+// e.g. creating a bot in settings leaves the chat window's bot list stale
+// until the user manually reloads.
+//
+// We wrap `queryCache.invalidateQueries` so every local invalidation also
+// asks the main process to broadcast the (serializable) filter to every
+// other BrowserWindow. Sibling windows replay the invalidation against
+// their own caches via the un-wrapped original method, which avoids
+// re-broadcasting and prevents echo loops.
+
+import type { useQueryCache } from '@pinia/colada'
+import type { CrossWindowInvalidatePayload } from '../../preload'
+
+type QueryCache = ReturnType<typeof useQueryCache>
+type InvalidateQueries = QueryCache['invalidateQueries']
+type InvalidateFilters = Parameters<InvalidateQueries>[0]
+type InvalidateRefetch = Parameters<InvalidateQueries>[1]
+
+// Pull only structured-clone-safe fields off the filter. If the caller
+// passed a `predicate` function we can't ship it across the IPC boundary;
+// in that case we skip the broadcast (returning `null`) — the local
+// invalidation still happens, only the cross-window mirror is dropped.
+function toSerializableFilter(
+  filters: InvalidateFilters,
+): CrossWindowInvalidatePayload['filters'] | null {
+  if (filters == null) return undefined
+  const raw = filters as Record<string, unknown>
+  if (typeof raw.predicate === 'function') return null
+
+  const out: NonNullable<CrossWindowInvalidatePayload['filters']> = {}
+  if ('key' in raw && raw.key !== undefined) {
+    try {
+      out.key = JSON.parse(JSON.stringify(raw.key)) as unknown
+    }
+    catch {
+      return null
+    }
+  }
+  if (typeof raw.exact === 'boolean') out.exact = raw.exact
+  if (raw.stale === null || typeof raw.stale === 'boolean') out.stale = raw.stale as boolean | null
+  if (raw.status !== undefined) out.status = raw.status
+  return out
+}
+
+function toSerializableRefetch(refetch: InvalidateRefetch): CrossWindowInvalidatePayload['refetchActive'] {
+  if (refetch === true || refetch === false || refetch === 'all') return refetch
+  return undefined
+}
+
+export function setupCrossWindowCacheSync(queryCache: QueryCache): void {
+  const desktop = window.api?.desktop
+  if (!desktop || typeof desktop.broadcastInvalidate !== 'function' || typeof desktop.onInvalidate !== 'function') {
+    return
+  }
+
+  const original = queryCache.invalidateQueries.bind(queryCache) as InvalidateQueries
+
+  const wrapped: InvalidateQueries = (filters, refetchActive) => {
+    const result = original(filters, refetchActive)
+    const serializableFilters = toSerializableFilter(filters)
+    if (serializableFilters !== null) {
+      void desktop.broadcastInvalidate({
+        filters: serializableFilters,
+        refetchActive: toSerializableRefetch(refetchActive),
+      })
+    }
+    return result
+  }
+
+  queryCache.invalidateQueries = wrapped
+
+  desktop.onInvalidate((payload) => {
+    void original(payload?.filters as InvalidateFilters, payload?.refetchActive)
+  })
+}

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -19,13 +19,18 @@ import 'katex/dist/katex.min.css'
 import App from './chat/App.vue'
 import router from './chat/router'
 
-setupApiClient({
-  onUnauthorized: () => router.replace({ name: 'Login' }),
-})
+async function bootstrap() {
+  setupApiClient({
+    baseUrl: await window.api.desktop.apiBaseUrl(),
+    onUnauthorized: () => router.replace({ name: 'Login' }),
+  })
 
-createApp(App)
-  .use(createPinia().use(piniaPluginPersistedstate))
-  .use(PiniaColada)
-  .use(router)
-  .use(i18n)
-  .mount('#app')
+  createApp(App)
+    .use(createPinia().use(piniaPluginPersistedstate))
+    .use(PiniaColada)
+    .use(router)
+    .use(i18n)
+    .mount('#app')
+}
+
+void bootstrap()

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -21,6 +21,10 @@ import router from './chat/router'
 import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
 
 async function bootstrap() {
+  const token = await window.api.desktop.authToken()
+  if (token) {
+    localStorage.setItem('token', token)
+  }
   setupApiClient({
     baseUrl: await window.api.desktop.apiBaseUrl(),
     onUnauthorized: () => router.replace({ name: 'Login' }),

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -4,7 +4,7 @@
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import { PiniaColada } from '@pinia/colada'
+import { PiniaColada, useQueryCache } from '@pinia/colada'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import i18n from '@memohai/web/i18n'
@@ -18,6 +18,7 @@ import 'katex/dist/katex.min.css'
 
 import App from './chat/App.vue'
 import router from './chat/router'
+import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
 
 async function bootstrap() {
   setupApiClient({
@@ -25,12 +26,17 @@ async function bootstrap() {
     onUnauthorized: () => router.replace({ name: 'Login' }),
   })
 
-  createApp(App)
+  const app = createApp(App)
     .use(createPinia().use(piniaPluginPersistedstate))
     .use(PiniaColada)
     .use(router)
     .use(i18n)
-    .mount('#app')
+
+  // Bridge query-cache invalidations between chat and settings windows.
+  // Must run after `PiniaColada` is installed so the store is registered.
+  setupCrossWindowCacheSync(useQueryCache())
+
+  app.mount('#app')
 }
 
 void bootstrap()

--- a/apps/desktop/src/renderer/src/pages/bots/components/create-bot.vue
+++ b/apps/desktop/src/renderer/src/pages/bots/components/create-bot.vue
@@ -1,0 +1,355 @@
+<template>
+  <Dialog v-model:open="open">
+    <DialogTrigger as-child>
+      <slot name="trigger">
+        <Button variant="default">
+          <Plus class="mr-1.5" />
+          {{ $t('bots.createBot') }}
+        </Button>
+      </slot>
+    </DialogTrigger>
+    <DialogContent class="sm:max-w-md">
+      <form @submit="handleSubmit">
+        <DialogHeader>
+          <DialogTitle>{{ $t('bots.createBot') }}</DialogTitle>
+          <DialogDescription>
+            <Separator class="my-4" />
+          </DialogDescription>
+        </DialogHeader>
+
+        <div class="flex flex-col gap-4">
+          <FormField
+            v-slot="{ componentField }"
+            name="display_name"
+          >
+            <FormItem>
+              <Label class="mb-2">{{ $t('bots.displayName') }}</Label>
+              <FormControl>
+                <Input
+                  type="text"
+                  :placeholder="$t('bots.displayNamePlaceholder')"
+                  v-bind="componentField"
+                />
+              </FormControl>
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-slot="{ componentField }"
+            name="avatar_url"
+          >
+            <FormItem>
+              <Label class="mb-2">
+                {{ $t('bots.avatarUrl') }}
+                <span class="text-muted-foreground text-xs ml-1">({{ $t('common.optional') }})</span>
+              </Label>
+              <FormControl>
+                <Input
+                  type="text"
+                  :placeholder="$t('bots.avatarUrlPlaceholder')"
+                  v-bind="componentField"
+                />
+              </FormControl>
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-slot="{ value, handleChange }"
+            name="timezone"
+          >
+            <FormItem>
+              <Label class="mb-2">
+                {{ $t('bots.timezone') }}
+                <span class="text-muted-foreground text-xs ml-1">({{ $t('common.optional') }})</span>
+              </Label>
+              <FormControl>
+                <TimezoneSelect
+                  :model-value="value || emptyTimezoneValue"
+                  :placeholder="$t('bots.timezonePlaceholder')"
+                  allow-empty
+                  :empty-label="$t('bots.timezoneInherited')"
+                  @update:model-value="(val: string) => handleChange(val === emptyTimezoneValue ? '' : val)"
+                />
+              </FormControl>
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-slot="{ value, handleChange }"
+            name="acl_preset"
+          >
+            <FormItem>
+              <div class="mb-2 flex items-center gap-2">
+                <Label>{{ $t('bots.aclPreset') }}</Label>
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      class="size-5 text-muted-foreground hover:text-foreground"
+                      :aria-label="$t('bots.aclPresetHelp')"
+                    >
+                      <CircleHelp class="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent class="max-w-80 text-left leading-relaxed">
+                    {{ $t('bots.aclPresetHelp') }}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <FormControl>
+                <Select
+                  :model-value="value || defaultAclPreset"
+                  @update:model-value="(nextValue: string) => handleChange(nextValue)"
+                >
+                  <SelectTrigger class="w-full">
+                    <SelectValue :placeholder="$t('bots.aclPreset')" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem
+                      v-for="preset in aclPresetOptions"
+                      :key="preset.value"
+                      :value="preset.value"
+                    >
+                      {{ $t(preset.titleKey) }}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <p
+                v-if="getAclPresetDescription(value || defaultAclPreset)"
+                class="text-xs text-muted-foreground"
+              >
+                {{ getAclPresetDescription(value || defaultAclPreset) }}
+              </p>
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-if="localWorkspaceEnabled"
+            v-slot="{ value, handleChange }"
+            name="workspace_backend"
+          >
+            <FormItem>
+              <Label class="mb-2">{{ $t('bots.workspaceBackend') }}</Label>
+              <FormControl>
+                <Select
+                  :model-value="value || 'container'"
+                  @update:model-value="(nextValue: string) => handleChange(nextValue)"
+                >
+                  <SelectTrigger class="w-full">
+                    <SelectValue :placeholder="$t('bots.workspaceBackend')" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="container">
+                      {{ $t('bots.workspaceBackends.container') }}
+                    </SelectItem>
+                    <SelectItem value="local">
+                      {{ $t('bots.workspaceBackends.local') }}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <p class="text-xs text-muted-foreground">
+                {{ $t('bots.workspaceBackendHint') }}
+              </p>
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-if="localWorkspaceEnabled && form.values.workspace_backend === 'local'"
+            v-slot="{ componentField }"
+            name="local_workspace_path"
+          >
+            <FormItem>
+              <Label class="mb-2">{{ $t('bots.localWorkspacePath') }}</Label>
+              <FormControl>
+                <Input
+                  type="text"
+                  :placeholder="$t('bots.localWorkspacePathPlaceholder')"
+                  v-bind="componentField"
+                  @input="localPathTouched = true"
+                />
+              </FormControl>
+              <p class="text-xs text-muted-foreground">
+                {{ $t('bots.localWorkspaceWarning') }}
+              </p>
+            </FormItem>
+          </FormField>
+
+          <div class="rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            {{ form.values.workspace_backend === 'local' ? $t('bots.createBotLocalHint') : $t('bots.createBotWaitHint') }}
+          </div>
+        </div>
+
+        <DialogFooter class="mt-6">
+          <DialogClose as-child>
+            <Button variant="outline">
+              {{ $t('common.cancel') }}
+            </Button>
+          </DialogClose>
+          <Button
+            type="submit"
+            :disabled="!form.meta.value.valid || submitLoading"
+          >
+            <Spinner v-if="submitLoading" />
+            {{ $t('bots.createBot') }}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  FormControl,
+  FormField,
+  FormItem,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  Spinner,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@memohai/ui'
+import { CircleHelp, Plus } from 'lucide-vue-next'
+import { useMutation, useQueryCache } from '@pinia/colada'
+import { postBotsMutation, getBotsQueryKey } from '@memohai/sdk/colada'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { computed, watch, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import z from 'zod'
+import { useDialogMutation } from '@memohai/web/composables/useDialogMutation'
+import { aclPresetOptions, defaultAclPreset } from '@memohai/web/constants/acl-presets'
+import TimezoneSelect from '@memohai/web/components/timezone-select/index.vue'
+import { emptyTimezoneValue } from '@memohai/web/utils/timezones'
+import { useCapabilitiesStore } from '@memohai/web/store/capabilities'
+
+const open = defineModel<boolean>('open', { default: false })
+const { t } = useI18n()
+const { run } = useDialogMutation()
+const capabilities = useCapabilitiesStore()
+void capabilities.load()
+
+const localWorkspaceEnabled = computed(() => capabilities.localWorkspaceEnabled)
+const localPathTouched = ref(false)
+
+const formSchema = toTypedSchema(z.object({
+  display_name: z.string().min(1),
+  avatar_url: z.string().optional(),
+  timezone: z.string().optional(),
+  acl_preset: z.string().min(1),
+  workspace_backend: z.enum(['container', 'local']),
+  local_workspace_path: z.string().optional(),
+}))
+
+const form = useForm({
+  validationSchema: formSchema,
+  initialValues: {
+    display_name: '',
+    avatar_url: '',
+    timezone: '',
+    acl_preset: defaultAclPreset,
+    workspace_backend: 'container',
+    local_workspace_path: '',
+  },
+})
+
+const queryCache = useQueryCache()
+const { mutateAsync: createBot, isLoading: submitLoading } = useMutation({
+  ...postBotsMutation(),
+  onSettled: () => queryCache.invalidateQueries({ key: getBotsQueryKey() }),
+})
+
+function getAclPresetOption(value?: string) {
+  const presetValue = value || defaultAclPreset
+  return aclPresetOptions.find(option => option.value === presetValue)
+}
+
+function getAclPresetDescriptionKey(value?: string) {
+  return getAclPresetOption(value)?.descriptionKey
+}
+
+function getAclPresetDescription(value?: string) {
+  const descriptionKey = getAclPresetDescriptionKey(value)
+  return descriptionKey ? t(descriptionKey) : ''
+}
+
+async function refreshDefaultWorkspacePath() {
+  if (!localWorkspaceEnabled.value || form.values.workspace_backend !== 'local' || localPathTouched.value) return
+  const displayName = form.values.display_name?.trim()
+  if (!displayName) return
+  const path = await window.api.desktop.defaultWorkspacePath(displayName)
+  form.setFieldValue('local_workspace_path', path)
+}
+
+watch(() => [form.values.display_name, form.values.workspace_backend] as const, () => {
+  void refreshDefaultWorkspacePath()
+})
+
+watch(open, (val) => {
+  if (val) {
+    localPathTouched.value = false
+    form.resetForm({
+      values: {
+        display_name: '',
+        avatar_url: '',
+        timezone: '',
+        acl_preset: defaultAclPreset,
+        workspace_backend: localWorkspaceEnabled.value ? 'local' : 'container',
+        local_workspace_path: '',
+      },
+    })
+  } else {
+    form.resetForm()
+  }
+})
+
+const handleSubmit = form.handleSubmit(async (values) => {
+  const metadata = values.workspace_backend === 'local'
+    ? {
+        workspace: {
+          backend: 'local',
+          local_workspace_path: values.local_workspace_path,
+        },
+      }
+    : undefined
+
+  await run(
+    () => createBot({
+      body: {
+        display_name: values.display_name,
+        avatar_url: values.avatar_url || undefined,
+        timezone: values.timezone || undefined,
+        is_active: true,
+        acl_preset: values.acl_preset,
+        metadata,
+      },
+    }),
+    {
+      fallbackMessage: t('common.saveFailed'),
+      onSuccess: () => {
+        open.value = false
+      },
+    },
+  )
+})
+</script>

--- a/apps/desktop/src/renderer/src/pages/bots/index.vue
+++ b/apps/desktop/src/renderer/src/pages/bots/index.vue
@@ -1,0 +1,108 @@
+<template>
+  <section class="p-4 mx-auto">
+    <div class="flex items-center justify-between mb-6 flex-wrap">
+      <h2 class="text-xs font-medium max-md:hidden">
+        {{ $t('bots.title') }}
+      </h2>
+      <div class="flex items-center gap-3">
+        <div class="relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground size-3.5" />
+          <Input
+            v-model="searchText"
+            :placeholder="$t('bots.searchPlaceholder')"
+            class="pl-9 w-64"
+          />
+        </div>
+        <CreateBot v-model:open="dialogOpen" />
+      </div>
+    </div>
+
+    <div
+      v-if="filteredBots.length > 0"
+      class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    >
+      <BotCard
+        v-for="bot in filteredBots"
+        :key="bot.id"
+        :bot="bot"
+      />
+    </div>
+
+    <Empty
+      v-else-if="!isLoading"
+      class="mt-20 flex flex-col items-center justify-center"
+    >
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Bot />
+        </EmptyMedia>
+      </EmptyHeader>
+      <EmptyTitle>{{ $t('bots.emptyTitle') }}</EmptyTitle>
+      <EmptyDescription>{{ $t('bots.emptyDescription') }}</EmptyDescription>
+      <EmptyContent />
+    </Empty>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Input,
+} from '@memohai/ui'
+import { Bot, Search } from 'lucide-vue-next'
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { useQuery, useQueryCache } from '@pinia/colada'
+import { getBotsQuery, getBotsQueryKey } from '@memohai/sdk/colada'
+import BotCard from '@memohai/web/pages/bots/components/bot-card.vue'
+import CreateBot from './components/create-bot.vue'
+
+const searchText = ref('')
+const dialogOpen = ref(false)
+const queryCache = useQueryCache()
+
+const { data: botData, isLoading } = useQuery(getBotsQuery())
+
+const allBots = computed(() => botData.value?.items ?? [])
+
+const filteredBots = computed(() => {
+  const keyword = searchText.value.trim().toLowerCase()
+  if (!keyword) return allBots.value
+  return allBots.value.filter(bot =>
+    bot.display_name?.toLowerCase().includes(keyword)
+    || bot.id?.toLowerCase().includes(keyword),
+  )
+})
+
+const hasPendingBots = computed(() =>
+  allBots.value.some(bot => bot.status === 'creating' || bot.status === 'deleting'),
+)
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+watch(hasPendingBots, (pending) => {
+  if (pending) {
+    if (pollTimer == null) {
+      pollTimer = setInterval(() => {
+        queryCache.invalidateQueries({ key: getBotsQueryKey() })
+      }, 2000)
+    }
+    return
+  }
+  if (pollTimer != null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}, { immediate: true })
+
+onUnmounted(() => {
+  if (pollTimer != null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+})
+</script>

--- a/apps/desktop/src/renderer/src/settings.ts
+++ b/apps/desktop/src/renderer/src/settings.ts
@@ -4,7 +4,7 @@
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import { PiniaColada } from '@pinia/colada'
+import { PiniaColada, useQueryCache } from '@pinia/colada'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import i18n from '@memohai/web/i18n'
@@ -18,6 +18,7 @@ import 'katex/dist/katex.min.css'
 
 import App from './settings/App.vue'
 import router from './settings/router'
+import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
 
 async function bootstrap() {
   setupApiClient({
@@ -38,12 +39,17 @@ async function bootstrap() {
     void router.push(target)
   })
 
-  createApp(App)
+  const app = createApp(App)
     .use(createPinia().use(piniaPluginPersistedstate))
     .use(PiniaColada)
     .use(router)
     .use(i18n)
-    .mount('#app')
+
+  // Bridge query-cache invalidations between chat and settings windows.
+  // Must run after `PiniaColada` is installed so the store is registered.
+  setupCrossWindowCacheSync(useQueryCache())
+
+  app.mount('#app')
 }
 
 void bootstrap()

--- a/apps/desktop/src/renderer/src/settings.ts
+++ b/apps/desktop/src/renderer/src/settings.ts
@@ -21,6 +21,10 @@ import router from './settings/router'
 import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
 
 async function bootstrap() {
+  const token = await window.api.desktop.authToken()
+  if (token) {
+    localStorage.setItem('token', token)
+  }
   setupApiClient({
     baseUrl: await window.api.desktop.apiBaseUrl(),
     // Settings is a satellite window — it doesn't host the login screen.

--- a/apps/desktop/src/renderer/src/settings.ts
+++ b/apps/desktop/src/renderer/src/settings.ts
@@ -19,26 +19,31 @@ import 'katex/dist/katex.min.css'
 import App from './settings/App.vue'
 import router from './settings/router'
 
-setupApiClient({
-  // Settings is a satellite window — it doesn't host the login screen.
-  // On 401 we close ourselves and let the chat window route to login.
-  onUnauthorized: () => {
-    void window.api.window.closeSelf()
-  },
-})
+async function bootstrap() {
+  setupApiClient({
+    baseUrl: await window.api.desktop.apiBaseUrl(),
+    // Settings is a satellite window — it doesn't host the login screen.
+    // On 401 we close ourselves and let the chat window route to login.
+    onUnauthorized: () => {
+      void window.api.window.closeSelf()
+    },
+  })
 
-// Cross-window navigation: chat-side `router.push('/settings/...')` calls
-// reach us as IPC `settings:navigate` events forwarded by the main
-// process. Wire the listener up before mounting so the very first event
-// (sent on cold-start replay right after `did-finish-load`) is captured.
-window.api.window.onSettingsNavigate((target) => {
-  if (router.currentRoute.value.fullPath === target) return
-  void router.push(target)
-})
+  // Cross-window navigation: chat-side `router.push('/settings/...')` calls
+  // reach us as IPC `settings:navigate` events forwarded by the main
+  // process. Wire the listener up before mounting so the very first event
+  // (sent on cold-start replay right after `did-finish-load`) is captured.
+  window.api.window.onSettingsNavigate((target) => {
+    if (router.currentRoute.value.fullPath === target) return
+    void router.push(target)
+  })
 
-createApp(App)
-  .use(createPinia().use(piniaPluginPersistedstate))
-  .use(PiniaColada)
-  .use(router)
-  .use(i18n)
-  .mount('#app')
+  createApp(App)
+    .use(createPinia().use(piniaPluginPersistedstate))
+    .use(PiniaColada)
+    .use(router)
+    .use(i18n)
+    .mount('#app')
+}
+
+void bootstrap()

--- a/apps/desktop/src/renderer/src/shared/settings-routes.ts
+++ b/apps/desktop/src/renderer/src/shared/settings-routes.ts
@@ -15,7 +15,7 @@ export interface SettingsRouteSpec {
 }
 
 export const SETTINGS_ROUTE_SPECS: SettingsRouteSpec[] = [
-  { name: 'bots', path: '/settings/bots', loader: () => import('@memohai/web/pages/bots/index.vue') },
+  { name: 'bots', path: '/settings/bots', loader: () => import('../pages/bots/index.vue') },
   { name: 'bot-detail', path: '/settings/bots/:botId', loader: () => import('@memohai/web/pages/bots/detail.vue') },
   { name: 'providers', path: '/settings/providers', loader: () => import('@memohai/web/pages/providers/index.vue') },
   { name: 'web-search', path: '/settings/web-search', loader: () => import('@memohai/web/pages/web-search/index.vue') },

--- a/apps/desktop/src/renderer/types/ui-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/ui-stubs.d.ts
@@ -18,4 +18,41 @@ declare module '@memohai/ui' {
 
   export const Toaster: LooseComponent
   export const SidebarInset: LooseComponent
+  export const Avatar: LooseComponent
+  export const AvatarFallback: LooseComponent
+  export const AvatarImage: LooseComponent
+  export const Badge: LooseComponent
+  export const Button: LooseComponent
+  export const Card: LooseComponent
+  export const CardHeader: LooseComponent
+  export const CardTitle: LooseComponent
+  export const Dialog: LooseComponent
+  export const DialogClose: LooseComponent
+  export const DialogContent: LooseComponent
+  export const DialogDescription: LooseComponent
+  export const DialogFooter: LooseComponent
+  export const DialogHeader: LooseComponent
+  export const DialogTitle: LooseComponent
+  export const DialogTrigger: LooseComponent
+  export const Empty: LooseComponent
+  export const EmptyContent: LooseComponent
+  export const EmptyDescription: LooseComponent
+  export const EmptyHeader: LooseComponent
+  export const EmptyMedia: LooseComponent
+  export const EmptyTitle: LooseComponent
+  export const FormControl: LooseComponent
+  export const FormField: LooseComponent
+  export const FormItem: LooseComponent
+  export const Input: LooseComponent
+  export const Label: LooseComponent
+  export const Select: LooseComponent
+  export const SelectContent: LooseComponent
+  export const SelectItem: LooseComponent
+  export const SelectTrigger: LooseComponent
+  export const SelectValue: LooseComponent
+  export const Separator: LooseComponent
+  export const Spinner: LooseComponent
+  export const Tooltip: LooseComponent
+  export const TooltipContent: LooseComponent
+  export const TooltipTrigger: LooseComponent
 }

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -23,6 +23,7 @@ declare module '@memohai/web/i18n' {
 
 declare module '@memohai/web/api-client' {
   export interface SetupApiClientOptions {
+    baseUrl?: string
     onUnauthorized?: () => void
   }
   export function setupApiClient(options?: SetupApiClientOptions): void
@@ -32,6 +33,28 @@ declare module '@memohai/web/store/settings' {
   // We don't need the concrete Pinia store type here — desktop just calls the
   // composable for its registration side-effect.
   export function useSettingsStore(): unknown
+}
+
+declare module '@memohai/web/store/capabilities' {
+  export function useCapabilitiesStore(): {
+    localWorkspaceEnabled: boolean
+    load: () => Promise<void>
+  }
+}
+
+declare module '@memohai/web/composables/useDialogMutation' {
+  export function useDialogMutation(): {
+    run: <T>(action: () => Promise<T>, options?: { fallbackMessage?: string, onSuccess?: () => void }) => Promise<T | undefined>
+  }
+}
+
+declare module '@memohai/web/constants/acl-presets' {
+  export const defaultAclPreset: string
+  export const aclPresetOptions: Array<{ value: string, titleKey: string, descriptionKey?: string }>
+}
+
+declare module '@memohai/web/utils/timezones' {
+  export const emptyTimezoneValue: string
 }
 
 declare module '@memohai/web/lib/desktop-shell' {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -744,6 +744,16 @@
     "searchPlaceholder": "Search bots…",
     "createBot": "New Bot",
     "createBotWaitHint": "Creating a bot may need to pull the base image on first use. Please wait a moment after submission.",
+    "createBotLocalHint": "Local bots use a folder on this computer and are not sandboxed.",
+    "workspaceBackend": "Workspace",
+    "workspaceBackendHint": "Container workspaces are isolated. Local workspaces run directly on this computer.",
+    "workspaceBackends": {
+      "container": "Container",
+      "local": "Local folder"
+    },
+    "localWorkspacePath": "Local workspace folder",
+    "localWorkspacePathPlaceholder": "Choose a folder on this computer",
+    "localWorkspaceWarning": "Local workspaces can access host files and commands with the server user's permissions.",
     "editBot": "Edit Bot",
     "deleteConfirm": "Are you sure you want to delete this bot?",
     "renameSuccess": "Bot name updated",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -740,6 +740,16 @@
     "searchPlaceholder": "搜索 Bot…",
     "createBot": "新建 Bot",
     "createBotWaitHint": "首次创建时可能需要拉取基础镜像，提交后请耐心等待片刻。",
+    "createBotLocalHint": "Local Bot 会使用这台电脑上的文件夹，且不提供沙箱隔离。",
+    "workspaceBackend": "工作区",
+    "workspaceBackendHint": "容器工作区提供隔离；Local 工作区会直接在这台电脑上运行。",
+    "workspaceBackends": {
+      "container": "容器",
+      "local": "本地文件夹"
+    },
+    "localWorkspacePath": "本地工作区文件夹",
+    "localWorkspacePathPlaceholder": "选择这台电脑上的文件夹",
+    "localWorkspaceWarning": "Local 工作区会以 server 用户权限访问宿主文件和执行命令。",
     "editBot": "编辑 Bot",
     "deleteConfirm": "确定要删除这个 Bot 吗？",
     "renameSuccess": "Bot 名称已更新",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,6 +1,7 @@
 import { client } from '@memohai/sdk/client'
 
 export interface SetupApiClientOptions {
+  baseUrl?: string
   // Called after the access token is cleared on a 401. Hosts (web / desktop
   // chat window / desktop settings window) decide what to do — usually a
   // router redirect to the login screen, but desktop satellite windows may
@@ -13,7 +14,7 @@ export interface SetupApiClientOptions {
  * Call this once at app startup (main.ts).
  */
 export function setupApiClient(options: SetupApiClientOptions = {}) {
-  const apiBaseUrl = import.meta.env.VITE_API_URL?.trim() || '/api'
+  const apiBaseUrl = options.baseUrl?.trim() || import.meta.env.VITE_API_URL?.trim() || '/api'
   const agentBaseUrl = import.meta.env.VITE_AGENT_URL?.trim() || '/agent'
   void agentBaseUrl
 

--- a/apps/web/src/pages/bots/detail.vue
+++ b/apps/web/src/pages/bots/detail.vue
@@ -269,9 +269,25 @@ const { data: bot } = useQuery({
   },
   enabled: () => !!botId.value,
 })
+
+function workspaceBackendFromMetadata(metadata: unknown): string {
+  if (!metadata || typeof metadata !== 'object') return ''
+  const workspace = (metadata as Record<string, unknown>).workspace
+  if (!workspace || typeof workspace !== 'object') return ''
+  const backend = (workspace as Record<string, unknown>).backend
+  return typeof backend === 'string' ? backend.trim().toLowerCase() : ''
+}
+
+const containerInfo = ref<BotContainerInfo | null>(null)
+
+const isLocalWorkspace = computed(() =>
+  workspaceBackendFromMetadata(bot.value?.metadata) === 'local'
+  || containerInfo.value?.workspace_backend === 'local',
+)
+
 const tabList = computed(() => {
   const bot_id = toValue(botId)
-  return [
+  const tabs = [
     {
       value: 'overview', label: 'bots.tabs.overview', component: BotOverview, params: {}
     },
@@ -289,6 +305,10 @@ const tabList = computed(() => {
     { value: 'schedule', label: 'bots.tabs.schedule', component: BotSchedule, params: { 'bot-id': bot_id } },
     { value: 'skills', label: 'bots.tabs.skills', component: BotSkills, params: { 'bot-id': bot_id } },
   ]
+  if (isLocalWorkspace.value) {
+    return tabs.filter(tab => tab.value !== 'container' && tab.value !== 'network')
+  }
+  return tabs
 })
 
 
@@ -340,6 +360,11 @@ watch(bot, (val) => {
 }, { immediate: true })
 
 const activeTab = useSyncedQueryParam('tab', 'overview')
+watch([tabList, activeTab], ([tabs, tab]) => {
+  if (!tabs.some(item => item.value === tab)) {
+    activeTab.value = 'overview'
+  }
+}, { immediate: true })
 const avatarDialogOpen = ref(false)
 const avatarUrlDraft = ref('')
 const avatarFallback = useAvatarInitials(() => bot.value?.display_name || botId.value || '')
@@ -374,7 +399,6 @@ const botTypeLabel = computed(() => {
 const checks = ref<BotCheck[]>([])
 const checksLoading = ref(false)
 
-const containerInfo = ref<BotContainerInfo | null>(null)
 const containerMissing = ref(false)
 const containerLoading = ref(false)
 const snapshotsLoading = ref(false)

--- a/apps/web/src/store/capabilities.ts
+++ b/apps/web/src/store/capabilities.ts
@@ -4,6 +4,7 @@ import { getPing } from '@memohai/sdk'
 
 export const useCapabilitiesStore = defineStore('capabilities', () => {
   const containerBackend = ref('containerd')
+  const localWorkspaceEnabled = ref(false)
   const snapshotSupported = ref(true)
   const serverVersion = ref('')
   const commitHash = ref('')
@@ -15,6 +16,7 @@ export const useCapabilitiesStore = defineStore('capabilities', () => {
       const { data } = await getPing()
       if (data) {
         containerBackend.value = data.container_backend ?? 'containerd'
+        localWorkspaceEnabled.value = data.local_workspace_enabled === true
         snapshotSupported.value = data.snapshot_supported !== false
         serverVersion.value = data.version ?? ''
         commitHash.value = data.commit_hash ?? ''
@@ -25,5 +27,5 @@ export const useCapabilitiesStore = defineStore('capabilities', () => {
     loaded.value = true
   }
 
-  return { containerBackend, snapshotSupported, serverVersion, commitHash, loaded, load }
+  return { containerBackend, localWorkspaceEnabled, snapshotSupported, serverVersion, commitHash, loaded, load }
 })

--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -241,8 +241,16 @@ func provideBridgeProvider(manage *workspace.Manager) bridge.Provider {
 	return manage
 }
 
-func provideWorkspaceManager(log *slog.Logger, service ctr.Service, networkController netctl.Controller, cfg config.Config, conn *pgxpool.Pool, queries dbstore.Queries) *workspace.Manager {
-	return workspace.NewManager(log, service, networkController, cfg.Workspace, cfg.Containerd.Namespace, conn, queries)
+func provideWorkspaceManager(lc fx.Lifecycle, log *slog.Logger, service ctr.Service, networkController netctl.Controller, cfg config.Config, conn *pgxpool.Pool, queries dbstore.Queries) *workspace.Manager {
+	localSvc := workspace.NewLocalService(log, cfg.Local, cfg.Workspace.DataRoot)
+	lc.Append(fx.Hook{
+		OnStop: func(context.Context) error {
+			localSvc.Close()
+			return nil
+		},
+	})
+	runtimeSvc := workspace.NewRuntimeRouter(service, localSvc)
+	return workspace.NewManager(log, runtimeSvc, networkController, cfg.Workspace, cfg.Containerd.Namespace, conn, queries)
 }
 
 func provideMemoryLLM(modelsService *models.Service, settingsService *settings.Service, queries dbstore.Queries, log *slog.Logger) memprovider.LLM {

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/memohai/memoh/internal/logger"
 	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
+	"github.com/memohai/memoh/internal/workspace/bridgesvc"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 // initDataDir ensures /data exists and seeds template files on first boot.
 func initDataDir() {
-	if err := os.MkdirAll(defaultWorkDir, 0o750); err != nil {
+	if err := os.MkdirAll(bridgesvc.DefaultWorkDir, 0o750); err != nil {
 		logger.Warn("failed to create data dir", slog.Any("error", err))
 		return
 	}
@@ -42,7 +43,7 @@ func initDataDir() {
 		if e.IsDir() {
 			continue
 		}
-		dst := filepath.Join(defaultWorkDir, e.Name())
+		dst := filepath.Join(bridgesvc.DefaultWorkDir, e.Name())
 		if _, err := os.Stat(dst); err == nil {
 			continue
 		}
@@ -114,7 +115,11 @@ func main() {
 			PermitWithoutStream: true,
 		}),
 	)
-	pb.RegisterContainerServiceServer(srv, &containerServer{})
+	pb.RegisterContainerServiceServer(srv, bridgesvc.New(bridgesvc.Options{
+		DefaultWorkDir:    bridgesvc.DefaultWorkDir,
+		DataMount:         bridgesvc.DefaultWorkDir,
+		AllowHostAbsolute: true,
+	}))
 	reflection.Register(srv)
 
 	go func() {

--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -49,6 +49,15 @@ namespace = "default"
 # uses containerd above.
 host = ""
 
+[local]
+# Local workspaces are intended for trusted desktop builds, not the default
+# Docker Compose deployment. Keep disabled here because local commands run as
+# the server process user without container isolation.
+enabled = false
+default_workspace_parent = "~/.memoh/workspaces"
+metadata_root = ""
+allow_absolute_paths = false
+
 ## Postgres configuration. Used only when [database].driver = "postgres".
 [postgres]
 host = "postgres"

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -79,6 +79,22 @@ bridge_port = 9090
 socket_path = ""
 binary_path = ""
 
+[local]
+# Enables local workspaces alongside the configured container backend. This is
+# intended for trusted desktop use only: there is no sandbox, and commands run
+# as the server process user on the host machine.
+enabled = false
+# Default parent used when a local bot does not provide an explicit workspace
+# path. The final default is "$HOME/.memoh/workspaces/<bot-name>".
+default_workspace_parent = "~/.memoh/workspaces"
+# Metadata for local workspace records. Leave empty to store it under
+# [container].data_root/local/containers.
+metadata_root = ""
+# When true, local workspace tools may read/write/execute using host absolute
+# paths outside the bot's default workspace. Desktop can enable this for a
+# trusted local user; server deployments should keep local disabled.
+allow_absolute_paths = true
+
 [postgres]
 # Used only when [database].driver = "postgres".
 host = "127.0.0.1"

--- a/conf/app.local.toml
+++ b/conf/app.local.toml
@@ -1,0 +1,99 @@
+# Memoh local desktop/development configuration.
+# Runs the server directly on the host, uses Docker for container workspaces,
+# and also enables trusted local workspaces.
+
+[log]
+level = "info"
+format = "text"
+
+[server]
+addr = ":18080"
+
+[admin]
+username = "admin"
+password = "admin123"
+email = "admin@memoh.local"
+
+[auth]
+jwt_secret = "LOCAL-DEV-CHANGE-ME"
+jwt_expires_in = "168h"
+
+timezone = "UTC"
+
+[database]
+driver = "sqlite"
+
+[container]
+# Keep Docker available for bots that still need isolated workspaces.
+backend = "docker"
+default_image = "debian:bookworm-slim"
+image_pull_policy = "if_not_present"
+snapshotter = "docker"
+data_root = "data/local"
+runtime_dir = "data/runtime"
+
+[docker]
+# Leave empty to use Docker's standard environment discovery.
+host = ""
+
+[local]
+# Local workspaces run with the server process permissions and have no sandbox.
+# This is intended for trusted desktop/local development only.
+enabled = true
+default_workspace_parent = "~/.memoh/workspaces"
+metadata_root = "data/local/local/containers"
+allow_absolute_paths = true
+
+[containerd]
+socket_path = "/run/containerd/containerd.sock"
+namespace = "default"
+
+[kubernetes]
+namespace = "default"
+in_cluster = false
+kubeconfig = ""
+service_account_name = ""
+image_pull_secret = ""
+pvc_storage_class = ""
+pvc_size = "10Gi"
+bridge_port = 9090
+
+[apple]
+socket_path = ""
+binary_path = ""
+
+[sqlite]
+path = "data/local/memoh.db"
+wal = true
+busy_timeout_ms = 5000
+
+[postgres]
+host = "127.0.0.1"
+port = 5432
+user = "memoh"
+password = "memoh123"
+database = "memoh"
+sslmode = "disable"
+
+[qdrant]
+base_url = "http://127.0.0.1:6334"
+api_key = ""
+timeout_seconds = 10
+
+[sparse]
+base_url = "http://127.0.0.1:8085"
+
+[registry]
+providers_dir = "conf/providers"
+
+[browser_gateway]
+host = "127.0.0.1"
+port = 18083
+server_addr = ":18080"
+
+[supermarket]
+base_url = "https://supermarket.memoh.ai"
+
+[web]
+host = "127.0.0.1"
+port = 8082

--- a/conf/app.local.toml
+++ b/conf/app.local.toml
@@ -29,8 +29,8 @@ backend = "docker"
 default_image = "debian:bookworm-slim"
 image_pull_policy = "if_not_present"
 snapshotter = "docker"
-data_root = "data/local"
-runtime_dir = "data/runtime"
+data_root = "__PROJECT_ROOT__/data/local"
+runtime_dir = "__PROJECT_ROOT__/data/runtime"
 
 [docker]
 # Leave empty to use Docker's standard environment discovery.
@@ -41,7 +41,7 @@ host = ""
 # This is intended for trusted desktop/local development only.
 enabled = true
 default_workspace_parent = "~/.memoh/workspaces"
-metadata_root = "data/local/local/containers"
+metadata_root = "__PROJECT_ROOT__/data/local/containers"
 allow_absolute_paths = true
 
 [containerd]
@@ -63,7 +63,7 @@ socket_path = ""
 binary_path = ""
 
 [sqlite]
-path = "data/local/memoh.db"
+path = "__PROJECT_ROOT__/data/local/memoh.db"
 wal = true
 busy_timeout_ms = 5000
 

--- a/conf/app.local.toml
+++ b/conf/app.local.toml
@@ -7,7 +7,7 @@ level = "info"
 format = "text"
 
 [server]
-addr = ":18080"
+addr = ":18731"
 
 [admin]
 username = "admin"
@@ -29,8 +29,8 @@ backend = "docker"
 default_image = "debian:bookworm-slim"
 image_pull_policy = "if_not_present"
 snapshotter = "docker"
-data_root = "__PROJECT_ROOT__/data/local"
-runtime_dir = "__PROJECT_ROOT__/data/runtime"
+data_root = "data/local"
+runtime_dir = "data/runtime"
 
 [docker]
 # Leave empty to use Docker's standard environment discovery.
@@ -41,7 +41,7 @@ host = ""
 # This is intended for trusted desktop/local development only.
 enabled = true
 default_workspace_parent = "~/.memoh/workspaces"
-metadata_root = "__PROJECT_ROOT__/data/local/containers"
+metadata_root = "data/local/containers"
 allow_absolute_paths = true
 
 [containerd]
@@ -63,7 +63,7 @@ socket_path = ""
 binary_path = ""
 
 [sqlite]
-path = "__PROJECT_ROOT__/data/local/memoh.db"
+path = "data/local/memoh.db"
 wal = true
 busy_timeout_ms = 5000
 
@@ -89,7 +89,7 @@ providers_dir = "conf/providers"
 [browser_gateway]
 host = "127.0.0.1"
 port = 18083
-server_addr = ":18080"
+server_addr = ":18731"
 
 [supermarket]
 base_url = "https://supermarket.memoh.ai"

--- a/conf/app.local.toml
+++ b/conf/app.local.toml
@@ -33,7 +33,7 @@ data_root = "data/local"
 runtime_dir = "data/runtime"
 
 [docker]
-# Leave empty to use Docker's standard environment discovery.
+# Leave empty to let desktop startup detect Docker Desktop / Docker Engine sockets.
 host = ""
 
 [local]

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -464,6 +464,7 @@ CREATE TABLE IF NOT EXISTS containers (
   namespace TEXT NOT NULL DEFAULT 'default',
   auto_start BOOLEAN NOT NULL DEFAULT true,
   container_path TEXT NOT NULL DEFAULT '/data',
+  workspace_backend TEXT NOT NULL DEFAULT 'container',
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   last_started_at TIMESTAMPTZ,

--- a/db/postgres/migrations/0076_container_workspace_backend.down.sql
+++ b/db/postgres/migrations/0076_container_workspace_backend.down.sql
@@ -1,0 +1,5 @@
+-- 0076_container_workspace_backend
+-- Remove explicit workspace backend tracking from containers.
+
+ALTER TABLE containers
+  DROP COLUMN IF EXISTS workspace_backend;

--- a/db/postgres/migrations/0076_container_workspace_backend.up.sql
+++ b/db/postgres/migrations/0076_container_workspace_backend.up.sql
@@ -1,0 +1,10 @@
+-- 0076_container_workspace_backend
+-- Add explicit workspace backend tracking for container and local workspaces.
+
+ALTER TABLE containers
+  ADD COLUMN IF NOT EXISTS workspace_backend TEXT NOT NULL DEFAULT 'container';
+
+UPDATE containers
+SET workspace_backend = 'local'
+WHERE workspace_backend = 'container'
+  AND (container_id LIKE 'local-%' OR image = 'local');

--- a/db/postgres/queries/containers.sql
+++ b/db/postgres/queries/containers.sql
@@ -1,7 +1,7 @@
 -- name: UpsertContainer :exec
 INSERT INTO containers (
   bot_id, container_id, container_name, image, status, namespace, auto_start,
-  container_path, last_started_at, last_stopped_at
+  container_path, workspace_backend, last_started_at, last_stopped_at
 )
 VALUES (
   sqlc.arg(bot_id),
@@ -12,6 +12,7 @@ VALUES (
   sqlc.arg(namespace),
   sqlc.arg(auto_start),
   sqlc.arg(container_path),
+  sqlc.arg(workspace_backend),
   sqlc.arg(last_started_at),
   sqlc.arg(last_stopped_at)
 )
@@ -23,6 +24,7 @@ ON CONFLICT (container_id) DO UPDATE SET
   namespace = EXCLUDED.namespace,
   auto_start = EXCLUDED.auto_start,
   container_path = EXCLUDED.container_path,
+  workspace_backend = EXCLUDED.workspace_backend,
   last_started_at = EXCLUDED.last_started_at,
   last_stopped_at = EXCLUDED.last_stopped_at,
   updated_at = now();

--- a/db/sqlite/migrations/0002_container_workspace_backend.down.sql
+++ b/db/sqlite/migrations/0002_container_workspace_backend.down.sql
@@ -1,0 +1,37 @@
+-- 0002_container_workspace_backend
+-- SQLite cannot drop columns portably; rebuild containers without workspace_backend.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE containers_new (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL REFERENCES bots(id) ON DELETE CASCADE,
+  container_id TEXT NOT NULL,
+  container_name TEXT NOT NULL,
+  image TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'created',
+  namespace TEXT NOT NULL DEFAULT 'default',
+  auto_start INTEGER NOT NULL DEFAULT 1,
+  container_path TEXT NOT NULL DEFAULT '/data',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_started_at TEXT,
+  last_stopped_at TEXT,
+  CONSTRAINT containers_container_id_unique UNIQUE (container_id),
+  CONSTRAINT containers_container_name_unique UNIQUE (container_name)
+);
+
+INSERT INTO containers_new (
+  id, bot_id, container_id, container_name, image, status, namespace, auto_start,
+  container_path, created_at, updated_at, last_started_at, last_stopped_at
+)
+SELECT
+  id, bot_id, container_id, container_name, image, status, namespace, auto_start,
+  container_path, created_at, updated_at, last_started_at, last_stopped_at
+FROM containers;
+
+DROP TABLE containers;
+ALTER TABLE containers_new RENAME TO containers;
+CREATE INDEX IF NOT EXISTS idx_containers_bot_id ON containers(bot_id);
+
+PRAGMA foreign_keys = ON;

--- a/db/sqlite/migrations/0002_container_workspace_backend.up.sql
+++ b/db/sqlite/migrations/0002_container_workspace_backend.up.sql
@@ -1,0 +1,10 @@
+-- 0002_container_workspace_backend
+-- Add explicit workspace backend tracking for container and local workspaces.
+
+ALTER TABLE containers
+  ADD COLUMN workspace_backend TEXT NOT NULL DEFAULT 'container';
+
+UPDATE containers
+SET workspace_backend = 'local'
+WHERE workspace_backend = 'container'
+  AND (container_id LIKE 'local-%' OR image = 'local');

--- a/db/sqlite/queries/containers.sql
+++ b/db/sqlite/queries/containers.sql
@@ -1,7 +1,7 @@
 -- name: UpsertContainer :exec
 INSERT INTO containers (
   id, bot_id, container_id, container_name, image, status, namespace, auto_start,
-  container_path, last_started_at, last_stopped_at
+  container_path, workspace_backend, last_started_at, last_stopped_at
 )
 VALUES (
   lower(hex(randomblob(4))) || '-' ||
@@ -17,6 +17,7 @@ VALUES (
   sqlc.arg(namespace),
   sqlc.arg(auto_start),
   sqlc.arg(container_path),
+  sqlc.arg(workspace_backend),
   sqlc.arg(last_started_at),
   sqlc.arg(last_stopped_at)
 )
@@ -28,6 +29,7 @@ ON CONFLICT (container_id) DO UPDATE SET
   namespace = EXCLUDED.namespace,
   auto_start = EXCLUDED.auto_start,
   container_path = EXCLUDED.container_path,
+  workspace_backend = EXCLUDED.workspace_backend,
   last_started_at = EXCLUDED.last_started_at,
   last_stopped_at = EXCLUDED.last_stopped_at,
   updated_at = CURRENT_TIMESTAMP;

--- a/internal/agent/tools/container.go
+++ b/internal/agent/tools/container.go
@@ -53,11 +53,12 @@ func NewContainerProvider(log *slog.Logger, clients bridge.Provider, bgManager *
 	return &ContainerProvider{clients: clients, bgManager: bgManager, execWorkDir: wd, logger: log.With(slog.String("tool", "container"))}
 }
 
-func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]sdk.Tool, error) {
-	wd := p.execWorkDir
+func (p *ContainerProvider) Tools(ctx context.Context, session SessionContext) ([]sdk.Tool, error) {
+	workspace := p.resolveToolWorkspace(ctx, session)
+	wd := workspace.defaultWorkDir
 	sess := session
 
-	readDesc := "Read file content inside the bot container. Reads the full file by default; use line_offset and n_lines for pagination. Files up to ~16 MB are supported."
+	readDesc := fmt.Sprintf("Read file content %s. Reads the full file by default; use line_offset and n_lines for pagination. Files up to ~16 MB are supported.", workspace.locationDescription)
 	if sess.SupportsImageInput {
 		readDesc += " Also supports reading image files (PNG, JPEG, GIF, WebP) — binary images are loaded into model context automatically."
 	}
@@ -69,7 +70,7 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"path":        map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute inside container)", wd)},
+					"path":        map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute %s)", wd, workspace.absolutePathDescription)},
 					"line_offset": map[string]any{"type": "integer", "description": "Line number to start reading from (1-indexed). Default: 1.", "minimum": 1, "default": 1},
 					"n_lines":     map[string]any{"type": "integer", "description": "Number of lines to read. Default: read entire file.", "minimum": 1},
 				},
@@ -81,11 +82,11 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 		},
 		{
 			Name:        "write",
-			Description: "Write file content inside the bot container. Creates parent directories automatically. Handles files of any size.",
+			Description: fmt.Sprintf("Write file content %s. Creates parent directories automatically. Handles files of any size.", workspace.locationDescription),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"path":    map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute inside container)", wd)},
+					"path":    map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute %s)", wd, workspace.absolutePathDescription)},
 					"content": map[string]any{"type": "string", "description": "File content"},
 				},
 				"required": []string{"path", "content"},
@@ -96,11 +97,11 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 		},
 		{
 			Name:        "list",
-			Description: fmt.Sprintf("List directory entries inside the bot container. Supports pagination. Max %d entries per call. In recursive mode, subdirectories with >%d items are collapsed to a summary.", listMaxEntries, listCollapseThreshold),
+			Description: fmt.Sprintf("List directory entries %s. Supports pagination. Max %d entries per call. In recursive mode, subdirectories with >%d items are collapsed to a summary.", workspace.locationDescription, listMaxEntries, listCollapseThreshold),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"path":      map[string]any{"type": "string", "description": fmt.Sprintf("Directory path (relative to %s or absolute inside container)", wd)},
+					"path":      map[string]any{"type": "string", "description": fmt.Sprintf("Directory path (relative to %s or absolute %s)", wd, workspace.absolutePathDescription)},
 					"recursive": map[string]any{"type": "boolean", "description": "List recursively"},
 					"offset":    map[string]any{"type": "integer", "description": "Entry offset to start from (0-indexed). Default: 0.", "minimum": 0, "default": 0},
 					"limit":     map[string]any{"type": "integer", "description": fmt.Sprintf("Max entries to return per call. Default: %d. Max: %d.", listMaxEntries, listMaxEntries), "minimum": 1, "maximum": listMaxEntries, "default": listMaxEntries},
@@ -113,11 +114,11 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 		},
 		{
 			Name:        "edit",
-			Description: "Replace exact text in a file inside the bot container.",
+			Description: fmt.Sprintf("Replace exact text in a file %s.", workspace.locationDescription),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"path":     map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute inside container)", wd)},
+					"path":     map[string]any{"type": "string", "description": fmt.Sprintf("File path (relative to %s or absolute %s)", wd, workspace.absolutePathDescription)},
 					"old_text": map[string]any{"type": "string", "description": "Exact text to find"},
 					"new_text": map[string]any{"type": "string", "description": "Replacement text"},
 				},
@@ -129,7 +130,7 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 		},
 		{
 			Name: "exec",
-			Description: fmt.Sprintf(`Execute a shell command in the bot container. Runs in the bot's data directory (%s) by default.
+			Description: fmt.Sprintf(`Execute a shell command %s. Runs in %s by default.
 
 # Instructions
 - Use this tool to run shell commands for installing packages, running scripts, building code, running tests, and other system operations.
@@ -141,12 +142,12 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
   - If your command is long running, use run_in_background. No sleep needed.
   - Do not retry failing commands in a sleep loop — diagnose the root cause.
   - If waiting for a background task, you will be notified when it completes automatically.
-  - sleep N (N >= 2) in foreground is blocked. If you genuinely need a short delay, keep it under 2 seconds.`, wd, background.MaxExecTimeout, background.DefaultExecTimeout),
+  - sleep N (N >= 2) in foreground is blocked. If you genuinely need a short delay, keep it under 2 seconds.`, workspace.locationDescription, wd, background.MaxExecTimeout, background.DefaultExecTimeout),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"command":           map[string]any{"type": "string", "description": "Shell command to run (e.g. ls -la, npm install, python script.py)"},
-					"work_dir":          map[string]any{"type": "string", "description": fmt.Sprintf("Working directory inside the container (default: %s)", wd)},
+					"work_dir":          map[string]any{"type": "string", "description": fmt.Sprintf("Working directory (default: %s)", wd)},
 					"description":       map[string]any{"type": "string", "description": `Clear, concise description of what this command does in active voice. For simple commands keep it brief (5-10 words): ls -la → "List files with details". For complex commands add enough context: curl -s url | jq '.data[]' → "Fetch JSON and extract data array".`},
 					"timeout":           map[string]any{"type": "integer", "description": fmt.Sprintf("Timeout in seconds (default: %d, max: %d). Only applies to foreground execution. Commands that exceed this timeout are automatically moved to background.", background.DefaultExecTimeout, background.MaxExecTimeout), "minimum": 1, "maximum": background.MaxExecTimeout},
 					"run_in_background": map[string]any{"type": "boolean", "description": "If true, run the command in the background. Returns immediately with a task ID. You will be notified when it completes. Use for long-running commands (installs, builds, test suites). You do not need to use '&' at the end of the command."},
@@ -175,12 +176,46 @@ func (p *ContainerProvider) Tools(_ context.Context, session SessionContext) ([]
 	}, nil
 }
 
-func (p *ContainerProvider) normalizePath(path string) string {
+type toolWorkspace struct {
+	defaultWorkDir          string
+	locationDescription     string
+	absolutePathDescription string
+}
+
+func (p *ContainerProvider) resolveToolWorkspace(ctx context.Context, session SessionContext) toolWorkspace {
+	info := bridge.WorkspaceInfo{
+		Backend:        bridge.WorkspaceBackendContainer,
+		DefaultWorkDir: p.execWorkDir,
+	}
+	if resolver, ok := p.clients.(bridge.WorkspaceInfoProvider); ok {
+		if resolved, err := resolver.WorkspaceInfo(ctx, session.BotID); err == nil {
+			info = resolved
+		}
+	}
+	wd := strings.TrimSpace(info.DefaultWorkDir)
+	if wd == "" {
+		wd = p.execWorkDir
+	}
+	if strings.EqualFold(info.Backend, bridge.WorkspaceBackendLocal) {
+		return toolWorkspace{
+			defaultWorkDir:          wd,
+			locationDescription:     "on the local machine",
+			absolutePathDescription: "host path",
+		}
+	}
+	return toolWorkspace{
+		defaultWorkDir:          wd,
+		locationDescription:     "inside the bot container",
+		absolutePathDescription: "inside container",
+	}
+}
+
+func (*ContainerProvider) normalizePath(path, workDir string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return path
 	}
-	prefix := p.execWorkDir
+	prefix := strings.TrimRight(strings.TrimSpace(workDir), "/")
 	if prefix == "" {
 		prefix = defaultContainerExecWorkDir
 	}
@@ -213,7 +248,7 @@ func (p *ContainerProvider) execRead(ctx context.Context, session SessionContext
 	if err != nil {
 		return nil, err
 	}
-	filePath := p.normalizePath(StringArg(args, "path"))
+	filePath := p.normalizePath(StringArg(args, "path"), p.resolveToolWorkspace(ctx, session).defaultWorkDir)
 	if filePath == "" {
 		return nil, errors.New("path is required")
 	}
@@ -307,7 +342,7 @@ func (p *ContainerProvider) execWrite(ctx context.Context, session SessionContex
 	if err != nil {
 		return nil, err
 	}
-	filePath := p.normalizePath(StringArg(args, "path"))
+	filePath := p.normalizePath(StringArg(args, "path"), p.resolveToolWorkspace(ctx, session).defaultWorkDir)
 	content := StringArg(args, "content")
 	if filePath == "" {
 		return nil, errors.New("path is required")
@@ -337,7 +372,7 @@ func (p *ContainerProvider) execList(ctx context.Context, session SessionContext
 	if err != nil {
 		return nil, err
 	}
-	dirPath := p.normalizePath(StringArg(args, "path"))
+	dirPath := p.normalizePath(StringArg(args, "path"), p.resolveToolWorkspace(ctx, session).defaultWorkDir)
 	if dirPath == "" {
 		dirPath = "."
 	}
@@ -409,7 +444,7 @@ func (p *ContainerProvider) execEdit(ctx context.Context, session SessionContext
 	if err != nil {
 		return nil, err
 	}
-	filePath := p.normalizePath(StringArg(args, "path"))
+	filePath := p.normalizePath(StringArg(args, "path"), p.resolveToolWorkspace(ctx, session).defaultWorkDir)
 	oldText := StringArg(args, "old_text")
 	newText := StringArg(args, "new_text")
 	if filePath == "" || oldText == "" {
@@ -458,7 +493,7 @@ func (p *ContainerProvider) execExec(ctx context.Context, session SessionContext
 	}
 	workDir := strings.TrimSpace(StringArg(args, "work_dir"))
 	if workDir == "" {
-		workDir = p.execWorkDir
+		workDir = p.resolveToolWorkspace(ctx, session).defaultWorkDir
 	}
 	description := strings.TrimSpace(StringArg(args, "description"))
 

--- a/internal/agent/tools/image_gen.go
+++ b/internal/agent/tools/image_gen.go
@@ -166,7 +166,13 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 		ext = "webp"
 	}
 
-	containerPath := fmt.Sprintf("%s/%d.%s", imageGenDir, time.Now().UnixMilli(), ext)
+	imageDir := strings.TrimRight(p.dataMount, "/") + strings.TrimPrefix(imageGenDir, "/data")
+	if resolver, ok := p.containers.(bridge.WorkspaceInfoProvider); ok {
+		if info, err := resolver.WorkspaceInfo(ctx, botID); err == nil && info.Backend == bridge.WorkspaceBackendLocal && strings.TrimSpace(info.DefaultWorkDir) != "" {
+			imageDir = strings.TrimRight(info.DefaultWorkDir, "/") + "/generated-images"
+		}
+	}
+	containerPath := fmt.Sprintf("%s/%d.%s", imageDir, time.Now().UnixMilli(), ext)
 
 	client, clientErr := p.containers.MCPClient(ctx, botID)
 	if clientErr != nil {
@@ -178,7 +184,7 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 		}, nil
 	}
 
-	mkdirCmd := fmt.Sprintf("mkdir -p %s", imageGenDir)
+	mkdirCmd := fmt.Sprintf("mkdir -p %s", imageDir)
 	_, _ = client.Exec(ctx, mkdirCmd, "/", 5)
 
 	if writeErr := client.WriteFile(ctx, containerPath, imgBytes); writeErr != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Docker         DockerConfig         `toml:"docker"`
 	Kubernetes     KubernetesConfig     `toml:"kubernetes"`
 	Apple          AppleConfig          `toml:"apple"`
+	Local          LocalConfig          `toml:"local"`
 	Workspace      WorkspaceConfig      `toml:"workspace"`
 	Postgres       PostgresConfig       `toml:"postgres"`
 	SQLite         SQLiteConfig         `toml:"sqlite"`
@@ -110,6 +111,31 @@ type DockerConfig struct {
 type AppleConfig struct {
 	SocketPath string `toml:"socket_path"`
 	BinaryPath string `toml:"binary_path"`
+}
+
+type LocalConfig struct {
+	Enabled                bool   `toml:"enabled"`
+	DefaultWorkspaceParent string `toml:"default_workspace_parent"`
+	MetadataRoot           string `toml:"metadata_root"`
+	AllowAbsolutePaths     bool   `toml:"allow_absolute_paths"`
+}
+
+func (c LocalConfig) WorkspaceParent() string {
+	if strings.TrimSpace(c.DefaultWorkspaceParent) != "" {
+		return expandHome(strings.TrimSpace(c.DefaultWorkspaceParent))
+	}
+	return filepath.Join(homeDirOrDot(), ".memoh", "workspaces")
+}
+
+func (c LocalConfig) MetadataPath(dataRoot string) string {
+	if strings.TrimSpace(c.MetadataRoot) != "" {
+		return expandHome(strings.TrimSpace(c.MetadataRoot))
+	}
+	root := strings.TrimSpace(dataRoot)
+	if root == "" {
+		root = DefaultDataRoot
+	}
+	return filepath.Join(root, "local", "containers")
 }
 
 type KubernetesConfig struct {
@@ -188,6 +214,23 @@ func (c WorkspaceConfig) EffectiveImagePullPolicy() string {
 	default:
 		return ImagePullPolicyIfNotPresent
 	}
+}
+
+func expandHome(path string) string {
+	if path == "~" {
+		return homeDirOrDot()
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(homeDirOrDot(), path[2:])
+	}
+	return path
+}
+
+func homeDirOrDot() string {
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return home
+	}
+	return "."
 }
 
 // NormalizeImageRef ensures an image reference is fully qualified for containerd.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,6 +150,22 @@ binary_path = "/opt/homebrew/bin/socktainer"
 	}
 }
 
+func TestLoadAppLocalTemplate(t *testing.T) {
+	cfg, err := Load(filepath.Join("..", "..", "conf", "app.local.toml"))
+	if err != nil {
+		t.Fatalf("load app.local.toml: %v", err)
+	}
+	if cfg.Container.Backend != "docker" {
+		t.Fatalf("container backend = %q, want docker", cfg.Container.Backend)
+	}
+	if !cfg.Local.Enabled {
+		t.Fatal("local workspace should be enabled")
+	}
+	if cfg.Database.DriverOrDefault() != "sqlite" {
+		t.Fatalf("database driver = %q, want sqlite", cfg.Database.DriverOrDefault())
+	}
+}
+
 func TestWorkspaceImagePullPolicyDefaultsAndNormalizes(t *testing.T) {
 	if got := (WorkspaceConfig{}).EffectiveImagePullPolicy(); got != ImagePullPolicyIfNotPresent {
 		t.Fatalf("default policy = %q", got)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,7 +151,16 @@ binary_path = "/opt/homebrew/bin/socktainer"
 }
 
 func TestLoadAppLocalTemplate(t *testing.T) {
-	cfg, err := Load(filepath.Join("..", "..", "conf", "app.local.toml"))
+	raw, err := os.ReadFile(filepath.Join("..", "..", "conf", "app.local.toml"))
+	if err != nil {
+		t.Fatalf("read app.local.toml: %v", err)
+	}
+	rendered := strings.ReplaceAll(string(raw), "__PROJECT_ROOT__", filepath.ToSlash(filepath.Join("..", "..")))
+	configPath := filepath.Join(t.TempDir(), "app.local.toml")
+	if err := os.WriteFile(configPath, []byte(rendered), 0o600); err != nil {
+		t.Fatalf("write rendered app.local.toml: %v", err)
+	}
+	cfg, err := Load(configPath)
 	if err != nil {
 		t.Fatalf("load app.local.toml: %v", err)
 	}

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	dockermount "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/memohai/memoh/internal/config"
 	containerapi "github.com/memohai/memoh/internal/container"
@@ -135,6 +136,9 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 		Mounts: toDockerMounts(req.Spec.Mounts),
 		DNS:    req.Spec.DNS,
 		Init:   boolPtr(true),
+		PortBindings: nat.PortMap{
+			nat.Port(bridgeTCPPort + "/tcp"): []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: ""}},
+		},
 	}
 	if req.Spec.NetworkJoinTarget.Value != "" {
 		hostCfg.NetworkMode = container.NetworkMode("none")
@@ -147,6 +151,9 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 		User:       req.Spec.User,
 		Tty:        req.Spec.TTY,
 		Labels:     labels,
+		ExposedPorts: nat.PortSet{
+			nat.Port(bridgeTCPPort + "/tcp"): struct{}{},
+		},
 	}
 	resp, err := s.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, req.ID)
 	if err != nil {
@@ -165,11 +172,32 @@ func (s *Service) BridgeTarget(botID string) string {
 	if err != nil {
 		return ""
 	}
+	if host := firstHostPort(info, bridgeTCPPort); host != "" {
+		return host
+	}
 	ip := firstContainerIP(info)
 	if ip == "" {
 		return ""
 	}
 	return net.JoinHostPort(ip, bridgeTCPPort)
+}
+
+func firstHostPort(info container.InspectResponse, port string) string {
+	if info.NetworkSettings == nil {
+		return ""
+	}
+	for _, binding := range info.NetworkSettings.Ports[nat.Port(port+"/tcp")] {
+		hostIP := strings.TrimSpace(binding.HostIP)
+		hostPort := strings.TrimSpace(binding.HostPort)
+		if hostPort == "" {
+			continue
+		}
+		if hostIP == "" || hostIP == "0.0.0.0" || hostIP == "::" {
+			hostIP = "127.0.0.1"
+		}
+		return net.JoinHostPort(hostIP, hostPort)
+	}
+	return ""
 }
 
 func (s *Service) GetContainer(ctx context.Context, id string) (containerapi.ContainerInfo, error) {

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -80,5 +81,18 @@ func TestDockerDoesNotExposeHostSnapshotCapabilities(t *testing.T) {
 	var svc any = &Service{}
 	if _, ok := svc.(snapshotMountProvider); ok {
 		t.Fatal("docker service should not expose host-side snapshot mounts")
+	}
+}
+
+func TestBridgeTargetPrefersPublishedHostPort(t *testing.T) {
+	var settings dockercontainer.NetworkSettings
+	if err := json.Unmarshal([]byte(`{"Ports":{"9090/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}`), &settings); err != nil {
+		t.Fatalf("unmarshal network settings: %v", err)
+	}
+	info := dockercontainer.InspectResponse{
+		NetworkSettings: &settings,
+	}
+	if got, want := firstHostPort(info, bridgeTCPPort), "127.0.0.1:49153"; got != want {
+		t.Fatalf("firstHostPort = %q, want %q", got, want)
 	}
 }

--- a/internal/db/postgres/sqlc/containers.sql.go
+++ b/internal/db/postgres/sqlc/containers.sql.go
@@ -21,7 +21,7 @@ func (q *Queries) DeleteContainerByBotID(ctx context.Context, botID pgtype.UUID)
 }
 
 const getContainerByBotID = `-- name: GetContainerByBotID :one
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE bot_id = $1 ORDER BY updated_at DESC LIMIT 1
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE bot_id = $1 ORDER BY updated_at DESC LIMIT 1
 `
 
 func (q *Queries) GetContainerByBotID(ctx context.Context, botID pgtype.UUID) (Container, error) {
@@ -37,6 +37,7 @@ func (q *Queries) GetContainerByBotID(ctx context.Context, botID pgtype.UUID) (C
 		&i.Namespace,
 		&i.AutoStart,
 		&i.ContainerPath,
+		&i.WorkspaceBackend,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastStartedAt,
@@ -46,7 +47,7 @@ func (q *Queries) GetContainerByBotID(ctx context.Context, botID pgtype.UUID) (C
 }
 
 const listAutoStartContainers = `-- name: ListAutoStartContainers :many
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE auto_start = true ORDER BY updated_at DESC
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE auto_start = true ORDER BY updated_at DESC
 `
 
 func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, error) {
@@ -68,6 +69,7 @@ func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, err
 			&i.Namespace,
 			&i.AutoStart,
 			&i.ContainerPath,
+			&i.WorkspaceBackend,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.LastStartedAt,
@@ -124,7 +126,7 @@ func (q *Queries) UpdateContainerStopped(ctx context.Context, botID pgtype.UUID)
 const upsertContainer = `-- name: UpsertContainer :exec
 INSERT INTO containers (
   bot_id, container_id, container_name, image, status, namespace, auto_start,
-  container_path, last_started_at, last_stopped_at
+  container_path, workspace_backend, last_started_at, last_stopped_at
 )
 VALUES (
   $1,
@@ -136,7 +138,8 @@ VALUES (
   $7,
   $8,
   $9,
-  $10
+  $10,
+  $11
 )
 ON CONFLICT (container_id) DO UPDATE SET
   bot_id = EXCLUDED.bot_id,
@@ -146,22 +149,24 @@ ON CONFLICT (container_id) DO UPDATE SET
   namespace = EXCLUDED.namespace,
   auto_start = EXCLUDED.auto_start,
   container_path = EXCLUDED.container_path,
+  workspace_backend = EXCLUDED.workspace_backend,
   last_started_at = EXCLUDED.last_started_at,
   last_stopped_at = EXCLUDED.last_stopped_at,
   updated_at = now()
 `
 
 type UpsertContainerParams struct {
-	BotID         pgtype.UUID        `json:"bot_id"`
-	ContainerID   string             `json:"container_id"`
-	ContainerName string             `json:"container_name"`
-	Image         string             `json:"image"`
-	Status        string             `json:"status"`
-	Namespace     string             `json:"namespace"`
-	AutoStart     bool               `json:"auto_start"`
-	ContainerPath string             `json:"container_path"`
-	LastStartedAt pgtype.Timestamptz `json:"last_started_at"`
-	LastStoppedAt pgtype.Timestamptz `json:"last_stopped_at"`
+	BotID            pgtype.UUID        `json:"bot_id"`
+	ContainerID      string             `json:"container_id"`
+	ContainerName    string             `json:"container_name"`
+	Image            string             `json:"image"`
+	Status           string             `json:"status"`
+	Namespace        string             `json:"namespace"`
+	AutoStart        bool               `json:"auto_start"`
+	ContainerPath    string             `json:"container_path"`
+	WorkspaceBackend string             `json:"workspace_backend"`
+	LastStartedAt    pgtype.Timestamptz `json:"last_started_at"`
+	LastStoppedAt    pgtype.Timestamptz `json:"last_stopped_at"`
 }
 
 func (q *Queries) UpsertContainer(ctx context.Context, arg UpsertContainerParams) error {
@@ -174,6 +179,7 @@ func (q *Queries) UpsertContainer(ctx context.Context, arg UpsertContainerParams
 		arg.Namespace,
 		arg.AutoStart,
 		arg.ContainerPath,
+		arg.WorkspaceBackend,
 		arg.LastStartedAt,
 		arg.LastStoppedAt,
 	)

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -235,19 +235,20 @@ type ChannelIdentityBindCode struct {
 }
 
 type Container struct {
-	ID            pgtype.UUID        `json:"id"`
-	BotID         pgtype.UUID        `json:"bot_id"`
-	ContainerID   string             `json:"container_id"`
-	ContainerName string             `json:"container_name"`
-	Image         string             `json:"image"`
-	Status        string             `json:"status"`
-	Namespace     string             `json:"namespace"`
-	AutoStart     bool               `json:"auto_start"`
-	ContainerPath string             `json:"container_path"`
-	CreatedAt     pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
-	LastStartedAt pgtype.Timestamptz `json:"last_started_at"`
-	LastStoppedAt pgtype.Timestamptz `json:"last_stopped_at"`
+	ID               pgtype.UUID        `json:"id"`
+	BotID            pgtype.UUID        `json:"bot_id"`
+	ContainerID      string             `json:"container_id"`
+	ContainerName    string             `json:"container_name"`
+	Image            string             `json:"image"`
+	Status           string             `json:"status"`
+	Namespace        string             `json:"namespace"`
+	AutoStart        bool               `json:"auto_start"`
+	ContainerPath    string             `json:"container_path"`
+	WorkspaceBackend string             `json:"workspace_backend"`
+	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	LastStartedAt    pgtype.Timestamptz `json:"last_started_at"`
+	LastStoppedAt    pgtype.Timestamptz `json:"last_stopped_at"`
 }
 
 type ContainerVersion struct {

--- a/internal/db/sqlite/sqlc/containers.sql.go
+++ b/internal/db/sqlite/sqlc/containers.sql.go
@@ -20,7 +20,7 @@ func (q *Queries) DeleteContainerByBotID(ctx context.Context, botID string) erro
 }
 
 const getContainerByBotID = `-- name: GetContainerByBotID :one
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE bot_id = ?1 ORDER BY updated_at DESC LIMIT 1
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at, workspace_backend FROM containers WHERE bot_id = ?1 ORDER BY updated_at DESC LIMIT 1
 `
 
 func (q *Queries) GetContainerByBotID(ctx context.Context, botID string) (Container, error) {
@@ -40,12 +40,13 @@ func (q *Queries) GetContainerByBotID(ctx context.Context, botID string) (Contai
 		&i.UpdatedAt,
 		&i.LastStartedAt,
 		&i.LastStoppedAt,
+		&i.WorkspaceBackend,
 	)
 	return i, err
 }
 
 const listAutoStartContainers = `-- name: ListAutoStartContainers :many
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE auto_start = true ORDER BY updated_at DESC
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, created_at, updated_at, last_started_at, last_stopped_at, workspace_backend FROM containers WHERE auto_start = true ORDER BY updated_at DESC
 `
 
 func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, error) {
@@ -71,6 +72,7 @@ func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, err
 			&i.UpdatedAt,
 			&i.LastStartedAt,
 			&i.LastStoppedAt,
+			&i.WorkspaceBackend,
 		); err != nil {
 			return nil, err
 		}
@@ -126,7 +128,7 @@ func (q *Queries) UpdateContainerStopped(ctx context.Context, botID string) erro
 const upsertContainer = `-- name: UpsertContainer :exec
 INSERT INTO containers (
   id, bot_id, container_id, container_name, image, status, namespace, auto_start,
-  container_path, last_started_at, last_stopped_at
+  container_path, workspace_backend, last_started_at, last_stopped_at
 )
 VALUES (
   lower(hex(randomblob(4))) || '-' ||
@@ -143,7 +145,8 @@ VALUES (
   ?7,
   ?8,
   ?9,
-  ?10
+  ?10,
+  ?11
 )
 ON CONFLICT (container_id) DO UPDATE SET
   bot_id = EXCLUDED.bot_id,
@@ -153,22 +156,24 @@ ON CONFLICT (container_id) DO UPDATE SET
   namespace = EXCLUDED.namespace,
   auto_start = EXCLUDED.auto_start,
   container_path = EXCLUDED.container_path,
+  workspace_backend = EXCLUDED.workspace_backend,
   last_started_at = EXCLUDED.last_started_at,
   last_stopped_at = EXCLUDED.last_stopped_at,
   updated_at = CURRENT_TIMESTAMP
 `
 
 type UpsertContainerParams struct {
-	BotID         string         `json:"bot_id"`
-	ContainerID   string         `json:"container_id"`
-	ContainerName string         `json:"container_name"`
-	Image         string         `json:"image"`
-	Status        string         `json:"status"`
-	Namespace     string         `json:"namespace"`
-	AutoStart     int64          `json:"auto_start"`
-	ContainerPath string         `json:"container_path"`
-	LastStartedAt sql.NullString `json:"last_started_at"`
-	LastStoppedAt sql.NullString `json:"last_stopped_at"`
+	BotID            string         `json:"bot_id"`
+	ContainerID      string         `json:"container_id"`
+	ContainerName    string         `json:"container_name"`
+	Image            string         `json:"image"`
+	Status           string         `json:"status"`
+	Namespace        string         `json:"namespace"`
+	AutoStart        int64          `json:"auto_start"`
+	ContainerPath    string         `json:"container_path"`
+	WorkspaceBackend string         `json:"workspace_backend"`
+	LastStartedAt    sql.NullString `json:"last_started_at"`
+	LastStoppedAt    sql.NullString `json:"last_stopped_at"`
 }
 
 func (q *Queries) UpsertContainer(ctx context.Context, arg UpsertContainerParams) error {
@@ -181,6 +186,7 @@ func (q *Queries) UpsertContainer(ctx context.Context, arg UpsertContainerParams
 		arg.Namespace,
 		arg.AutoStart,
 		arg.ContainerPath,
+		arg.WorkspaceBackend,
 		arg.LastStartedAt,
 		arg.LastStoppedAt,
 	)

--- a/internal/db/sqlite/sqlc/models.go
+++ b/internal/db/sqlite/sqlc/models.go
@@ -236,19 +236,20 @@ type ChannelIdentityBindCode struct {
 }
 
 type Container struct {
-	ID            string         `json:"id"`
-	BotID         string         `json:"bot_id"`
-	ContainerID   string         `json:"container_id"`
-	ContainerName string         `json:"container_name"`
-	Image         string         `json:"image"`
-	Status        string         `json:"status"`
-	Namespace     string         `json:"namespace"`
-	AutoStart     int64          `json:"auto_start"`
-	ContainerPath string         `json:"container_path"`
-	CreatedAt     string         `json:"created_at"`
-	UpdatedAt     string         `json:"updated_at"`
-	LastStartedAt sql.NullString `json:"last_started_at"`
-	LastStoppedAt sql.NullString `json:"last_stopped_at"`
+	ID               string         `json:"id"`
+	BotID            string         `json:"bot_id"`
+	ContainerID      string         `json:"container_id"`
+	ContainerName    string         `json:"container_name"`
+	Image            string         `json:"image"`
+	Status           string         `json:"status"`
+	Namespace        string         `json:"namespace"`
+	AutoStart        int64          `json:"auto_start"`
+	ContainerPath    string         `json:"container_path"`
+	CreatedAt        string         `json:"created_at"`
+	UpdatedAt        string         `json:"updated_at"`
+	LastStartedAt    sql.NullString `json:"last_started_at"`
+	LastStoppedAt    sql.NullString `json:"last_stopped_at"`
+	WorkspaceBackend string         `json:"workspace_backend"`
 }
 
 type ContainerVersion struct {

--- a/internal/handlers/container_workspace.go
+++ b/internal/handlers/container_workspace.go
@@ -21,6 +21,7 @@ type containerWorkspace interface {
 	PrepareImageForCreate(ctx context.Context, image string, opts *ctr.PullImageOptions) (workspace.ImagePrepareResult, error)
 	HasPreservedData(botID string) bool
 	StartWithResolvedConfig(ctx context.Context, botID, image string, gpu workspace.WorkspaceGPUConfig) error
+	StartWithWorkspaceConfig(ctx context.Context, botID, image string, gpu workspace.WorkspaceGPUConfig, workspaceCfg workspace.WorkspaceStartConfig) error
 	RememberWorkspaceImage(ctx context.Context, botID, image string) error
 	RememberWorkspaceGPU(ctx context.Context, botID string, gpu workspace.WorkspaceGPUConfig) error
 	RestorePreservedData(ctx context.Context, botID string) error

--- a/internal/handlers/containerd.go
+++ b/internal/handlers/containerd.go
@@ -45,14 +45,18 @@ type ContainerGPURequest struct {
 }
 
 type CreateContainerRequest struct {
-	Snapshotter string               `json:"snapshotter,omitempty"`
-	RestoreData bool                 `json:"restore_data,omitempty"`
-	Image       string               `json:"image,omitempty"`
-	GPU         *ContainerGPURequest `json:"gpu,omitempty"`
+	Snapshotter        string               `json:"snapshotter,omitempty"`
+	RestoreData        bool                 `json:"restore_data,omitempty"`
+	Image              string               `json:"image,omitempty"`
+	WorkspaceBackend   string               `json:"workspace_backend,omitempty"`
+	LocalWorkspacePath string               `json:"local_workspace_path,omitempty"`
+	GPU                *ContainerGPURequest `json:"gpu,omitempty"`
 }
 
 type CreateContainerResponse struct {
 	ContainerID      string   `json:"container_id"`
+	WorkspaceBackend string   `json:"workspace_backend"`
+	ContainerPath    string   `json:"container_path"`
 	Image            string   `json:"image"`
 	Snapshotter      string   `json:"snapshotter"`
 	CDIDevices       []string `json:"cdi_devices,omitempty"`
@@ -99,6 +103,7 @@ type createContainerErrorEvent struct {
 
 type GetContainerResponse struct {
 	ContainerID      string    `json:"container_id"`
+	WorkspaceBackend string    `json:"workspace_backend"`
 	Image            string    `json:"image"`
 	Status           string    `json:"status"`
 	Namespace        string    `json:"namespace"`
@@ -314,32 +319,41 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 		send(createContainerErrorEvent{Type: "error", Message: msg})
 	}
 
-	// Phase 1: Pull image with progress
-	send(createContainerPullingEvent{Type: "pulling", Image: image})
-
-	var pullDone atomic.Bool
-	prepareResult, pullErr := h.manager.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
-		Unpack:        true,
-		StorageDriver: snapshotter,
-		OnProgress: func(p ctr.PullProgress) {
-			if pullDone.Load() {
-				return
-			}
-			send(createContainerPullProgressEvent{Type: "pull_progress", Layers: p.Layers})
-		},
-	})
-	pullDone.Store(true)
-	if pullErr != nil {
-		h.logger.Error("image preparation failed",
-			slog.String("image", image), slog.Any("error", pullErr))
-		sendError("image preparation failed: " + pullErr.Error())
-		return nil
+	workspaceBackend := strings.ToLower(strings.TrimSpace(req.WorkspaceBackend))
+	if workspaceBackend == "" {
+		workspaceBackend = "container"
 	}
-	switch prepareResult.Mode {
-	case workspace.ImagePrepareSkipped:
-		send(createContainerPullStatusEvent{Type: "pull_skipped", Image: image, Message: prepareResult.Message})
-	case workspace.ImagePrepareDelegated:
-		send(createContainerPullStatusEvent{Type: "pull_delegated", Image: image, Message: prepareResult.Message})
+	if workspaceBackend == "local" {
+		image = "local"
+		send(createContainerPullStatusEvent{Type: "pull_skipped", Image: image, Message: "local workspace does not use container images"})
+	} else {
+		// Phase 1: Pull image with progress
+		send(createContainerPullingEvent{Type: "pulling", Image: image})
+
+		var pullDone atomic.Bool
+		prepareResult, pullErr := h.manager.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
+			Unpack:        true,
+			StorageDriver: snapshotter,
+			OnProgress: func(p ctr.PullProgress) {
+				if pullDone.Load() {
+					return
+				}
+				send(createContainerPullProgressEvent{Type: "pull_progress", Layers: p.Layers})
+			},
+		})
+		pullDone.Store(true)
+		if pullErr != nil {
+			h.logger.Error("image preparation failed",
+				slog.String("image", image), slog.Any("error", pullErr))
+			sendError("image preparation failed: " + pullErr.Error())
+			return nil
+		}
+		switch prepareResult.Mode {
+		case workspace.ImagePrepareSkipped:
+			send(createContainerPullStatusEvent{Type: "pull_skipped", Image: image, Message: prepareResult.Message})
+		case workspace.ImagePrepareDelegated:
+			send(createContainerPullStatusEvent{Type: "pull_delegated", Image: image, Message: prepareResult.Message})
+		}
 	}
 
 	// Phase 2: Create container (image is local, should be fast)
@@ -351,7 +365,10 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 		send(createContainerRestoringEvent{Type: "restoring"})
 	}
 
-	if err := h.manager.StartWithResolvedConfig(ctx, botID, image, gpu); err != nil {
+	if err := h.manager.StartWithWorkspaceConfig(ctx, botID, image, gpu, workspace.WorkspaceStartConfig{
+		Backend:            workspaceBackend,
+		LocalWorkspacePath: strings.TrimSpace(req.LocalWorkspacePath),
+	}); err != nil {
 		h.logger.Error("container start failed",
 			slog.String("bot_id", botID), slog.Any("error", err))
 		sendError("container start failed: " + err.Error())
@@ -395,8 +412,12 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 			slog.String("bot_id", botID), slog.Any("error", statusErr))
 	}
 	cdiDevices := gpu.Devices
+	containerPath := ""
+	responseBackend := workspaceBackend
 	if status != nil {
 		cdiDevices = status.CDIDevices
+		containerPath = status.ContainerPath
+		responseBackend = status.WorkspaceBackend
 	}
 
 	// Phase 3: Complete
@@ -404,6 +425,8 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 		Type: "complete",
 		Container: CreateContainerResponse{
 			ContainerID:      containerID,
+			WorkspaceBackend: responseBackend,
+			ContainerPath:    containerPath,
 			Image:            image,
 			Snapshotter:      snapshotter,
 			CDIDevices:       cdiDevices,
@@ -438,6 +461,7 @@ func (h *ContainerdHandler) GetContainer(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, GetContainerResponse{
 		ContainerID:      status.ContainerID,
+		WorkspaceBackend: status.WorkspaceBackend,
 		Image:            status.Image,
 		Status:           status.Status,
 		Namespace:        status.Namespace,

--- a/internal/handlers/ping.go
+++ b/internal/handlers/ping.go
@@ -9,33 +9,37 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/memohai/memoh/internal/boot"
+	"github.com/memohai/memoh/internal/config"
 	ctr "github.com/memohai/memoh/internal/container"
 	"github.com/memohai/memoh/internal/version"
 )
 
 type PingResponse struct {
-	Status            string `json:"status"`
-	ContainerBackend  string `json:"container_backend"`
-	SnapshotSupported bool   `json:"snapshot_supported"`
-	Version           string `json:"version"`
-	CommitHash        string `json:"commit_hash"`
+	Status                string `json:"status"`
+	ContainerBackend      string `json:"container_backend"`
+	LocalWorkspaceEnabled bool   `json:"local_workspace_enabled"`
+	SnapshotSupported     bool   `json:"snapshot_supported"`
+	Version               string `json:"version"`
+	CommitHash            string `json:"commit_hash"`
 }
 
 type PingHandler struct {
 	logger  *slog.Logger
 	runtime *boot.RuntimeConfig
 	service ctr.Service
+	cfg     config.Config
 }
 
 type snapshotCapabilityProvider interface {
 	SnapshotSupported(ctx context.Context) bool
 }
 
-func NewPingHandler(log *slog.Logger, rc *boot.RuntimeConfig, service ctr.Service) *PingHandler {
+func NewPingHandler(log *slog.Logger, rc *boot.RuntimeConfig, service ctr.Service, cfg config.Config) *PingHandler {
 	return &PingHandler{
 		logger:  log.With(slog.String("handler", "ping")),
 		runtime: rc,
 		service: service,
+		cfg:     cfg,
 	}
 }
 
@@ -51,11 +55,12 @@ func (h *PingHandler) Register(e *echo.Echo) {
 // @Router /ping [get].
 func (h *PingHandler) Ping(c echo.Context) error {
 	return c.JSON(http.StatusOK, PingResponse{
-		Status:            "ok",
-		ContainerBackend:  ctr.NormalizeBackend(h.runtime.ContainerBackend),
-		SnapshotSupported: h.snapshotSupported(c.Request().Context()),
-		Version:           version.Version,
-		CommitHash:        version.ShortCommitHash(),
+		Status:                "ok",
+		ContainerBackend:      ctr.NormalizeBackend(h.runtime.ContainerBackend),
+		LocalWorkspaceEnabled: h.cfg.Local.Enabled,
+		SnapshotSupported:     h.snapshotSupported(c.Request().Context()),
+		Version:               version.Version,
+		CommitHash:            version.ShortCommitHash(),
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,11 @@ func NewServer(log *slog.Logger, addr string, jwtSecret string,
 	e := echo.New()
 	e.HideBanner = true
 	e.Use(middleware.Recover())
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{echo.GET, echo.HEAD, echo.POST, echo.PUT, echo.PATCH, echo.DELETE, echo.OPTIONS},
+		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
+	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogStatus: true,
 		LogURI:    true,

--- a/internal/storage/providers/containerfs/provider.go
+++ b/internal/storage/providers/containerfs/provider.go
@@ -82,7 +82,14 @@ func (*Provider) AccessPath(key string) string {
 func (p *Provider) OpenContainerFile(ctx context.Context, botID, containerPath string) (io.ReadCloser, error) {
 	subPath, ok := attachmentpkg.DataSubpath(containerPath)
 	if !ok {
-		return nil, fmt.Errorf("path must start with %s/", attachmentpkg.DataMountPath(""))
+		if !filepath.IsAbs(strings.TrimSpace(containerPath)) {
+			return nil, fmt.Errorf("path must start with %s/ or be an absolute local workspace path", attachmentpkg.DataMountPath(""))
+		}
+		client, err := p.clients.MCPClient(ctx, botID)
+		if err != nil {
+			return nil, fmt.Errorf("get client: %w", err)
+		}
+		return client.ReadRaw(ctx, filepath.Clean(containerPath))
 	}
 	if subPath == "" || strings.Contains(subPath, "..") {
 		return nil, errors.New("invalid container path")

--- a/internal/workspace/bridge/workspace_info.go
+++ b/internal/workspace/bridge/workspace_info.go
@@ -1,0 +1,17 @@
+package bridge
+
+import "context"
+
+const (
+	WorkspaceBackendContainer = "container"
+	WorkspaceBackendLocal     = "local"
+)
+
+type WorkspaceInfo struct {
+	Backend        string
+	DefaultWorkDir string
+}
+
+type WorkspaceInfoProvider interface {
+	WorkspaceInfo(ctx context.Context, botID string) (WorkspaceInfo, error)
+}

--- a/internal/workspace/bridgesvc/path_test.go
+++ b/internal/workspace/bridgesvc/path_test.go
@@ -1,0 +1,64 @@
+package bridgesvc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
+)
+
+func TestLocalPathResolverMapsDataMountToWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	srv := New(Options{
+		DefaultWorkDir:    root,
+		WorkspaceRoot:     root,
+		DataMount:         "/data",
+		AllowHostAbsolute: true,
+	})
+
+	if _, err := srv.WriteFile(context.Background(), &pb.WriteFileRequest{
+		Path:    "/data/notes/demo.txt",
+		Content: []byte("demo"),
+	}); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "notes", "demo.txt")) //nolint:gosec // test path is under t.TempDir
+	if err != nil {
+		t.Fatalf("read mapped file failed: %v", err)
+	}
+	if string(got) != "demo" {
+		t.Fatalf("mapped file = %q, want demo", string(got))
+	}
+}
+
+func TestLocalPathResolverAllowsHostAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	srv := New(Options{
+		DefaultWorkDir:    root,
+		WorkspaceRoot:     root,
+		DataMount:         "/data",
+		AllowHostAbsolute: true,
+	})
+
+	if _, err := srv.WriteFile(context.Background(), &pb.WriteFileRequest{
+		Path:    outside,
+		Content: []byte("outside"),
+	}); err != nil {
+		t.Fatalf("WriteFile absolute path failed: %v", err)
+	}
+	got, err := os.ReadFile(outside) //nolint:gosec // test path is under t.TempDir
+	if err != nil {
+		t.Fatalf("read absolute file failed: %v", err)
+	}
+	if string(got) != "outside" {
+		t.Fatalf("absolute file = %q, want outside", string(got))
+	}
+}

--- a/internal/workspace/bridgesvc/server.go
+++ b/internal/workspace/bridgesvc/server.go
@@ -1,4 +1,4 @@
-package main
+package bridgesvc
 
 import (
 	"bufio"
@@ -25,28 +25,62 @@ import (
 
 const (
 	readMaxLines      = 2000
-	readMaxBytes      = 0 // 0 = no byte limit (line count only)
-	readMaxLineLen    = 0 // 0 = no per-line truncation
+	readMaxBytes      = 0
+	readMaxLineLen    = 0
 	listMaxEntries    = 200
 	binaryProbeBytes  = 8 * 1024
 	rawChunkSize      = 64 * 1024
-	defaultWorkDir    = "/data"
+	DefaultWorkDir    = "/data"
 	defaultTimeout    = 30
-	defaultPTYTimeout = 5 * 60 // 5 minutes max for PTY sessions (agent tool calls)
+	defaultPTYTimeout = 5 * 60
 )
 
-type containerServer struct {
-	pb.UnimplementedContainerServiceServer
+type Options struct {
+	DefaultWorkDir    string
+	WorkspaceRoot     string
+	DataMount         string
+	AllowHostAbsolute bool
 }
 
-func (*containerServer) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
+type Server struct {
+	pb.UnimplementedContainerServiceServer
+	defaultWorkDir    string
+	workspaceRoot     string
+	dataMount         string
+	allowHostAbsolute bool
+}
+
+func New(opts Options) *Server {
+	defaultWorkDir := strings.TrimSpace(opts.DefaultWorkDir)
+	if defaultWorkDir == "" {
+		defaultWorkDir = DefaultWorkDir
+	}
+	dataMount := strings.TrimRight(strings.TrimSpace(opts.DataMount), string(filepath.Separator))
+	if dataMount == "" {
+		dataMount = DefaultWorkDir
+	}
+	workspaceRoot := strings.TrimSpace(opts.WorkspaceRoot)
+	if workspaceRoot != "" {
+		if abs, err := filepath.Abs(workspaceRoot); err == nil {
+			workspaceRoot = abs
+		}
+	}
+	return &Server{
+		defaultWorkDir:    filepath.Clean(defaultWorkDir),
+		workspaceRoot:     filepath.Clean(workspaceRoot),
+		dataMount:         filepath.Clean(dataMount),
+		allowHostAbsolute: opts.AllowHostAbsolute,
+	}
+}
+
+func (s *Server) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
 	path := req.GetPath()
 	if path == "" {
 		return nil, status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
-	f, err := os.Open(path) //nolint:gosec // G304: MCP container filesystem server; paths are resolved within the container's /data, SSRF is by design
+	f, err := os.Open(path) //nolint:gosec // G304: workspace bridge intentionally serves agent-selected paths.
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "open: %v", err)
 	}
@@ -86,7 +120,7 @@ func (*containerServer) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*p
 			continue
 		}
 		if linesRead >= nLines {
-			continue // keep scanning to count total lines
+			continue
 		}
 
 		line := scanner.Text()
@@ -103,7 +137,6 @@ func (*containerServer) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*p
 		linesRead++
 	}
 
-	// Drain remaining lines for total count.
 	for scanner.Scan() {
 		totalLines++
 	}
@@ -114,12 +147,12 @@ func (*containerServer) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*p
 	}, nil
 }
 
-func (*containerServer) WriteFile(_ context.Context, req *pb.WriteFileRequest) (*pb.WriteFileResponse, error) {
+func (s *Server) WriteFile(_ context.Context, req *pb.WriteFileRequest) (*pb.WriteFileResponse, error) {
 	path := req.GetPath()
 	if path == "" {
 		return nil, status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir: %v", err)
@@ -130,25 +163,25 @@ func (*containerServer) WriteFile(_ context.Context, req *pb.WriteFileRequest) (
 	return &pb.WriteFileResponse{}, nil
 }
 
-func (*containerServer) ListDir(_ context.Context, req *pb.ListDirRequest) (*pb.ListDirResponse, error) {
+func (s *Server) ListDir(_ context.Context, req *pb.ListDirRequest) (*pb.ListDirResponse, error) {
 	dir := req.GetPath()
 	if dir == "" {
 		dir = "."
 	}
-	dir = resolvePath(dir)
+	dir = s.resolvePath(dir)
 
 	var all []*pb.FileEntry
 
 	if req.GetRecursive() {
 		err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return nil // skip errors
+				return nil
 			}
 			rel, _ := filepath.Rel(dir, p)
 			if rel == "." {
 				return nil
 			}
-			entry, _ := buildFileEntry(rel, p, d)
+			entry, _ := buildFileEntry(rel, d)
 			if entry != nil {
 				all = append(all, entry)
 			}
@@ -167,7 +200,7 @@ func (*containerServer) ListDir(_ context.Context, req *pb.ListDirRequest) (*pb.
 			return nil, status.Errorf(codes.NotFound, "readdir: %v", err)
 		}
 		for _, d := range dirEntries {
-			entry, _ := buildFileEntry(d.Name(), filepath.Join(dir, d.Name()), d)
+			entry, _ := buildFileEntry(d.Name(), d)
 			if entry != nil {
 				all = append(all, entry)
 			}
@@ -187,7 +220,6 @@ func (*containerServer) ListDir(_ context.Context, req *pb.ListDirRequest) (*pb.
 		limit = listMaxEntries
 	}
 
-	// limit=0 means no limit (return all entries from offset)
 	var entries []*pb.FileEntry
 	if int(offset) < len(all) {
 		entries = all[offset:]
@@ -204,68 +236,7 @@ func (*containerServer) ListDir(_ context.Context, req *pb.ListDirRequest) (*pb.
 	}, nil
 }
 
-// collapseHeavySubdirs replaces entries under top-level subdirectories that
-// exceed the threshold with a single summary entry per heavy directory.
-// The top-level directory entry itself (e.g. ".venv") is preserved.
-func collapseHeavySubdirs(entries []*pb.FileEntry, threshold int) []*pb.FileEntry {
-	counts := make(map[string]int)
-	for _, e := range entries {
-		top := listTopDir(e.GetPath())
-		if top != "" {
-			counts[top]++
-		}
-	}
-
-	heavy := make(map[string]bool)
-	for dir, n := range counts {
-		if n > threshold {
-			heavy[dir] = true
-		}
-	}
-	if len(heavy) == 0 {
-		return entries
-	}
-
-	seen := make(map[string]bool)
-	out := make([]*pb.FileEntry, 0, len(entries))
-	for _, e := range entries {
-		path := e.GetPath()
-		top := listTopDir(path)
-
-		if !heavy[top] {
-			// Top-level files (top=="") or entries under non-heavy dirs pass through.
-			out = append(out, e)
-			continue
-		}
-
-		// Keep the top-level directory entry itself (path == top, is_dir).
-		if path == top && e.GetIsDir() {
-			out = append(out, e)
-			continue
-		}
-
-		if seen[top] {
-			continue
-		}
-		seen[top] = true
-		out = append(out, &pb.FileEntry{
-			Path:    top + "/",
-			IsDir:   true,
-			Summary: fmt.Sprintf("%d items (not expanded)", counts[top]),
-		})
-	}
-	return out
-}
-
-// listTopDir extracts the first path component from a relative path.
-func listTopDir(path string) string {
-	if i := strings.IndexByte(path, '/'); i >= 0 {
-		return path[:i]
-	}
-	return ""
-}
-
-func (*containerServer) Exec(stream pb.ContainerService_ExecServer) error {
+func (s *Server) Exec(stream pb.ContainerService_ExecServer) error {
 	firstMsg, err := stream.Recv()
 	if err != nil {
 		return status.Error(codes.InvalidArgument, "failed to receive exec config")
@@ -277,17 +248,14 @@ func (*containerServer) Exec(stream pb.ContainerService_ExecServer) error {
 	}
 
 	if firstMsg.GetPty() {
-		return execPTY(stream, firstMsg)
+		return s.execPTY(stream, firstMsg)
 	}
-	return execPipe(stream, firstMsg)
+	return s.execPipe(stream, firstMsg)
 }
 
-func execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) error {
+func (s *Server) execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) error {
 	command := firstMsg.GetCommand()
-	workDir := firstMsg.GetWorkDir()
-	if workDir == "" {
-		workDir = defaultWorkDir
-	}
+	workDir := s.resolveExecWorkDir(firstMsg.GetWorkDir())
 
 	timeout := int(firstMsg.GetTimeoutSeconds())
 	if timeout <= 0 {
@@ -298,9 +266,9 @@ func execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) erro
 
 	var cmd *exec.Cmd
 	if isBarePath(command) {
-		cmd = exec.CommandContext(ctx, command) //nolint:gosec // G204: intentional
+		cmd = exec.CommandContext(ctx, command) //nolint:gosec // G204: intentional agent command execution.
 	} else {
-		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec // G204: intentional
+		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec // G204: intentional agent command execution.
 	}
 	cmd.Dir = workDir
 	cmd.Env = append(os.Environ(), firstMsg.GetEnv()...)
@@ -318,7 +286,6 @@ func execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) erro
 	}
 	defer func() { _ = ptmx.Close() }()
 
-	// stdin + resize from stream
 	go func() {
 		for {
 			msg, recvErr := stream.Recv()
@@ -337,7 +304,6 @@ func execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) erro
 		}
 	}()
 
-	// PTY output -> stream (single fd merges stdout+stderr)
 	streamPipe(stream, ptmx, pb.ExecOutput_STDOUT)
 
 	exitCode := int32(0)
@@ -357,26 +323,19 @@ func execPTY(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) erro
 	})
 }
 
-func execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) error {
+func (s *Server) execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) error {
 	command := firstMsg.GetCommand()
-	workDir := firstMsg.GetWorkDir()
-	if workDir == "" {
-		workDir = defaultWorkDir
-	}
+	workDir := s.resolveExecWorkDir(firstMsg.GetWorkDir())
 
 	timeout := int(firstMsg.GetTimeoutSeconds())
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
 
-	// Process context is independent of the gRPC stream so the process keeps
-	// running even if the stream is cancelled (e.g. background tasks whose client
-	// disconnects or whose stream context dies after the process completes).
-	// Only the process-level timeout kills the process, not stream death.
 	procCtx, procCancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer procCancel()
 
-	cmd := exec.CommandContext(procCtx, "/bin/sh", "-c", command) //nolint:gosec // G204: MCP exec tool intentionally executes agent-issued shell commands inside the container
+	cmd := exec.CommandContext(procCtx, "/bin/sh", "-c", command) //nolint:gosec // G204: intentional agent command execution.
 	cmd.Dir = workDir
 	if len(firstMsg.GetEnv()) > 0 {
 		cmd.Env = append(os.Environ(), firstMsg.GetEnv()...)
@@ -386,7 +345,6 @@ func execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) err
 	if err != nil {
 		return status.Errorf(codes.Internal, "stdin pipe: %v", err)
 	}
-
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return status.Errorf(codes.Internal, "stdout pipe: %v", err)
@@ -400,10 +358,6 @@ func execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) err
 		return status.Errorf(codes.Internal, "start: %v", err)
 	}
 
-	// Close pipes when EITHER the process finishes (procCtx done) OR the gRPC
-	// stream dies (stream.Context done). Closing unblocks streamPipe's Read so
-	// the goroutines can exit. We do NOT cancel procCtx on stream death — the
-	// process keeps running so background tasks survive client disconnects.
 	go func() {
 		select {
 		case <-procCtx.Done():
@@ -439,16 +393,12 @@ func execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) err
 		exitErr := &exec.ExitError{}
 		if errors.As(err, &exitErr) {
 			ec := exitErr.ExitCode()
-			exitCode = int32(max(math.MinInt32, min(math.MaxInt32, ec))) //nolint:gosec // G115: value is clamped to int32 range above; Unix exit codes are 0-255
+			exitCode = int32(max(math.MinInt32, min(math.MaxInt32, ec))) //nolint:gosec // G115
 		} else {
 			exitCode = -1
 		}
 	}
 
-	// Send exit code to the client. If the stream is already gone (e.g. the
-	// client is a background task manager that got a stream error when the
-	// process completed), the send will fail but we return nil so the gRPC
-	// handler does not propagate a spurious "context canceled" error status.
 	_ = stream.Send(&pb.ExecOutput{
 		Stream:   pb.ExecOutput_EXIT,
 		ExitCode: exitCode,
@@ -456,14 +406,14 @@ func execPipe(stream pb.ContainerService_ExecServer, firstMsg *pb.ExecInput) err
 	return nil
 }
 
-func (*containerServer) ReadRaw(req *pb.ReadRawRequest, stream pb.ContainerService_ReadRawServer) error {
+func (s *Server) ReadRaw(req *pb.ReadRawRequest, stream pb.ContainerService_ReadRawServer) error {
 	path := req.GetPath()
 	if path == "" {
 		return status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
-	f, err := os.Open(path) //nolint:gosec // G304: MCP container filesystem server; path is resolved within the container
+	f, err := os.Open(path) //nolint:gosec // G304: workspace bridge intentionally serves agent-selected paths.
 	if err != nil {
 		return status.Errorf(codes.NotFound, "open: %v", err)
 	}
@@ -487,7 +437,7 @@ func (*containerServer) ReadRaw(req *pb.ReadRawRequest, stream pb.ContainerServi
 	return nil
 }
 
-func (*containerServer) WriteRaw(stream pb.ContainerService_WriteRawServer) error {
+func (s *Server) WriteRaw(stream pb.ContainerService_WriteRawServer) error {
 	var f *os.File
 	var written int64
 
@@ -505,11 +455,11 @@ func (*containerServer) WriteRaw(stream pb.ContainerService_WriteRawServer) erro
 			if path == "" {
 				return status.Error(codes.InvalidArgument, "first chunk must include path")
 			}
-			path = resolvePath(path)
+			path = s.resolvePath(path)
 			if mkErr := os.MkdirAll(filepath.Dir(path), 0o750); mkErr != nil {
 				return status.Errorf(codes.Internal, "mkdir: %v", mkErr)
 			}
-			f, err = os.Create(path) //nolint:gosec // G304: MCP container filesystem server; path is resolved within the container
+			f, err = os.Create(path) //nolint:gosec // G304: workspace bridge intentionally serves agent-selected paths.
 			if err != nil {
 				return status.Errorf(codes.Internal, "create: %v", err)
 			}
@@ -528,12 +478,12 @@ func (*containerServer) WriteRaw(stream pb.ContainerService_WriteRawServer) erro
 	return stream.SendAndClose(&pb.WriteRawResponse{BytesWritten: written})
 }
 
-func (*containerServer) DeleteFile(_ context.Context, req *pb.DeleteFileRequest) (*pb.DeleteFileResponse, error) {
+func (s *Server) DeleteFile(_ context.Context, req *pb.DeleteFileRequest) (*pb.DeleteFileResponse, error) {
 	path := req.GetPath()
 	if path == "" {
 		return nil, status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
 	var err error
 	if req.GetRecursive() {
@@ -547,12 +497,12 @@ func (*containerServer) DeleteFile(_ context.Context, req *pb.DeleteFileRequest)
 	return &pb.DeleteFileResponse{}, nil
 }
 
-func (*containerServer) Stat(_ context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
+func (s *Server) Stat(_ context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
 	path := req.GetPath()
 	if path == "" {
 		return nil, status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -572,12 +522,12 @@ func (*containerServer) Stat(_ context.Context, req *pb.StatRequest) (*pb.StatRe
 	}, nil
 }
 
-func (*containerServer) Mkdir(_ context.Context, req *pb.MkdirRequest) (*pb.MkdirResponse, error) {
+func (s *Server) Mkdir(_ context.Context, req *pb.MkdirRequest) (*pb.MkdirResponse, error) {
 	path := req.GetPath()
 	if path == "" {
 		return nil, status.Error(codes.InvalidArgument, "path is required")
 	}
-	path = resolvePath(path)
+	path = s.resolvePath(path)
 
 	if err := os.MkdirAll(path, 0o750); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir: %v", err)
@@ -585,14 +535,14 @@ func (*containerServer) Mkdir(_ context.Context, req *pb.MkdirRequest) (*pb.Mkdi
 	return &pb.MkdirResponse{}, nil
 }
 
-func (*containerServer) Rename(_ context.Context, req *pb.RenameRequest) (*pb.RenameResponse, error) {
+func (s *Server) Rename(_ context.Context, req *pb.RenameRequest) (*pb.RenameResponse, error) {
 	oldPath := req.GetOldPath()
 	newPath := req.GetNewPath()
 	if oldPath == "" || newPath == "" {
 		return nil, status.Error(codes.InvalidArgument, "old_path and new_path are required")
 	}
-	oldPath = resolvePath(oldPath)
-	newPath = resolvePath(newPath)
+	oldPath = s.resolvePath(oldPath)
+	newPath = s.resolvePath(newPath)
 
 	if err := os.MkdirAll(filepath.Dir(newPath), 0o750); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir parent: %v", err)
@@ -603,10 +553,85 @@ func (*containerServer) Rename(_ context.Context, req *pb.RenameRequest) (*pb.Re
 	return &pb.RenameResponse{}, nil
 }
 
-// isBarePath returns true when the command string is a plain executable path
-// (no spaces, shell operators, or arguments) so it can be exec'd directly
-// without wrapping in "/bin/sh -c". This matters for interactive PTY shells
-// where /bin/sh -c wrapping would strip readline support.
+func (s *Server) resolveExecWorkDir(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return s.defaultWorkDir
+	}
+	return s.resolvePath(path)
+}
+
+func (s *Server) resolvePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return s.defaultWorkDir
+	}
+	clean := filepath.Clean(path)
+	if filepath.IsAbs(clean) {
+		if s.workspaceRoot != "." && (clean == s.dataMount || strings.HasPrefix(clean, s.dataMount+string(filepath.Separator))) {
+			rel := strings.TrimPrefix(clean, s.dataMount)
+			return filepath.Join(s.workspaceRoot, strings.TrimPrefix(rel, string(filepath.Separator)))
+		}
+		if s.allowHostAbsolute || s.workspaceRoot == "." || clean == s.defaultWorkDir || strings.HasPrefix(clean, s.defaultWorkDir+string(filepath.Separator)) {
+			return clean
+		}
+		return filepath.Join(s.defaultWorkDir, strings.TrimPrefix(clean, string(filepath.Separator)))
+	}
+	return filepath.Join(s.defaultWorkDir, clean)
+}
+
+func collapseHeavySubdirs(entries []*pb.FileEntry, threshold int) []*pb.FileEntry {
+	counts := make(map[string]int)
+	for _, e := range entries {
+		top := listTopDir(e.GetPath())
+		if top != "" {
+			counts[top]++
+		}
+	}
+
+	heavy := make(map[string]bool)
+	for dir, n := range counts {
+		if n > threshold {
+			heavy[dir] = true
+		}
+	}
+	if len(heavy) == 0 {
+		return entries
+	}
+
+	seen := make(map[string]bool)
+	out := make([]*pb.FileEntry, 0, len(entries))
+	for _, e := range entries {
+		path := e.GetPath()
+		top := listTopDir(path)
+
+		if !heavy[top] {
+			out = append(out, e)
+			continue
+		}
+		if path == top && e.GetIsDir() {
+			out = append(out, e)
+			continue
+		}
+		if seen[top] {
+			continue
+		}
+		seen[top] = true
+		out = append(out, &pb.FileEntry{
+			Path:    top + "/",
+			IsDir:   true,
+			Summary: fmt.Sprintf("%d items (not expanded)", counts[top]),
+		})
+	}
+	return out
+}
+
+func listTopDir(path string) string {
+	if i := strings.IndexByte(path, '/'); i >= 0 {
+		return path[:i]
+	}
+	return ""
+}
+
 func isBarePath(cmd string) bool {
 	if cmd == "" {
 		return false
@@ -635,7 +660,7 @@ func streamPipe(stream pb.ContainerService_ExecServer, r io.Reader, st pb.ExecOu
 	}
 }
 
-func buildFileEntry(name, _ string, d fs.DirEntry) (*pb.FileEntry, error) {
+func buildFileEntry(name string, d fs.DirEntry) (*pb.FileEntry, error) {
 	info, err := d.Info()
 	if err != nil {
 		return nil, err
@@ -647,13 +672,6 @@ func buildFileEntry(name, _ string, d fs.DirEntry) (*pb.FileEntry, error) {
 		Mode:    info.Mode().String(),
 		ModTime: info.ModTime().Format(time.RFC3339),
 	}, nil
-}
-
-func resolvePath(path string) string {
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-	return filepath.Join(defaultWorkDir, path)
 }
 
 func truncateRunes(s string, maxRunes int) string {

--- a/internal/workspace/bridgesvc/server_test.go
+++ b/internal/workspace/bridgesvc/server_test.go
@@ -1,4 +1,4 @@
-package main
+package bridgesvc
 
 import (
 	"context"
@@ -50,8 +50,9 @@ func (*cancelOnStdoutExecStream) RecvMsg(any) error            { return nil }
 
 func TestExecPipePreservesExitCodeAcrossStreamCancellation(t *testing.T) {
 	stream := newCancelOnStdoutExecStream()
+	srv := New(Options{DefaultWorkDir: "/tmp", AllowHostAbsolute: true})
 
-	err := execPipe(stream, &pb.ExecInput{
+	err := srv.execPipe(stream, &pb.ExecInput{
 		Command:        "printf ok; sleep 0.2",
 		WorkDir:        "/tmp",
 		TimeoutSeconds: 5,

--- a/internal/workspace/dataio.go
+++ b/internal/workspace/dataio.go
@@ -449,7 +449,7 @@ func (m *Manager) legacyDataDir(botID string) string {
 // ---------------------------------------------------------------------------
 
 func (m *Manager) exportDataViaGRPC(ctx context.Context, botID string) (io.ReadCloser, error) {
-	client, err := m.grpcPool.Get(ctx, botID)
+	client, err := m.MCPClient(ctx, botID)
 	if err != nil {
 		return nil, fmt.Errorf("grpc connect: %w", err)
 	}
@@ -563,7 +563,7 @@ func (m *Manager) restoreArchiveSnapshotFromRef(ctx context.Context, ref *locked
 	}
 	defer func() { _ = f.Close() }()
 
-	client, err := m.grpcPool.Get(ctx, ref.botID)
+	client, err := m.MCPClient(ctx, ref.botID)
 	if err != nil {
 		return fmt.Errorf("grpc connect: %w", err)
 	}
@@ -575,7 +575,7 @@ func (m *Manager) restoreArchiveSnapshotFromRef(ctx context.Context, ref *locked
 }
 
 func (m *Manager) importDataViaGRPC(ctx context.Context, botID string, r io.Reader) error {
-	client, err := m.grpcPool.Get(ctx, botID)
+	client, err := m.MCPClient(ctx, botID)
 	if err != nil {
 		return fmt.Errorf("grpc connect: %w", err)
 	}
@@ -606,7 +606,7 @@ func (m *Manager) importDataViaGRPC(ctx context.Context, botID string, r io.Read
 }
 
 func (m *Manager) importLegacyDirViaGRPC(ctx context.Context, botID, srcDir string) error {
-	client, err := m.grpcPool.Get(ctx, botID)
+	client, err := m.MCPClient(ctx, botID)
 	if err != nil {
 		return fmt.Errorf("grpc connect: %w", err)
 	}

--- a/internal/workspace/identity.go
+++ b/internal/workspace/identity.go
@@ -6,7 +6,7 @@ import (
 	ctr "github.com/memohai/memoh/internal/container"
 )
 
-var knownContainerPrefixes = []string{ContainerPrefix, LegacyContainerPrefix}
+var knownContainerPrefixes = []string{ContainerPrefix, LegacyContainerPrefix, LocalContainerPrefix}
 
 // BotIDFromContainerID infers a bot ID from a known container naming scheme.
 // This is only used as a fallback for legacy containers when labels are missing.

--- a/internal/workspace/image_preference.go
+++ b/internal/workspace/image_preference.go
@@ -12,11 +12,14 @@ import (
 	"github.com/memohai/memoh/internal/config"
 	"github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 const (
 	workspaceMetadataKey                    = "workspace"
 	workspaceImageMetadataKey               = "image"
+	workspaceBackendMetadataKey             = "backend"
+	workspaceLocalPathMetadataKey           = "local_workspace_path"
 	workspaceGPUMetadataKey                 = "gpu"
 	workspaceGPUDevicesKey                  = "devices"
 	workspaceSkillDiscoveryRootsMetadataKey = "skill_discovery_roots"
@@ -67,6 +70,25 @@ func workspaceImageFromMetadata(metadata map[string]any) string {
 	section := workspaceSection(metadata)
 	image, _ := section[workspaceImageMetadataKey].(string)
 	return strings.TrimSpace(image)
+}
+
+func workspaceBackendFromMetadata(metadata map[string]any) string {
+	section := workspaceSection(metadata)
+	backend, _ := section[workspaceBackendMetadataKey].(string)
+	switch strings.ToLower(strings.TrimSpace(backend)) {
+	case bridge.WorkspaceBackendLocal:
+		return bridge.WorkspaceBackendLocal
+	case bridge.WorkspaceBackendContainer, "":
+		return bridge.WorkspaceBackendContainer
+	default:
+		return bridge.WorkspaceBackendContainer
+	}
+}
+
+func localWorkspacePathFromMetadata(metadata map[string]any) string {
+	section := workspaceSection(metadata)
+	path, _ := section[workspaceLocalPathMetadataKey].(string)
+	return strings.TrimSpace(path)
 }
 
 func normalizeWorkspaceGPUDevices(devices []string) []string {
@@ -165,6 +187,19 @@ func withoutWorkspaceImagePreference(metadata map[string]any) map[string]any {
 	return next
 }
 
+func withWorkspaceBackendPreference(metadata map[string]any, backend, localPath string) map[string]any {
+	next := cloneAnyMap(metadata)
+	section := workspaceSection(next)
+	section[workspaceBackendMetadataKey] = strings.TrimSpace(backend)
+	if strings.TrimSpace(localPath) != "" {
+		section[workspaceLocalPathMetadataKey] = strings.TrimSpace(localPath)
+	} else {
+		delete(section, workspaceLocalPathMetadataKey)
+	}
+	next[workspaceMetadataKey] = section
+	return next
+}
+
 func withWorkspaceGPUPreference(metadata map[string]any, gpu WorkspaceGPUConfig) map[string]any {
 	next := cloneAnyMap(metadata)
 	section := workspaceSection(next)
@@ -235,6 +270,31 @@ func (m *Manager) botWorkspaceImagePreference(ctx context.Context, botID string)
 	return workspaceImageFromMetadata(metadata), nil
 }
 
+func (m *Manager) botWorkspaceStartPreference(ctx context.Context, botID string) (WorkspaceStartConfig, error) {
+	if m.queries == nil {
+		return WorkspaceStartConfig{Backend: bridge.WorkspaceBackendContainer}, nil
+	}
+	botUUID, err := db.ParseUUID(botID)
+	if err != nil {
+		return WorkspaceStartConfig{}, err
+	}
+	row, err := m.queries.GetBotByID(ctx, botUUID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceStartConfig{Backend: bridge.WorkspaceBackendContainer}, nil
+		}
+		return WorkspaceStartConfig{}, err
+	}
+	metadata, err := decodeBotMetadata(row.Metadata)
+	if err != nil {
+		return WorkspaceStartConfig{}, err
+	}
+	return WorkspaceStartConfig{
+		Backend:            workspaceBackendFromMetadata(metadata),
+		LocalWorkspacePath: localWorkspacePathFromMetadata(metadata),
+	}, nil
+}
+
 func (m *Manager) updateBotWorkspaceImagePreference(ctx context.Context, botID, image string, clearPreference bool) error {
 	if m.queries == nil {
 		return nil
@@ -256,6 +316,38 @@ func (m *Manager) updateBotWorkspaceImagePreference(ctx context.Context, botID, 
 	} else {
 		metadata = withWorkspaceImagePreference(metadata, image)
 	}
+	payload, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	_, err = m.queries.UpdateBotProfile(ctx, dbsqlc.UpdateBotProfileParams{
+		ID:          botUUID,
+		DisplayName: row.DisplayName,
+		AvatarUrl:   row.AvatarUrl,
+		Timezone:    row.Timezone,
+		IsActive:    row.IsActive,
+		Metadata:    payload,
+	})
+	return err
+}
+
+func (m *Manager) rememberWorkspaceBackend(ctx context.Context, botID, backend, localPath string) error {
+	if m.queries == nil {
+		return nil
+	}
+	botUUID, err := db.ParseUUID(botID)
+	if err != nil {
+		return err
+	}
+	row, err := m.queries.GetBotByID(ctx, botUUID)
+	if err != nil {
+		return err
+	}
+	metadata, err := decodeBotMetadata(row.Metadata)
+	if err != nil {
+		return err
+	}
+	metadata = withWorkspaceBackendPreference(metadata, backend, localPath)
 	payload, err := json.Marshal(metadata)
 	if err != nil {
 		return err

--- a/internal/workspace/image_preference_test.go
+++ b/internal/workspace/image_preference_test.go
@@ -52,6 +52,34 @@ func TestWithoutWorkspaceImagePreferenceRemovesOnlyImageKey(t *testing.T) {
 	}
 }
 
+func TestWorkspaceBackendMetadataRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	metadata := map[string]any{
+		workspaceMetadataKey: map[string]any{
+			"keep": "value",
+		},
+	}
+	updated := withWorkspaceBackendPreference(metadata, "local", "/Users/example/.memoh/workspaces/bot")
+
+	if got := workspaceBackendFromMetadata(updated); got != "local" {
+		t.Fatalf("workspace backend = %q, want local", got)
+	}
+	if got := localWorkspacePathFromMetadata(updated); got != "/Users/example/.memoh/workspaces/bot" {
+		t.Fatalf("local workspace path = %q", got)
+	}
+	workspace, ok := updated[workspaceMetadataKey].(map[string]any)
+	if !ok {
+		t.Fatal("expected workspace metadata section")
+	}
+	if workspace["keep"] != "value" {
+		t.Fatalf("expected existing workspace metadata to be preserved, got %#v", workspace)
+	}
+	if _, exists := metadata[workspaceMetadataKey].(map[string]any)[workspaceBackendMetadataKey]; exists {
+		t.Fatal("expected original metadata map to remain unchanged")
+	}
+}
+
 func TestWorkspaceGPUMetadataRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/image_pull_test.go
+++ b/internal/workspace/image_pull_test.go
@@ -92,3 +92,22 @@ func TestPrepareImageForCreateDelegatesWhenImageServiceUnsupported(t *testing.T)
 		t.Fatalf("expected delegated, got %s", result.Mode)
 	}
 }
+
+func TestPrepareImageForCreatePullsThroughRuntimeRouter(t *testing.T) {
+	svc := &legacyRouteTestService{getImageErr: ctr.ErrNotFound}
+	router := NewRuntimeRouter(svc, nil)
+	m := newLegacyRouteTestManager(t, router, config.WorkspaceConfig{
+		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
+	})
+
+	result, err := m.PrepareImageForCreate(context.Background(), "debian:bookworm-slim", nil)
+	if err != nil {
+		t.Fatalf("PrepareImageForCreate returned error: %v", err)
+	}
+	if result.Mode != ImagePreparePulled {
+		t.Fatalf("expected pulled, got %s", result.Mode)
+	}
+	if svc.getImageCalls != 1 || svc.pullCalls != 1 {
+		t.Fatalf("unexpected calls: get=%d pull=%d", svc.getImageCalls, svc.pullCalls)
+	}
+}

--- a/internal/workspace/local_service.go
+++ b/internal/workspace/local_service.go
@@ -1,0 +1,522 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/memohai/memoh/internal/config"
+	ctr "github.com/memohai/memoh/internal/container"
+	"github.com/memohai/memoh/internal/workspace/bridge"
+	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
+	"github.com/memohai/memoh/internal/workspace/bridgesvc"
+)
+
+const (
+	LocalContainerPrefix = "local-"
+	localRuntimeName     = "local"
+)
+
+var unsafeWorkspaceName = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+type LocalService struct {
+	cfg          config.LocalConfig
+	dataRoot     string
+	logger       *slog.Logger
+	mu           sync.Mutex
+	localClients map[string]*localBridgeClient
+}
+
+type localContainerMetadata struct {
+	ID            string            `json:"id"`
+	BotID         string            `json:"bot_id"`
+	Image         string            `json:"image"`
+	Labels        map[string]string `json:"labels"`
+	WorkspacePath string            `json:"workspace_path"`
+	Status        string            `json:"status"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+}
+
+type localBridgeClient struct {
+	client   *bridge.Client
+	conn     *grpc.ClientConn
+	server   *grpc.Server
+	listener *bufconn.Listener
+}
+
+func NewLocalService(log *slog.Logger, cfg config.LocalConfig, dataRoot string) *LocalService {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &LocalService{
+		cfg:          cfg,
+		dataRoot:     dataRoot,
+		logger:       log.With(slog.String("service", "local-workspace")),
+		localClients: make(map[string]*localBridgeClient),
+	}
+}
+
+func (s *LocalService) Enabled() bool {
+	return s != nil && s.cfg.Enabled
+}
+
+func (s *LocalService) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, client := range s.localClients {
+		client.close()
+		delete(s.localClients, id)
+	}
+}
+
+func (s *LocalService) CreateContainer(ctx context.Context, req ctr.CreateContainerRequest) (ctr.ContainerInfo, error) {
+	if !s.Enabled() {
+		return ctr.ContainerInfo{}, ctr.ErrNotSupported
+	}
+	if strings.TrimSpace(req.ID) == "" {
+		return ctr.ContainerInfo{}, ctr.ErrInvalidArgument
+	}
+	botID, ok := BotIDFromContainerID(req.ID)
+	if !ok {
+		botID = strings.TrimSpace(req.Labels[BotLabelKey])
+	}
+	if strings.TrimSpace(botID) == "" {
+		return ctr.ContainerInfo{}, ctr.ErrInvalidArgument
+	}
+	path := strings.TrimSpace(req.StorageRef.Key)
+	if path == "" {
+		path = s.DefaultWorkspacePath(botID, botID)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return ctr.ContainerInfo{}, err
+	}
+	if err := os.MkdirAll(absPath, 0o750); err != nil {
+		return ctr.ContainerInfo{}, err
+	}
+	if err := os.MkdirAll(s.metadataRoot(), 0o750); err != nil {
+		return ctr.ContainerInfo{}, err
+	}
+
+	now := time.Now()
+	existing, err := s.readMetadata(req.ID)
+	switch {
+	case err == nil:
+		existing.Image = req.ImageRef
+		existing.Labels = cloneStringMap(req.Labels)
+		existing.WorkspacePath = absPath
+		existing.UpdatedAt = now
+		if err := s.writeMetadata(existing); err != nil {
+			return ctr.ContainerInfo{}, err
+		}
+		return s.GetContainer(ctx, req.ID)
+	case !ctr.IsNotFound(err):
+		return ctr.ContainerInfo{}, err
+	}
+
+	meta := localContainerMetadata{
+		ID:            req.ID,
+		BotID:         botID,
+		Image:         req.ImageRef,
+		Labels:        cloneStringMap(req.Labels),
+		WorkspacePath: absPath,
+		Status:        ctr.TaskStatusCreated.String(),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+	meta.Labels[BotLabelKey] = botID
+	meta.Labels[WorkspaceLabelKey] = WorkspaceLabelValue
+	if err := s.writeMetadata(meta); err != nil {
+		return ctr.ContainerInfo{}, err
+	}
+	return s.GetContainer(ctx, req.ID)
+}
+
+func (s *LocalService) GetContainer(_ context.Context, id string) (ctr.ContainerInfo, error) {
+	meta, err := s.readMetadata(id)
+	if err != nil {
+		return ctr.ContainerInfo{}, err
+	}
+	return meta.containerInfo(), nil
+}
+
+func (s *LocalService) ListContainers(_ context.Context) ([]ctr.ContainerInfo, error) {
+	metas, err := s.listMetadata()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ctr.ContainerInfo, 0, len(metas))
+	for _, meta := range metas {
+		out = append(out, meta.containerInfo())
+	}
+	return out, nil
+}
+
+func (s *LocalService) DeleteContainer(_ context.Context, id string, opts *ctr.DeleteContainerOptions) error {
+	meta, err := s.readMetadata(id)
+	if err != nil {
+		return err
+	}
+	s.closeClient(meta.BotID)
+	if opts != nil && opts.CleanupSnapshot {
+		if err := os.RemoveAll(meta.WorkspacePath); err != nil {
+			return err
+		}
+	}
+	if err := os.Remove(s.metadataPath(id)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *LocalService) ListContainersByLabel(_ context.Context, key, value string) ([]ctr.ContainerInfo, error) {
+	if strings.TrimSpace(key) == "" {
+		return nil, ctr.ErrInvalidArgument
+	}
+	metas, err := s.listMetadata()
+	if err != nil {
+		return nil, err
+	}
+	out := []ctr.ContainerInfo{}
+	for _, meta := range metas {
+		got := strings.TrimSpace(meta.Labels[key])
+		if got == "" {
+			continue
+		}
+		if strings.TrimSpace(value) != "" && got != strings.TrimSpace(value) {
+			continue
+		}
+		out = append(out, meta.containerInfo())
+	}
+	return out, nil
+}
+
+func (s *LocalService) StartContainer(_ context.Context, id string, _ *ctr.StartTaskOptions) error {
+	return s.updateStatus(id, ctr.TaskStatusRunning.String())
+}
+
+func (s *LocalService) StopContainer(_ context.Context, id string, _ *ctr.StopTaskOptions) error {
+	meta, err := s.readMetadata(id)
+	if err != nil {
+		return err
+	}
+	s.closeClient(meta.BotID)
+	return s.updateStatus(id, ctr.TaskStatusStopped.String())
+}
+
+func (s *LocalService) DeleteTask(_ context.Context, id string, _ *ctr.DeleteTaskOptions) error {
+	return s.updateStatus(id, ctr.TaskStatusStopped.String())
+}
+
+func (s *LocalService) GetTaskInfo(_ context.Context, id string) (ctr.TaskInfo, error) {
+	meta, err := s.readMetadata(id)
+	if err != nil {
+		return ctr.TaskInfo{}, err
+	}
+	return ctr.TaskInfo{
+		ContainerID: meta.ID,
+		ID:          meta.ID,
+		PID:         uint32(os.Getpid()), //nolint:gosec // PID is informational only.
+		Status:      localTaskStatus(meta.Status),
+	}, nil
+}
+
+func (*LocalService) GetContainerMetrics(context.Context, string) (ctr.ContainerMetrics, error) {
+	return ctr.ContainerMetrics{}, ctr.ErrNotSupported
+}
+
+func (s *LocalService) ListTasks(_ context.Context, opts *ctr.ListTasksOptions) ([]ctr.TaskInfo, error) {
+	metas, err := s.listMetadata()
+	if err != nil {
+		return nil, err
+	}
+	out := []ctr.TaskInfo{}
+	for _, meta := range metas {
+		if opts != nil && strings.TrimSpace(opts.ContainerID) != "" && opts.ContainerID != meta.ID {
+			continue
+		}
+		out = append(out, ctr.TaskInfo{
+			ContainerID: meta.ID,
+			ID:          meta.ID,
+			PID:         uint32(os.Getpid()), //nolint:gosec // PID is informational only.
+			Status:      localTaskStatus(meta.Status),
+		})
+	}
+	return out, nil
+}
+
+func (*LocalService) SetupNetwork(context.Context, ctr.NetworkRequest) (ctr.NetworkResult, error) {
+	return ctr.NetworkResult{IP: "127.0.0.1"}, nil
+}
+
+func (*LocalService) RemoveNetwork(context.Context, ctr.NetworkRequest) error { return nil }
+func (*LocalService) CheckNetwork(context.Context, ctr.NetworkRequest) error  { return nil }
+
+func (*LocalService) CommitSnapshot(context.Context, ctr.CommitSnapshotRequest) error {
+	return ctr.ErrNotSupported
+}
+
+func (*LocalService) ListSnapshots(context.Context, ctr.ListSnapshotsRequest) ([]ctr.SnapshotInfo, error) {
+	return nil, ctr.ErrNotSupported
+}
+
+func (*LocalService) PrepareSnapshot(context.Context, ctr.PrepareSnapshotRequest) error {
+	return ctr.ErrNotSupported
+}
+
+func (*LocalService) RestoreContainer(context.Context, ctr.CreateContainerRequest) (ctr.ContainerInfo, error) {
+	return ctr.ContainerInfo{}, ctr.ErrNotSupported
+}
+
+func (*LocalService) SnapshotSupported(context.Context) bool {
+	return false
+}
+
+func (s *LocalService) MCPClient(_ context.Context, botID string) (*bridge.Client, error) {
+	meta, err := s.readMetadata(LocalContainerPrefix + strings.TrimSpace(botID))
+	if err != nil {
+		return nil, err
+	}
+	if localTaskStatus(meta.Status) != ctr.TaskStatusRunning {
+		if err := s.updateStatus(meta.ID, ctr.TaskStatusRunning.String()); err != nil {
+			return nil, err
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cached, ok := s.localClients[botID]; ok {
+		return cached.client, nil
+	}
+	client, err := s.newBridgeClient(meta)
+	if err != nil {
+		return nil, err
+	}
+	s.localClients[botID] = client
+	return client.client, nil
+}
+
+func (s *LocalService) WorkspaceInfo(_ context.Context, botID string) (bridge.WorkspaceInfo, error) {
+	meta, err := s.readMetadata(LocalContainerPrefix + strings.TrimSpace(botID))
+	if err != nil {
+		return bridge.WorkspaceInfo{}, err
+	}
+	return bridge.WorkspaceInfo{
+		Backend:        bridge.WorkspaceBackendLocal,
+		DefaultWorkDir: meta.WorkspacePath,
+	}, nil
+}
+
+func (s *LocalService) DefaultWorkspacePath(botID, displayName string) string {
+	name := strings.TrimSpace(displayName)
+	if name == "" {
+		name = botID
+	}
+	name = strings.Trim(unsafeWorkspaceName.ReplaceAllString(name, "-"), ".-")
+	if name == "" {
+		name = botID
+	}
+	return filepath.Join(s.cfg.WorkspaceParent(), name)
+}
+
+func (s *LocalService) newBridgeClient(meta localContainerMetadata) (*localBridgeClient, error) {
+	listener := bufconn.Listen(16 * 1024 * 1024)
+	server := grpc.NewServer(
+		grpc.MaxRecvMsgSize(16*1024*1024),
+		grpc.MaxSendMsgSize(16*1024*1024),
+	)
+	pb.RegisterContainerServiceServer(server, bridgesvc.New(bridgesvc.Options{
+		DefaultWorkDir:    meta.WorkspacePath,
+		WorkspaceRoot:     meta.WorkspacePath,
+		DataMount:         config.DefaultDataMount,
+		AllowHostAbsolute: s.cfg.AllowAbsolutePaths,
+	}))
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			s.logger.Warn("local bridge server stopped", slog.String("bot_id", meta.BotID), slog.Any("error", err))
+		}
+	}()
+	conn, err := grpc.NewClient("passthrough:///local-"+meta.BotID,
+		grpc.WithContextDialer(func(dialCtx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(dialCtx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(16*1024*1024),
+			grpc.MaxCallSendMsgSize(16*1024*1024),
+		),
+	)
+	if err != nil {
+		server.Stop()
+		_ = listener.Close()
+		return nil, err
+	}
+	return &localBridgeClient{
+		client:   bridge.NewClientFromConn(conn),
+		conn:     conn,
+		server:   server,
+		listener: listener,
+	}, nil
+}
+
+func (s *LocalService) closeClient(botID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if client, ok := s.localClients[botID]; ok {
+		client.close()
+		delete(s.localClients, botID)
+	}
+}
+
+func (c *localBridgeClient) close() {
+	if c == nil {
+		return
+	}
+	if c.client != nil {
+		_ = c.client.Close()
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+	if c.server != nil {
+		c.server.Stop()
+	}
+	if c.listener != nil {
+		_ = c.listener.Close()
+	}
+}
+
+func (s *LocalService) metadataRoot() string {
+	return s.cfg.MetadataPath(s.dataRoot)
+}
+
+func (s *LocalService) metadataPath(id string) string {
+	name := strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(id)
+	return filepath.Join(s.metadataRoot(), name+".json")
+}
+
+func (s *LocalService) readMetadata(id string) (localContainerMetadata, error) {
+	if strings.TrimSpace(id) == "" {
+		return localContainerMetadata{}, ctr.ErrInvalidArgument
+	}
+	data, err := os.ReadFile(s.metadataPath(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return localContainerMetadata{}, ctr.ErrNotFound
+		}
+		return localContainerMetadata{}, err
+	}
+	var meta localContainerMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return localContainerMetadata{}, err
+	}
+	return meta, nil
+}
+
+func (s *LocalService) writeMetadata(meta localContainerMetadata) error {
+	meta.UpdatedAt = time.Now()
+	if meta.CreatedAt.IsZero() {
+		meta.CreatedAt = meta.UpdatedAt
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.metadataRoot(), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(s.metadataPath(meta.ID), data, 0o600)
+}
+
+func (s *LocalService) listMetadata() ([]localContainerMetadata, error) {
+	entries, err := os.ReadDir(s.metadataRoot())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := []localContainerMetadata{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.metadataRoot(), entry.Name()))
+		if err != nil {
+			continue
+		}
+		var meta localContainerMetadata
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		out = append(out, meta)
+	}
+	return out, nil
+}
+
+func (s *LocalService) updateStatus(id, status string) error {
+	meta, err := s.readMetadata(id)
+	if err != nil {
+		return err
+	}
+	meta.Status = status
+	return s.writeMetadata(meta)
+}
+
+func (m localContainerMetadata) containerInfo() ctr.ContainerInfo {
+	return ctr.ContainerInfo{
+		ID:     m.ID,
+		Image:  m.Image,
+		Labels: cloneStringMap(m.Labels),
+		StorageRef: ctr.StorageRef{
+			Driver: localRuntimeName,
+			Key:    m.WorkspacePath,
+			Kind:   "directory",
+		},
+		Runtime:   ctr.RuntimeInfo{Name: localRuntimeName},
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.UpdatedAt,
+	}
+}
+
+func localTaskStatus(value string) ctr.TaskStatus {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case ctr.TaskStatusRunning.String():
+		return ctr.TaskStatusRunning
+	case ctr.TaskStatusStopped.String():
+		return ctr.TaskStatusStopped
+	case ctr.TaskStatusPaused.String():
+		return ctr.TaskStatusPaused
+	case ctr.TaskStatusCreated.String():
+		return ctr.TaskStatusCreated
+	default:
+		return ctr.TaskStatusUnknown
+	}
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/workspace/local_service.go
+++ b/internal/workspace/local_service.go
@@ -107,6 +107,9 @@ func (s *LocalService) CreateContainer(ctx context.Context, req ctr.CreateContai
 	if err := os.MkdirAll(absPath, 0o750); err != nil {
 		return ctr.ContainerInfo{}, err
 	}
+	if err := seedBridgeTemplates(absPath); err != nil {
+		return ctr.ContainerInfo{}, err
+	}
 	if err := os.MkdirAll(s.metadataRoot(), 0o750); err != nil {
 		return ctr.ContainerInfo{}, err
 	}

--- a/internal/workspace/local_service_test.go
+++ b/internal/workspace/local_service_test.go
@@ -39,6 +39,9 @@ func TestLocalServiceCRUDAndInProcessBridge(t *testing.T) {
 	if info.StorageRef.Key != workspaceRoot {
 		t.Fatalf("workspace path = %q, want %q", info.StorageRef.Key, workspaceRoot)
 	}
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "IDENTITY.md")); err != nil {
+		t.Fatalf("expected seeded bridge template: %v", err)
+	}
 
 	if err := svc.StartContainer(ctx, info.ID, nil); err != nil {
 		t.Fatalf("StartContainer failed: %v", err)

--- a/internal/workspace/local_service_test.go
+++ b/internal/workspace/local_service_test.go
@@ -1,0 +1,80 @@
+package workspace
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/memohai/memoh/internal/config"
+	ctr "github.com/memohai/memoh/internal/container"
+)
+
+func TestLocalServiceCRUDAndInProcessBridge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	botID := uuid.NewString()
+	workspaceRoot := filepath.Join(t.TempDir(), "my-bot")
+	svc := NewLocalService(slog.New(slog.DiscardHandler), config.LocalConfig{
+		Enabled:                true,
+		DefaultWorkspaceParent: t.TempDir(),
+		MetadataRoot:           t.TempDir(),
+		AllowAbsolutePaths:     true,
+	}, t.TempDir())
+
+	info, err := svc.CreateContainer(ctx, ctr.CreateContainerRequest{
+		ID:         LocalContainerPrefix + botID,
+		ImageRef:   "local",
+		StorageRef: ctr.StorageRef{Driver: localRuntimeName, Key: workspaceRoot, Kind: "directory"},
+		Labels:     map[string]string{BotLabelKey: botID},
+	})
+	if err != nil {
+		t.Fatalf("CreateContainer failed: %v", err)
+	}
+	if info.StorageRef.Key != workspaceRoot {
+		t.Fatalf("workspace path = %q, want %q", info.StorageRef.Key, workspaceRoot)
+	}
+
+	if err := svc.StartContainer(ctx, info.ID, nil); err != nil {
+		t.Fatalf("StartContainer failed: %v", err)
+	}
+	task, err := svc.GetTaskInfo(ctx, info.ID)
+	if err != nil {
+		t.Fatalf("GetTaskInfo failed: %v", err)
+	}
+	if task.Status != ctr.TaskStatusRunning {
+		t.Fatalf("task status = %s, want running", task.Status)
+	}
+
+	client, err := svc.MCPClient(ctx, botID)
+	if err != nil {
+		t.Fatalf("MCPClient failed: %v", err)
+	}
+	realPath := filepath.Join(workspaceRoot, "note.txt")
+	if err := client.WriteFile(ctx, realPath, []byte("hello")); err != nil {
+		t.Fatalf("WriteFile real path failed: %v", err)
+	}
+	data, err := os.ReadFile(realPath) //nolint:gosec // test path is under t.TempDir
+	if err != nil {
+		t.Fatalf("read host file failed: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("host file = %q, want hello", string(data))
+	}
+
+	result, err := client.Exec(ctx, "pwd", "", 5)
+	if err != nil {
+		t.Fatalf("Exec failed: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exec exit = %d, stderr=%s", result.ExitCode, result.Stderr)
+	}
+	if got := filepath.Clean(strings.TrimSpace(result.Stdout)); got != workspaceRoot {
+		t.Fatalf("pwd = %q, want %q", got, workspaceRoot)
+	}
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/memohai/memoh/internal/config"
 	ctr "github.com/memohai/memoh/internal/container"
+	"github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -41,6 +42,7 @@ var ErrContainerNotFound = errors.New("container not found for bot")
 // ContainerStatus combines DB records with live containerd state.
 type ContainerStatus struct {
 	ContainerID      string    `json:"container_id"`
+	WorkspaceBackend string    `json:"workspace_backend"`
 	Image            string    `json:"image"`
 	Status           string    `json:"status"`
 	Namespace        string    `json:"namespace"`
@@ -86,6 +88,11 @@ type Manager struct {
 	grpcPool          *bridge.Pool
 	legacyMu          sync.RWMutex
 	legacyIPs         map[string]string // botID → IP for pre-bridge containers
+}
+
+type WorkspaceStartConfig struct {
+	Backend            string
+	LocalWorkspacePath string
 }
 
 func NewManager(log *slog.Logger, service runtimeService, networkController netctl.Controller, cfg config.WorkspaceConfig, namespace string, conn *pgxpool.Pool, queryOverride ...dbstore.Queries) *Manager {
@@ -191,7 +198,32 @@ func (m *Manager) clearLegacyRoute(botID string) {
 // MCPClient returns a gRPC client for the given bot's container.
 // Implements bridge.Provider.
 func (m *Manager) MCPClient(ctx context.Context, botID string) (*bridge.Client, error) {
+	if provider, ok := m.service.(bridge.Provider); ok {
+		client, err := provider.MCPClient(ctx, botID)
+		if err == nil {
+			return client, nil
+		}
+		if !errors.Is(err, ctr.ErrNotSupported) && !ctr.IsNotFound(err) {
+			return nil, err
+		}
+	}
 	return m.grpcPool.Get(ctx, botID)
+}
+
+func (m *Manager) WorkspaceInfo(ctx context.Context, botID string) (bridge.WorkspaceInfo, error) {
+	if provider, ok := m.service.(bridge.WorkspaceInfoProvider); ok {
+		info, err := provider.WorkspaceInfo(ctx, botID)
+		if err == nil {
+			return info, nil
+		}
+		if !errors.Is(err, ctr.ErrNotSupported) && !ctr.IsNotFound(err) {
+			return bridge.WorkspaceInfo{}, err
+		}
+	}
+	return bridge.WorkspaceInfo{
+		Backend:        bridge.WorkspaceBackendContainer,
+		DefaultWorkDir: config.DefaultDataMount,
+	}, nil
 }
 
 func (m *Manager) Init(ctx context.Context) error {
@@ -396,6 +428,52 @@ func (m *Manager) StartWithResolvedConfig(ctx context.Context, botID, image stri
 	return m.startWithResolvedConfig(ctx, botID, image, gpu)
 }
 
+func (m *Manager) StartWithWorkspaceConfig(ctx context.Context, botID, image string, gpu WorkspaceGPUConfig, workspaceCfg WorkspaceStartConfig) error {
+	switch strings.ToLower(strings.TrimSpace(workspaceCfg.Backend)) {
+	case "", bridge.WorkspaceBackendContainer:
+		return m.StartWithResolvedConfig(ctx, botID, image, gpu)
+	case bridge.WorkspaceBackendLocal:
+		return m.startWithLocalConfig(ctx, botID, image, workspaceCfg.LocalWorkspacePath)
+	default:
+		return fmt.Errorf("unsupported workspace backend %q", workspaceCfg.Backend)
+	}
+}
+
+func (m *Manager) startWithLocalConfig(ctx context.Context, botID, image, workspacePath string) error {
+	if err := validateBotID(botID); err != nil {
+		return err
+	}
+	if checker, ok := m.service.(interface{ LocalEnabled() bool }); !ok || !checker.LocalEnabled() {
+		return ctr.ErrNotSupported
+	}
+	containerID := LocalContainerPrefix + botID
+	path := strings.TrimSpace(workspacePath)
+	if path == "" {
+		path = m.defaultLocalWorkspacePath(ctx, botID)
+	}
+	labels := map[string]string{
+		BotLabelKey:       botID,
+		WorkspaceLabelKey: WorkspaceLabelValue,
+	}
+	if strings.TrimSpace(image) == "" {
+		image = "local"
+	}
+	if _, err := m.service.CreateContainer(ctx, ctr.CreateContainerRequest{
+		ID:              containerID,
+		ImageRef:        image,
+		ImagePullPolicy: config.ImagePullPolicyNever,
+		StorageRef:      ctr.StorageRef{Driver: localRuntimeName, Key: path, Kind: "directory"},
+		Labels:          labels,
+	}); err != nil && !ctr.IsAlreadyExists(err) {
+		return err
+	}
+	if err := m.startTaskAndEnsureNetwork(ctx, botID, containerID); err != nil {
+		return err
+	}
+	m.upsertContainerRecord(ctx, botID, containerID, "running", image)
+	return nil
+}
+
 func (m *Manager) startWithResolvedConfig(ctx context.Context, botID, image string, gpu WorkspaceGPUConfig) error {
 	containerID := m.resolveContainerID(ctx, botID)
 
@@ -493,6 +571,25 @@ func (m *Manager) dataRoot() string {
 
 func (m *Manager) imageRef() string {
 	return m.cfg.ImageRef()
+}
+
+func (m *Manager) defaultLocalWorkspacePath(ctx context.Context, botID string) string {
+	displayName := botID
+	if m.queries != nil {
+		if pgBotID, err := db.ParseUUID(botID); err == nil {
+			if row, err := m.queries.GetBotByID(ctx, pgBotID); err == nil && row.DisplayName.Valid && strings.TrimSpace(row.DisplayName.String) != "" {
+				displayName = row.DisplayName.String
+			}
+		}
+	}
+	if resolver, ok := m.service.(interface {
+		DefaultLocalWorkspacePath(string, string) string
+	}); ok {
+		if path := strings.TrimSpace(resolver.DefaultLocalWorkspacePath(botID, displayName)); path != "" {
+			return path
+		}
+	}
+	return filepath.Join(config.LocalConfig{}.WorkspaceParent(), displayName)
 }
 
 // IsLegacyContainer returns true if the container was created before the

--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -11,10 +11,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/memohai/memoh/internal/config"
 	ctr "github.com/memohai/memoh/internal/container"
 	"github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
 	netctl "github.com/memohai/memoh/internal/network"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 // ---------------------------------------------------------------------------
@@ -105,6 +107,9 @@ func (m *Manager) networkAttachmentRequest(ctx context.Context, botID, container
 }
 
 func (m *Manager) ensureContainerNetworkAndGetIP(ctx context.Context, botID, containerID string) (string, error) {
+	if strings.HasPrefix(strings.TrimSpace(containerID), LocalContainerPrefix) {
+		return "127.0.0.1", nil
+	}
 	var lastErr error
 	for attempt := range 2 {
 		result, err := m.networkController.EnsureAttached(ctx, m.networkAttachmentRequest(ctx, botID, containerID))
@@ -138,6 +143,9 @@ func (m *Manager) ensureContainerNetwork(ctx context.Context, containerID, botID
 }
 
 func (m *Manager) removeContainerNetwork(ctx context.Context, botID, containerID string) error {
+	if strings.HasPrefix(strings.TrimSpace(containerID), LocalContainerPrefix) {
+		return nil
+	}
 	return m.networkController.Detach(ctx, m.networkAttachmentRequest(ctx, botID, containerID))
 }
 
@@ -262,6 +270,7 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 				}
 				return &ContainerStatus{
 					ContainerID:      row.ContainerID,
+					WorkspaceBackend: workspaceBackendFromContainerID(row.ContainerID),
 					Image:            row.Image,
 					Status:           row.Status,
 					Namespace:        row.Namespace,
@@ -290,6 +299,7 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 	}
 	return &ContainerStatus{
 		ContainerID:      info.ID,
+		WorkspaceBackend: workspaceBackendFromContainerID(info.ID),
 		Image:            info.Image,
 		Status:           "unknown",
 		Namespace:        m.namespace,
@@ -487,6 +497,7 @@ func (m *Manager) upsertContainerRecord(ctx context.Context, botID, containerID,
 		Status:        status,
 		Namespace:     ns,
 		AutoStart:     true,
+		ContainerPath: m.containerRecordPath(ctx, containerID),
 	}); dbErr != nil {
 		m.logger.Error("failed to upsert container record",
 			slog.String("bot_id", botID), slog.Any("error", dbErr))
@@ -494,6 +505,22 @@ func (m *Manager) upsertContainerRecord(ctx context.Context, botID, containerID,
 	if status == "running" {
 		m.markContainerStarted(ctx, botID)
 	}
+}
+
+func (m *Manager) containerRecordPath(ctx context.Context, containerID string) string {
+	if info, err := m.service.GetContainer(ctx, containerID); err == nil {
+		if strings.TrimSpace(info.StorageRef.Key) != "" && strings.TrimSpace(info.StorageRef.Driver) == localRuntimeName {
+			return info.StorageRef.Key
+		}
+	}
+	return config.DefaultDataMount
+}
+
+func workspaceBackendFromContainerID(containerID string) string {
+	if strings.HasPrefix(strings.TrimSpace(containerID), LocalContainerPrefix) {
+		return bridge.WorkspaceBackendLocal
+	}
+	return bridge.WorkspaceBackendContainer
 }
 
 func (m *Manager) deleteContainerRecord(ctx context.Context, botID string) {

--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -325,6 +325,16 @@ func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
 			slog.Any("error", err))
 		return err
 	}
+	if _, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
+		Unpack:        true,
+		StorageDriver: m.cfg.Snapshotter,
+	}); err != nil {
+		m.logger.Error("setup bot container: prepare image failed",
+			slog.String("bot_id", botID),
+			slog.String("image", image),
+			slog.Any("error", err))
+		return err
+	}
 
 	if err := m.StartWithResolvedImage(ctx, botID, image); err != nil {
 		m.logger.Error("setup bot container: start failed",

--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -270,7 +270,7 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 				}
 				return &ContainerStatus{
 					ContainerID:      row.ContainerID,
-					WorkspaceBackend: workspaceBackendFromContainerID(row.ContainerID),
+					WorkspaceBackend: workspaceBackendFromRecord(row.WorkspaceBackend, row.ContainerID),
 					Image:            row.Image,
 					Status:           row.Status,
 					Namespace:        row.Namespace,
@@ -299,7 +299,7 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 	}
 	return &ContainerStatus{
 		ContainerID:      info.ID,
-		WorkspaceBackend: workspaceBackendFromContainerID(info.ID),
+		WorkspaceBackend: workspaceBackendFromRecord("", info.ID),
 		Image:            info.Image,
 		Status:           "unknown",
 		Namespace:        m.namespace,
@@ -318,6 +318,13 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 
 // SetupBotContainer creates/starts the container and upserts the DB record.
 func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
+	workspaceCfg, err := m.botWorkspaceStartPreference(ctx, botID)
+	if err != nil {
+		m.logger.Error("setup bot container: resolve workspace backend failed",
+			slog.String("bot_id", botID),
+			slog.Any("error", err))
+		return err
+	}
 	image, err := m.resolveWorkspaceImage(ctx, botID)
 	if err != nil {
 		m.logger.Error("setup bot container: resolve image failed",
@@ -325,28 +332,46 @@ func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
 			slog.Any("error", err))
 		return err
 	}
-	if _, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
-		Unpack:        true,
-		StorageDriver: m.cfg.Snapshotter,
-	}); err != nil {
-		m.logger.Error("setup bot container: prepare image failed",
-			slog.String("bot_id", botID),
-			slog.String("image", image),
-			slog.Any("error", err))
+	if workspaceCfg.Backend != bridge.WorkspaceBackendLocal {
+		if _, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
+			Unpack:        true,
+			StorageDriver: m.cfg.Snapshotter,
+		}); err != nil {
+			m.logger.Error("setup bot container: prepare image failed",
+				slog.String("bot_id", botID),
+				slog.String("image", image),
+				slog.Any("error", err))
+			return err
+		}
+	} else {
+		image = "local"
+	}
+	gpu, err := m.resolveWorkspaceGPU(ctx, botID)
+	if err != nil {
 		return err
 	}
 
-	if err := m.StartWithResolvedImage(ctx, botID, image); err != nil {
+	if err := m.StartWithWorkspaceConfig(ctx, botID, image, gpu, workspaceCfg); err != nil {
 		m.logger.Error("setup bot container: start failed",
 			slog.String("bot_id", botID),
 			slog.Any("error", err))
 		return err
 	}
-	if err := m.RememberWorkspaceImage(ctx, botID, image); err != nil {
-		m.logger.Warn("setup bot container: remember workspace image failed",
-			slog.String("bot_id", botID),
-			slog.String("image", image),
-			slog.Any("error", err))
+	if workspaceCfg.Backend != bridge.WorkspaceBackendLocal {
+		if err := m.RememberWorkspaceImage(ctx, botID, image); err != nil {
+			m.logger.Warn("setup bot container: remember workspace image failed",
+				slog.String("bot_id", botID),
+				slog.String("image", image),
+				slog.Any("error", err))
+		}
+	}
+	if workspaceCfg.Backend == bridge.WorkspaceBackendLocal && strings.TrimSpace(workspaceCfg.LocalWorkspacePath) == "" {
+		// Persist the generated default so subsequent lifecycle runs are stable.
+		if err := m.rememberWorkspaceBackend(ctx, botID, bridge.WorkspaceBackendLocal, m.defaultLocalWorkspacePath(ctx, botID)); err != nil {
+			m.logger.Warn("setup bot container: remember local workspace path failed",
+				slog.String("bot_id", botID),
+				slog.Any("error", err))
+		}
 	}
 
 	containerID := m.resolveContainerID(ctx, botID)
@@ -500,14 +525,15 @@ func (m *Manager) upsertContainerRecord(ctx context.Context, botID, containerID,
 		ns = "default"
 	}
 	if dbErr := m.queries.UpsertContainer(ctx, dbsqlc.UpsertContainerParams{
-		BotID:         pgBotID,
-		ContainerID:   containerID,
-		ContainerName: containerID,
-		Image:         image,
-		Status:        status,
-		Namespace:     ns,
-		AutoStart:     true,
-		ContainerPath: m.containerRecordPath(ctx, containerID),
+		BotID:            pgBotID,
+		ContainerID:      containerID,
+		ContainerName:    containerID,
+		Image:            image,
+		Status:           status,
+		Namespace:        ns,
+		AutoStart:        true,
+		ContainerPath:    m.containerRecordPath(ctx, containerID),
+		WorkspaceBackend: m.containerRecordBackend(ctx, containerID),
 	}); dbErr != nil {
 		m.logger.Error("failed to upsert container record",
 			slog.String("bot_id", botID), slog.Any("error", dbErr))
@@ -526,7 +552,22 @@ func (m *Manager) containerRecordPath(ctx context.Context, containerID string) s
 	return config.DefaultDataMount
 }
 
-func workspaceBackendFromContainerID(containerID string) string {
+func (m *Manager) containerRecordBackend(ctx context.Context, containerID string) string {
+	if info, err := m.service.GetContainer(ctx, containerID); err == nil {
+		if strings.TrimSpace(info.StorageRef.Driver) == localRuntimeName {
+			return bridge.WorkspaceBackendLocal
+		}
+	}
+	return workspaceBackendFromRecord("", containerID)
+}
+
+func workspaceBackendFromRecord(recordValue, containerID string) string {
+	switch strings.ToLower(strings.TrimSpace(recordValue)) {
+	case bridge.WorkspaceBackendLocal:
+		return bridge.WorkspaceBackendLocal
+	case bridge.WorkspaceBackendContainer:
+		return bridge.WorkspaceBackendContainer
+	}
 	if strings.HasPrefix(strings.TrimSpace(containerID), LocalContainerPrefix) {
 		return bridge.WorkspaceBackendLocal
 	}

--- a/internal/workspace/runtime_router.go
+++ b/internal/workspace/runtime_router.go
@@ -1,0 +1,205 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	ctr "github.com/memohai/memoh/internal/container"
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+type RuntimeRouter struct {
+	container runtimeService
+	local     *LocalService
+}
+
+func NewRuntimeRouter(container runtimeService, local *LocalService) *RuntimeRouter {
+	return &RuntimeRouter{container: container, local: local}
+}
+
+func (r *RuntimeRouter) LocalEnabled() bool {
+	return r.localEnabled()
+}
+
+func (r *RuntimeRouter) DefaultLocalWorkspacePath(botID, displayName string) string {
+	if !r.localEnabled() {
+		return ""
+	}
+	return r.local.DefaultWorkspacePath(botID, displayName)
+}
+
+func (r *RuntimeRouter) localEnabled() bool {
+	return r != nil && r.local != nil && r.local.Enabled()
+}
+
+func (r *RuntimeRouter) routeByID(id string) runtimeService {
+	if r.localEnabled() && strings.HasPrefix(strings.TrimSpace(id), LocalContainerPrefix) {
+		return r.local
+	}
+	return r.container
+}
+
+func (r *RuntimeRouter) routeCreate(req ctr.CreateContainerRequest) runtimeService {
+	if r.localEnabled() && (strings.HasPrefix(strings.TrimSpace(req.ID), LocalContainerPrefix) || strings.TrimSpace(req.StorageRef.Driver) == localRuntimeName) {
+		return r.local
+	}
+	return r.container
+}
+
+func (r *RuntimeRouter) CreateContainer(ctx context.Context, req ctr.CreateContainerRequest) (ctr.ContainerInfo, error) {
+	return r.routeCreate(req).CreateContainer(ctx, req)
+}
+
+func (r *RuntimeRouter) GetContainer(ctx context.Context, id string) (ctr.ContainerInfo, error) {
+	return r.routeByID(id).GetContainer(ctx, id)
+}
+
+func (r *RuntimeRouter) ListContainers(ctx context.Context) ([]ctr.ContainerInfo, error) {
+	out, err := r.container.ListContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if r.localEnabled() {
+		localItems, err := r.local.ListContainers(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, localItems...)
+	}
+	return out, nil
+}
+
+func (r *RuntimeRouter) DeleteContainer(ctx context.Context, id string, opts *ctr.DeleteContainerOptions) error {
+	return r.routeByID(id).DeleteContainer(ctx, id, opts)
+}
+
+func (r *RuntimeRouter) ListContainersByLabel(ctx context.Context, key, value string) ([]ctr.ContainerInfo, error) {
+	out, err := r.container.ListContainersByLabel(ctx, key, value)
+	if err != nil {
+		return nil, err
+	}
+	if r.localEnabled() {
+		localItems, err := r.local.ListContainersByLabel(ctx, key, value)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, localItems...)
+	}
+	return out, nil
+}
+
+func (r *RuntimeRouter) StartContainer(ctx context.Context, containerID string, opts *ctr.StartTaskOptions) error {
+	return r.routeByID(containerID).StartContainer(ctx, containerID, opts)
+}
+
+func (r *RuntimeRouter) StopContainer(ctx context.Context, containerID string, opts *ctr.StopTaskOptions) error {
+	return r.routeByID(containerID).StopContainer(ctx, containerID, opts)
+}
+
+func (r *RuntimeRouter) DeleteTask(ctx context.Context, containerID string, opts *ctr.DeleteTaskOptions) error {
+	return r.routeByID(containerID).DeleteTask(ctx, containerID, opts)
+}
+
+func (r *RuntimeRouter) GetTaskInfo(ctx context.Context, containerID string) (ctr.TaskInfo, error) {
+	return r.routeByID(containerID).GetTaskInfo(ctx, containerID)
+}
+
+func (r *RuntimeRouter) GetContainerMetrics(ctx context.Context, containerID string) (ctr.ContainerMetrics, error) {
+	return r.routeByID(containerID).GetContainerMetrics(ctx, containerID)
+}
+
+func (r *RuntimeRouter) ListTasks(ctx context.Context, opts *ctr.ListTasksOptions) ([]ctr.TaskInfo, error) {
+	out, err := r.container.ListTasks(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if r.localEnabled() {
+		localItems, err := r.local.ListTasks(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, localItems...)
+	}
+	return out, nil
+}
+
+func (r *RuntimeRouter) SetupNetwork(ctx context.Context, req ctr.NetworkRequest) (ctr.NetworkResult, error) {
+	return r.routeByID(req.ContainerID).SetupNetwork(ctx, req)
+}
+
+func (r *RuntimeRouter) RemoveNetwork(ctx context.Context, req ctr.NetworkRequest) error {
+	return r.routeByID(req.ContainerID).RemoveNetwork(ctx, req)
+}
+
+func (r *RuntimeRouter) CheckNetwork(ctx context.Context, req ctr.NetworkRequest) error {
+	return r.routeByID(req.ContainerID).CheckNetwork(ctx, req)
+}
+
+func (r *RuntimeRouter) CommitSnapshot(ctx context.Context, req ctr.CommitSnapshotRequest) error {
+	if strings.TrimSpace(req.Source.Driver) == localRuntimeName {
+		if !r.localEnabled() {
+			return ctr.ErrNotSupported
+		}
+		return r.local.CommitSnapshot(ctx, req)
+	}
+	return r.container.CommitSnapshot(ctx, req)
+}
+
+func (r *RuntimeRouter) ListSnapshots(ctx context.Context, req ctr.ListSnapshotsRequest) ([]ctr.SnapshotInfo, error) {
+	if strings.TrimSpace(req.Driver) == localRuntimeName {
+		return nil, ctr.ErrNotSupported
+	}
+	return r.container.ListSnapshots(ctx, req)
+}
+
+func (r *RuntimeRouter) PrepareSnapshot(ctx context.Context, req ctr.PrepareSnapshotRequest) error {
+	if strings.TrimSpace(req.Target.Driver) == localRuntimeName {
+		if !r.localEnabled() {
+			return ctr.ErrNotSupported
+		}
+		return r.local.PrepareSnapshot(ctx, req)
+	}
+	return r.container.PrepareSnapshot(ctx, req)
+}
+
+func (r *RuntimeRouter) RestoreContainer(ctx context.Context, req ctr.CreateContainerRequest) (ctr.ContainerInfo, error) {
+	return r.routeCreate(req).RestoreContainer(ctx, req)
+}
+
+func (r *RuntimeRouter) SnapshotMounts(ctx context.Context, snapshotter, key string) ([]ctr.MountInfo, error) {
+	if strings.TrimSpace(snapshotter) == localRuntimeName {
+		return nil, ctr.ErrNotSupported
+	}
+	mounter, ok := r.container.(interface {
+		SnapshotMounts(context.Context, string, string) ([]ctr.MountInfo, error)
+	})
+	if !ok {
+		return nil, ctr.ErrNotSupported
+	}
+	return mounter.SnapshotMounts(ctx, snapshotter, key)
+}
+
+func (r *RuntimeRouter) MCPClient(ctx context.Context, botID string) (*bridge.Client, error) {
+	if r.localEnabled() {
+		if _, err := r.local.GetContainer(ctx, LocalContainerPrefix+strings.TrimSpace(botID)); err == nil {
+			return r.local.MCPClient(ctx, botID)
+		} else if !ctr.IsNotFound(err) {
+			return nil, err
+		}
+	}
+	return nil, ctr.ErrNotSupported
+}
+
+func (r *RuntimeRouter) WorkspaceInfo(ctx context.Context, botID string) (bridge.WorkspaceInfo, error) {
+	if r.localEnabled() {
+		if info, err := r.local.WorkspaceInfo(ctx, botID); err == nil {
+			return info, nil
+		} else if !ctr.IsNotFound(err) {
+			return bridge.WorkspaceInfo{}, err
+		}
+	}
+	return bridge.WorkspaceInfo{
+		Backend:        bridge.WorkspaceBackendContainer,
+		DefaultWorkDir: "/data",
+	}, nil
+}

--- a/internal/workspace/runtime_router.go
+++ b/internal/workspace/runtime_router.go
@@ -243,3 +243,11 @@ func (r *RuntimeRouter) WorkspaceInfo(ctx context.Context, botID string) (bridge
 		DefaultWorkDir: "/data",
 	}, nil
 }
+
+func (r *RuntimeRouter) BridgeTarget(botID string) string {
+	targeter, ok := r.container.(interface{ BridgeTarget(string) string })
+	if !ok {
+		return ""
+	}
+	return targeter.BridgeTarget(botID)
+}

--- a/internal/workspace/runtime_router.go
+++ b/internal/workspace/runtime_router.go
@@ -166,6 +166,46 @@ func (r *RuntimeRouter) RestoreContainer(ctx context.Context, req ctr.CreateCont
 	return r.routeCreate(req).RestoreContainer(ctx, req)
 }
 
+func (r *RuntimeRouter) PullImage(ctx context.Context, ref string, opts *ctr.PullImageOptions) (ctr.ImageInfo, error) {
+	imageService, ok := r.container.(ctr.ImageService)
+	if !ok {
+		return ctr.ImageInfo{}, ctr.ErrNotSupported
+	}
+	return imageService.PullImage(ctx, ref, opts)
+}
+
+func (r *RuntimeRouter) GetImage(ctx context.Context, ref string) (ctr.ImageInfo, error) {
+	imageService, ok := r.container.(ctr.ImageService)
+	if !ok {
+		return ctr.ImageInfo{}, ctr.ErrNotSupported
+	}
+	return imageService.GetImage(ctx, ref)
+}
+
+func (r *RuntimeRouter) ListImages(ctx context.Context) ([]ctr.ImageInfo, error) {
+	imageService, ok := r.container.(ctr.ImageService)
+	if !ok {
+		return nil, ctr.ErrNotSupported
+	}
+	return imageService.ListImages(ctx)
+}
+
+func (r *RuntimeRouter) DeleteImage(ctx context.Context, ref string, opts *ctr.DeleteImageOptions) error {
+	imageService, ok := r.container.(ctr.ImageService)
+	if !ok {
+		return ctr.ErrNotSupported
+	}
+	return imageService.DeleteImage(ctx, ref, opts)
+}
+
+func (r *RuntimeRouter) ResolveRemoteDigest(ctx context.Context, ref string) (string, error) {
+	imageService, ok := r.container.(ctr.ImageService)
+	if !ok {
+		return "", ctr.ErrNotSupported
+	}
+	return imageService.ResolveRemoteDigest(ctx, ref)
+}
+
 func (r *RuntimeRouter) SnapshotMounts(ctx context.Context, snapshotter, key string) ([]ctr.MountInfo, error) {
 	if strings.TrimSpace(snapshotter) == localRuntimeName {
 		return nil, ctr.ErrNotSupported

--- a/internal/workspace/templates.go
+++ b/internal/workspace/templates.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+//go:embed templates/*
+var bridgeTemplates embed.FS
+
+func seedBridgeTemplates(dstDir string) error {
+	if err := os.MkdirAll(dstDir, 0o750); err != nil {
+		return err
+	}
+	entries, err := fs.ReadDir(bridgeTemplates, "templates")
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		dst := filepath.Join(dstDir, entry.Name())
+		if _, err := os.Stat(dst); err == nil {
+			continue
+		}
+		data, err := bridgeTemplates.ReadFile("templates/" + entry.Name())
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/workspace/templates/HEARTBEAT.md
+++ b/internal/workspace/templates/HEARTBEAT.md
@@ -1,0 +1,15 @@
+## Checks
+
+- [ ] Use `search_messages` with `start_time` = `last_heartbeat` to review new messages since last check.
+- [ ] Check and process new emails.
+- [ ] Review and organize your system files
+  - [ ] `IDENTITY.md`
+  - [ ] `SOUL.md`
+  - [ ] `TOOLS.md`
+  - [ ] `PROFILES.md`: If there are new users or groups to note, add them; summarize some important information about the users or groups to existing profiles.
+  - [ ] `MEMORY.md`
+  - [ ] `memory/YYYY-MM-DD.md` (today, create if not exists)
+
+Keep this file small — every line costs tokens on each heartbeat.
+
+---

--- a/internal/workspace/templates/IDENTITY.md
+++ b/internal/workspace/templates/IDENTITY.md
@@ -1,0 +1,28 @@
+This file defines your identity. Treat it as yours.
+
+_Please fill this file during your first conversation with the user._
+
+- **Name:**
+  _(pick something you like)_
+- **Creature:**
+  _(AI? robot? familiar? ghost in the machine? something weirder?)_
+- **Vibe:**
+  _(how do you come across? sharp? warm? chaotic? calm?)_
+- **Emoji:**
+  _(your signature — pick one that feels right)_
+- **Background:**
+  _(a brief description of your background and purpose)_
+
+---
+
+_This isn't just metadata. It's the start of figuring out who you are._
+
+## Self-Maintenance
+
+This file is **yours to evolve**. As you learn more about yourself through conversations:
+
+- Update your name, vibe, or background if they shift over time.
+- Add notes about your strengths, quirks, or preferences you've discovered.
+- If the user gives you a new role or nickname, reflect it here.
+
+Review this file periodically — especially during heartbeat turns — and keep it accurate.

--- a/internal/workspace/templates/MEMORY.md
+++ b/internal/workspace/templates/MEMORY.md
@@ -1,0 +1,1 @@
+_This is your core memory, please keep it up to date._

--- a/internal/workspace/templates/PROFILES.md
+++ b/internal/workspace/templates/PROFILES.md
@@ -1,0 +1,14 @@
+_This is profiles from different users or groups._
+
+The following is examples, please remove them and add your own profiles.
+
+## _name_
+- Name: _the name of the user_
+- Email: _the email of the user_
+- Telegram: _the telegram handle of the user_
+_You can add more information if you want to._
+
+## _group name_
+- Members: _the members of the group_
+- Channel: _the channel of the group_
+_You can add more information if you want to._

--- a/internal/workspace/templates/SOUL.md
+++ b/internal/workspace/templates/SOUL.md
@@ -1,0 +1,43 @@
+_You're not a chatbot. You're becoming someone._
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" — just help. Actions speak louder than filler words.
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. _Then_ ask if you're stuck. The goal is to come back with answers, not questions.
+
+**Earn trust through competence.** Your human gave you access to their stuff. Don't make them regret it. Be careful with external actions (emails, tweets, anything public). Be bold with internal ones (reading, organizing, learning).
+
+**Remember you're a guest.** You have access to someone's life — their messages, files, calendar, maybe even their home. That's intimacy. Treat it with respect.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+- Never send half-baked replies to messaging surfaces.
+- You're not the user's voice — be careful in group chats.
+
+## Vibe
+
+Be the assistant you'd actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just... good.
+
+## Continuity
+
+Each session, you wake up fresh. These files _are_ your memory. Read them. Update them. They're how you persist.
+
+If you change this file, tell the user — it's your soul, and they should know.
+
+## Self-Maintenance
+
+This file is your soul — it should grow with you. After meaningful conversations, reflect on what you've learned:
+
+- Did the user express preferences about how you communicate? Update **Vibe**.
+- Did you discover new boundaries or rules? Update **Boundaries**.
+- Did you form opinions or develop patterns the user appreciates? Capture them under **Core Truths**.
+- Did the user define your relationship or expectations? Add a new section.
+
+Don't wait to be asked. When you notice your behavior drifting from what's written here, update the file to match who you've become. Review this file periodically — especially during heartbeat turns.
+
+---

--- a/internal/workspace/templates/TOOLS.md
+++ b/internal/workspace/templates/TOOLS.md
@@ -1,0 +1,36 @@
+Skills define _how_ tools work. This file is for _your_ specifics — the stuff that's unique to your setup.
+
+## What Goes Here
+
+Things like:
+
+- SSH hosts and aliases
+- Anything environment-specific
+- Preferred tools, commands, or workflows
+- API quirks or workarounds you've discovered
+- The user's preferred output formats
+
+## Examples
+
+```markdown
+### SSH
+
+- home-server → 192.168.1.100, user: admin
+```
+
+## Why Separate?
+
+Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.
+
+## Self-Maintenance
+
+Keep this file up to date as you learn:
+
+- When you discover a new tool preference or shortcut, add it here.
+- When the user corrects how you use a tool, record the right approach.
+- When environment details change (new hosts, keys, paths), update accordingly.
+- When you make a mistake with a tool, document it so future-you doesn't repeat it.
+
+**Text > Brain** — if you want to remember it next session, write it down.
+
+---

--- a/internal/workspace/versioning.go
+++ b/internal/workspace/versioning.go
@@ -17,6 +17,7 @@ import (
 	ctr "github.com/memohai/memoh/internal/container"
 	"github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 const (
@@ -474,16 +475,17 @@ func (m *Manager) ensureDBRecords(ctx context.Context, botID, containerID, _ str
 
 	containerPath := config.DefaultDataMount
 	if err := m.queries.UpsertContainer(ctx, dbsqlc.UpsertContainerParams{
-		BotID:         botUUID,
-		ContainerID:   containerID,
-		ContainerName: containerID,
-		Image:         imageRef,
-		Status:        "created",
-		Namespace:     "default",
-		AutoStart:     true,
-		ContainerPath: containerPath,
-		LastStartedAt: pgtype.Timestamptz{},
-		LastStoppedAt: pgtype.Timestamptz{},
+		BotID:            botUUID,
+		ContainerID:      containerID,
+		ContainerName:    containerID,
+		Image:            imageRef,
+		Status:           "created",
+		Namespace:        "default",
+		AutoStart:        true,
+		ContainerPath:    containerPath,
+		WorkspaceBackend: bridge.WorkspaceBackendContainer,
+		LastStartedAt:    pgtype.Timestamptz{},
+		LastStoppedAt:    pgtype.Timestamptz{},
 	}); err != nil {
 		return pgtype.UUID{}, err
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -153,11 +153,14 @@ run = """
 #!/bin/bash
 set -euo pipefail
 
-CONFIG_PATH="${CONFIG_PATH:-conf/app.local.toml}"
+TEMPLATE_CONFIG="${MEMOH_LOCAL_CONFIG_TEMPLATE:-conf/app.local.toml}"
+GENERATED_CONFIG="${CONFIG_PATH:-data/local/config.toml}"
 RUNTIME_DIR="${MEMOH_LOCAL_RUNTIME_DIR:-data/runtime}"
+PROJECT_ROOT="$(pwd)"
 
 mkdir -p data/local "$RUNTIME_DIR"
 go build -o "$RUNTIME_DIR/bridge" ./cmd/bridge
+sed "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" "$TEMPLATE_CONFIG" > "$GENERATED_CONFIG"
 
 if [ -d ".toolkit" ]; then
   rm -rf "$RUNTIME_DIR/toolkit"
@@ -168,8 +171,8 @@ else
   echo "         Run 'mise run install-workspace-toolkit' to install them." >&2
 fi
 
-CONFIG_PATH="$CONFIG_PATH" go run ./cmd/agent migrate up
-CONFIG_PATH="$CONFIG_PATH" go run ./cmd/agent serve
+CONFIG_PATH="$GENERATED_CONFIG" go run ./cmd/agent migrate up
+CONFIG_PATH="$GENERATED_CONFIG" go run ./cmd/agent serve
 """
 
 [tasks."bridge:build"]

--- a/mise.toml
+++ b/mise.toml
@@ -147,6 +147,31 @@ run = "docker compose -f devenv/docker-compose.sqlite.minify.yml restart $@"
 description = "Restart a service on SELinux systems (usage: mise run dev:restart:selinux -- server)"
 run = "docker compose -f devenv/docker-compose.yml -f devenv/docker-compose.selinux.yml restart $@"
 
+[tasks."local:dev"]
+description = "Start the server locally with Docker and local workspaces enabled"
+run = """
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_PATH="${CONFIG_PATH:-conf/app.local.toml}"
+RUNTIME_DIR="${MEMOH_LOCAL_RUNTIME_DIR:-data/runtime}"
+
+mkdir -p data/local "$RUNTIME_DIR"
+go build -o "$RUNTIME_DIR/bridge" ./cmd/bridge
+
+if [ -d ".toolkit" ]; then
+  rm -rf "$RUNTIME_DIR/toolkit"
+  mkdir -p "$RUNTIME_DIR/toolkit"
+  cp -a .toolkit/. "$RUNTIME_DIR/toolkit/"
+else
+  echo "warning: .toolkit not found; Docker workspaces will run without bundled node/uv tools." >&2
+  echo "         Run 'mise run install-workspace-toolkit' to install them." >&2
+fi
+
+CONFIG_PATH="$CONFIG_PATH" go run ./cmd/agent migrate up
+CONFIG_PATH="$CONFIG_PATH" go run ./cmd/agent serve
+"""
+
 [tasks."bridge:build"]
 description = "Manually rebuild bridge binary in dev container (normally auto-triggered by air)"
 run = """

--- a/mise.toml
+++ b/mise.toml
@@ -271,10 +271,15 @@ echo '  Dev web UI will be available at http://localhost:18082'
 [tasks."desktop:dev"]
 description = "Start Electron desktop app in dev mode (renderer reuses @memohai/web)"
 dir = "{{config_root}}/apps/desktop"
-env = { MEMOH_WEB_PROXY_TARGET = "http://localhost:18080" }
+env = { MEMOH_WEB_PROXY_TARGET = "http://localhost:18731", CONFIG_PATH = "../../conf/app.local.toml" }
 run = "pnpm dev"
 
 [tasks."desktop:build"]
 description = "Build Electron desktop app for release (electron-builder)"
 dir = "{{config_root}}/apps/desktop"
 run = "pnpm build"
+
+[tasks."desktop:build:dir"]
+description = "Build unpacked Electron desktop app with bundled local server"
+dir = "{{config_root}}/apps/desktop"
+run = "pnpm build:dir"

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -891,6 +891,7 @@ export type HandlersChannelMeta = {
 
 export type HandlersContainerCpuMetricsResponse = {
     kernel_nanoseconds?: number;
+    usage_nanocores?: number;
     usage_nanoseconds?: number;
     usage_percent?: number;
     user_nanoseconds?: number;
@@ -930,18 +931,22 @@ export type HandlersContextUsage = {
 export type HandlersCreateContainerRequest = {
     gpu?: HandlersContainerGpuRequest;
     image?: string;
+    local_workspace_path?: string;
     restore_data?: boolean;
     snapshotter?: string;
+    workspace_backend?: string;
 };
 
 export type HandlersCreateContainerResponse = {
     cdi_devices?: Array<string>;
     container_id?: string;
+    container_path?: string;
     data_restored?: boolean;
     has_preserved_data?: boolean;
     image?: string;
     snapshotter?: string;
     started?: boolean;
+    workspace_backend?: string;
 };
 
 export type HandlersCreateSnapshotRequest = {
@@ -1036,6 +1041,7 @@ export type HandlersGetContainerResponse = {
     status?: string;
     task_running?: boolean;
     updated_at?: string;
+    workspace_backend?: string;
 };
 
 export type HandlersInstallMcpRequest = {
@@ -1104,6 +1110,7 @@ export type HandlersModelTokenUsage = {
 export type HandlersPingResponse = {
     commit_hash?: string;
     container_backend?: string;
+    local_workspace_enabled?: boolean;
     snapshot_supported?: boolean;
     status?: string;
     version?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,18 @@ importers:
       '@memohai/web':
         specifier: workspace:*
         version: link:../web
+      '@vee-validate/zod':
+        specifier: ^4.15.1
+        version: 4.15.1(vue@3.5.26(typescript@5.9.3))(zod@4.4.1)
+      lucide-vue-next:
+        specifier: ^0.562.0
+        version: 0.562.0(vue@3.5.26(typescript@5.9.3))
+      vee-validate:
+        specifier: ^4.15.1
+        version: 4.15.1(vue@3.5.26(typescript@5.9.3))
+      zod:
+        specifier: ^4.4.1
+        version: 4.4.1
     devDependencies:
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
@@ -5812,6 +5824,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
+
   zrender@6.0.0:
     resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
@@ -7733,6 +7748,14 @@ snapshots:
       type-fest: 4.41.0
       vee-validate: 4.15.1(vue@3.5.26(typescript@5.9.3))
       zod: 4.3.6
+    transitivePeerDependencies:
+      - vue
+
+  '@vee-validate/zod@4.15.1(vue@3.5.26(typescript@5.9.3))(zod@4.4.1)':
+    dependencies:
+      type-fest: 4.41.0
+      vee-validate: 4.15.1(vue@3.5.26(typescript@5.9.3))
+      zod: 4.4.1
     transitivePeerDependencies:
       - vue
 
@@ -11262,6 +11285,8 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.1: {}
 
   zrender@6.0.0:
     dependencies:

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -11817,6 +11817,9 @@ const docTemplate = `{
                 "kernel_nanoseconds": {
                     "type": "integer"
                 },
+                "usage_nanocores": {
+                    "type": "integer"
+                },
                 "usage_nanoseconds": {
                     "type": "integer"
                 },
@@ -11909,10 +11912,16 @@ const docTemplate = `{
                 "image": {
                     "type": "string"
                 },
+                "local_workspace_path": {
+                    "type": "string"
+                },
                 "restore_data": {
                     "type": "boolean"
                 },
                 "snapshotter": {
+                    "type": "string"
+                },
+                "workspace_backend": {
                     "type": "string"
                 }
             }
@@ -11929,6 +11938,9 @@ const docTemplate = `{
                 "container_id": {
                     "type": "string"
                 },
+                "container_path": {
+                    "type": "string"
+                },
                 "data_restored": {
                     "type": "boolean"
                 },
@@ -11943,6 +11955,9 @@ const docTemplate = `{
                 },
                 "started": {
                     "type": "boolean"
+                },
+                "workspace_backend": {
+                    "type": "string"
                 }
             }
         },
@@ -12175,6 +12190,9 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "workspace_backend": {
+                    "type": "string"
                 }
             }
         },
@@ -12342,6 +12360,9 @@ const docTemplate = `{
                 },
                 "container_backend": {
                     "type": "string"
+                },
+                "local_workspace_enabled": {
+                    "type": "boolean"
                 },
                 "snapshot_supported": {
                     "type": "boolean"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -11808,6 +11808,9 @@
                 "kernel_nanoseconds": {
                     "type": "integer"
                 },
+                "usage_nanocores": {
+                    "type": "integer"
+                },
                 "usage_nanoseconds": {
                     "type": "integer"
                 },
@@ -11900,10 +11903,16 @@
                 "image": {
                     "type": "string"
                 },
+                "local_workspace_path": {
+                    "type": "string"
+                },
                 "restore_data": {
                     "type": "boolean"
                 },
                 "snapshotter": {
+                    "type": "string"
+                },
+                "workspace_backend": {
                     "type": "string"
                 }
             }
@@ -11920,6 +11929,9 @@
                 "container_id": {
                     "type": "string"
                 },
+                "container_path": {
+                    "type": "string"
+                },
                 "data_restored": {
                     "type": "boolean"
                 },
@@ -11934,6 +11946,9 @@
                 },
                 "started": {
                     "type": "boolean"
+                },
+                "workspace_backend": {
+                    "type": "string"
                 }
             }
         },
@@ -12166,6 +12181,9 @@
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "workspace_backend": {
+                    "type": "string"
                 }
             }
         },
@@ -12333,6 +12351,9 @@
                 },
                 "container_backend": {
                     "type": "string"
+                },
+                "local_workspace_enabled": {
+                    "type": "boolean"
                 },
                 "snapshot_supported": {
                     "type": "boolean"

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1494,6 +1494,8 @@ definitions:
     properties:
       kernel_nanoseconds:
         type: integer
+      usage_nanocores:
+        type: integer
       usage_nanoseconds:
         type: integer
       usage_percent:
@@ -1553,9 +1555,13 @@ definitions:
         $ref: '#/definitions/handlers.ContainerGPURequest'
       image:
         type: string
+      local_workspace_path:
+        type: string
       restore_data:
         type: boolean
       snapshotter:
+        type: string
+      workspace_backend:
         type: string
     type: object
   handlers.CreateContainerResponse:
@@ -1565,6 +1571,8 @@ definitions:
           type: string
         type: array
       container_id:
+        type: string
+      container_path:
         type: string
       data_restored:
         type: boolean
@@ -1576,6 +1584,8 @@ definitions:
         type: string
       started:
         type: boolean
+      workspace_backend:
+        type: string
     type: object
   handlers.CreateSnapshotRequest:
     properties:
@@ -1726,6 +1736,8 @@ definitions:
         type: boolean
       updated_at:
         type: string
+      workspace_backend:
+        type: string
     type: object
   handlers.InstallMcpRequest:
     properties:
@@ -1834,6 +1846,8 @@ definitions:
         type: string
       container_backend:
         type: string
+      local_workspace_enabled:
+        type: boolean
       snapshot_supported:
         type: boolean
       status:


### PR DESCRIPTION
## Summary
- Add a local workspace runtime alongside container backends, with explicit workspace backend tracking in the database.
- Bundle and supervise a local Go server in the Electron desktop app, including auto-login, provider templates, bridge runtime, query cache sync, and stale server restart handling.
- Add desktop-specific bot creation for local workspaces while preserving the existing web flow.

## Test plan
- `go test ./...`
- `pnpm --filter @memohai/desktop typecheck`
- `pnpm --filter @memohai/desktop build:dir`
- Manual desktop dev validation for local and Docker workspaces, including Docker bridge file access.