### PR TITLE
fix(providers): use Anthropic model import headers

### DIFF
--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -210,7 +210,10 @@ func (s *Service) Count(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
-const probeTimeout = models.DefaultProviderProbeTimeout
+const (
+	probeTimeout        = models.DefaultProviderProbeTimeout
+	anthropicAPIVersion = "2023-06-01"
+)
 
 // Test probes the provider using the Twilight AI SDK to check
 // reachability and authentication.
@@ -310,10 +313,14 @@ func (s *Service) FetchRemoteModels(ctx context.Context, id string) ([]RemoteMod
 		return remoteModels, nil
 	}
 
+	return fetchRemoteModelsFromProvider(ctx, provider)
+}
+
+func fetchRemoteModelsFromProvider(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {
 	cfg := providerConfig(provider.Config)
 	baseURL := strings.TrimRight(configString(cfg, "base_url"), "/")
 	apiKey := configString(cfg, "api_key")
-	modelsURL := fmt.Sprintf("%s/models", baseURL)
+	modelsURL := fetchModelsURL(models.ClientType(provider.ClientType), baseURL)
 
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
@@ -323,9 +330,7 @@ func (s *Service) FetchRemoteModels(ctx context.Context, id string) ([]RemoteMod
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	if apiKey != "" && !supportsOAuth(provider) {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
-	}
+	setFetchModelsAuthHeaders(req, models.ClientType(provider.ClientType), apiKey)
 
 	resp, err := models.NewProviderHTTPClient(probeTimeout).Do(req) //nolint:gosec // G704: URL is from operator-configured LLM provider base URL
 	if err != nil {
@@ -343,7 +348,44 @@ func (s *Service) FetchRemoteModels(ctx context.Context, id string) ([]RemoteMod
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
+	normalizeFetchedModels(models.ClientType(provider.ClientType), fetchResp.Data)
 	return fetchResp.Data, nil
+}
+
+func fetchModelsURL(clientType models.ClientType, baseURL string) string {
+	if clientType == models.ClientTypeAnthropicMessages && !strings.HasSuffix(baseURL, "/v1") {
+		baseURL += "/v1"
+	}
+	return fmt.Sprintf("%s/models", baseURL)
+}
+
+func setFetchModelsAuthHeaders(req *http.Request, clientType models.ClientType, apiKey string) {
+	if apiKey == "" {
+		return
+	}
+	if clientType == models.ClientTypeAnthropicMessages {
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("anthropic-version", anthropicAPIVersion)
+		return
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+}
+
+func normalizeFetchedModels(clientType models.ClientType, remoteModels []RemoteModel) {
+	if clientType != models.ClientTypeAnthropicMessages {
+		return
+	}
+	for i := range remoteModels {
+		if strings.TrimSpace(remoteModels[i].Name) == "" {
+			remoteModels[i].Name = strings.TrimSpace(remoteModels[i].DisplayName)
+		}
+		if strings.TrimSpace(remoteModels[i].Object) == "" {
+			remoteModels[i].Object = remoteModels[i].Type
+		}
+		if strings.TrimSpace(remoteModels[i].Type) == "model" {
+			remoteModels[i].Type = string(models.ModelTypeChat)
+		}
+	}
 }
 
 // toGetResponse converts a database provider to a response.

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1,6 +1,10 @@
 package providers
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -202,5 +206,53 @@ func TestOAuthConfigForGitHubCopilotUsesFixedDeviceFlowSettings(t *testing.T) {
 	}
 	if cfg.Scopes != "read:user user:email" {
 		t.Fatalf("expected fixed scope, got %q", cfg.Scopes)
+	}
+}
+
+func TestFetchRemoteModelsFromAnthropicUsesAnthropicHeaders(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("expected /v1/models path, got %q", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "sk-ant-test" {
+			t.Fatalf("expected x-api-key header, got %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != anthropicAPIVersion {
+			t.Fatalf("expected anthropic-version %q, got %q", anthropicAPIVersion, got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected no Authorization header, got %q", got)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{
+					"id":           "claude-sonnet-4-20250514",
+					"display_name": "Claude Sonnet 4",
+					"type":         "model",
+				},
+			},
+			"has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	remoteModels, err := fetchRemoteModelsFromProvider(context.Background(), sqlc.Provider{
+		ClientType: string(models.ClientTypeAnthropicMessages),
+		Config:     []byte(`{"base_url":"` + server.URL + `","api_key":"sk-ant-test"}`),
+	})
+	if err != nil {
+		t.Fatalf("fetch remote models: %v", err)
+	}
+	if len(remoteModels) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(remoteModels))
+	}
+	if remoteModels[0].Name != "Claude Sonnet 4" {
+		t.Fatalf("expected display name to be mapped, got %q", remoteModels[0].Name)
+	}
+	if remoteModels[0].Type != string(models.ModelTypeChat) {
+		t.Fatalf("expected Anthropic model type to import as chat, got %q", remoteModels[0].Type)
 	}
 }

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -94,6 +94,7 @@ type RemoteModel struct {
 	Created          int64    `json:"created"`
 	OwnedBy          string   `json:"owned_by"`
 	Name             string   `json:"name,omitempty"`
+	DisplayName      string   `json:"display_name,omitempty"`
 	Type             string   `json:"type,omitempty"`
 	Compatibilities  []string `json:"compatibilities,omitempty"`
 	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`


### PR DESCRIPTION
## Summary

- Use Anthropic-specific headers when importing remote models from Anthropic providers.
- Request Anthropic models from `/v1/models` when the configured base URL does not already include `/v1`.
- Map Anthropic `display_name` and `type: model` responses into Memoh model import fields.

## Root Cause

The provider model import path treated Anthropic as OpenAI-compatible and sent `Authorization: Bearer <api_key>` to `/models`. Anthropic requires `x-api-key` and `anthropic-version: 2023-06-01` for the Models API.

## Validation

- `mise exec -- go test ./internal/providers`
- pre-commit Go lint
- pre-commit Go test
