### PR TITLE
feat(anthropic): add prompt caching support

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -370,6 +370,14 @@
     "iconPlaceholder": "Icon URL or identifier (optional)",
     "enable": "Enable",
     "enableHint": "Only models from enabled providers appear in the available model list",
+    "promptCache": {
+      "label": "Prompt Cache",
+      "option5m": "5 minutes (default)",
+      "option1h": "1 hour (higher cost)",
+      "optionOff": "Off (not recommended)",
+      "description": "Enable prompt caching for the system prompt and tool list to cut input cost on repeat requests. Currently honored only by Anthropic models.",
+      "descriptionOff": "Disabling caching rebills the full system prompt and tool list on every request. Only use this for strict context isolation."
+    },
     "oauth": {
       "openaiTitle": "OpenAI OAuth",
       "openaiDescription": "Authorize this provider with your ChatGPT account for Codex-compatible OpenAI access.",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -366,6 +366,14 @@
     "iconPlaceholder": "图标 URL 或标识（可选）",
     "enable": "启用",
     "enableHint": "只有启用的供应商的模型才会出现在可用模型列表中",
+    "promptCache": {
+      "label": "Prompt 缓存",
+      "option5m": "5 分钟（默认）",
+      "option1h": "1 小时（费用更高）",
+      "optionOff": "关闭（不推荐）",
+      "description": "对系统提示词与工具列表启用 Prompt Caching，可显著降低重复请求的输入费用。当前仅 Anthropic 系列模型生效。",
+      "descriptionOff": "关闭后每次请求都会重新计费完整的系统提示词与工具列表，仅在需要严格隔离上下文时使用。"
+    },
     "oauth": {
       "openaiTitle": "OpenAI OAuth",
       "openaiDescription": "使用你的 ChatGPT 账号为该提供商授权，以启用 Codex 兼容的 OpenAI 访问。",

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -71,6 +71,42 @@
         </FormItem>
       </FormField>
 
+      <FormField
+        v-if="supportsPromptCache(form.values.client_type)"
+        v-slot="{ value, handleChange }"
+        name="prompt_cache_ttl"
+      >
+        <FormItem class="md:col-span-2">
+          <FormLabel>{{ $t('provider.promptCache.label') }}</FormLabel>
+          <FormControl>
+            <Select
+              :model-value="value || '5m'"
+              @update:model-value="handleChange"
+            >
+              <SelectTrigger>
+                <SelectValue :placeholder="$t('provider.promptCache.label')" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="5m">
+                  {{ $t('provider.promptCache.option5m') }}
+                </SelectItem>
+                <SelectItem value="1h">
+                  {{ $t('provider.promptCache.option1h') }}
+                </SelectItem>
+                <SelectItem value="off">
+                  {{ $t('provider.promptCache.optionOff') }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </FormControl>
+          <FormDescription>
+            {{ form.values.prompt_cache_ttl === 'off'
+              ? $t('provider.promptCache.descriptionOff')
+              : $t('provider.promptCache.description') }}
+          </FormDescription>
+        </FormItem>
+      </FormField>
+
       <section
         v-if="['openai-codex', 'github-copilot'].includes(form.values.client_type)"
         class="md:col-span-2 rounded-lg border p-4 space-y-3 text-xs"
@@ -288,9 +324,15 @@ import {
   Input,
   Button,
   FormControl,
+  FormDescription,
   FormField,
   FormLabel,
   FormItem,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Spinner,
 } from '@memohai/ui'
 import { Copy, KeyRound, RefreshCw, Trash2 } from 'lucide-vue-next'
@@ -348,6 +390,20 @@ function getStoredSecret(config: Record<string, unknown> | undefined) {
   if (!config) return ''
   const apiKey = config.api_key
   return typeof apiKey === 'string' ? apiKey : ''
+}
+
+type PromptCacheTtl = '5m' | '1h' | 'off'
+
+function normalizeCacheTtl(value: string | undefined): PromptCacheTtl {
+  return value === '1h' || value === 'off' ? value : '5m'
+}
+
+// Vendors that expose configurable prompt cache TTL. Currently only
+// Anthropic Messages; expand this list as other providers gain support.
+const PROMPT_CACHE_CLIENT_TYPES = new Set(['anthropic-messages'])
+
+function supportsPromptCache(clientType: string | undefined): boolean {
+  return !!clientType && PROMPT_CACHE_CLIENT_TYPES.has(clientType)
 }
 
 const props = defineProps<{
@@ -409,6 +465,7 @@ const providerSchema = toTypedSchema(z.object({
   base_url: z.string().optional(),
   api_key: z.string().optional(),
   client_type: z.string().min(1),
+  prompt_cache_ttl: z.enum(['5m', '1h', 'off']).optional(),
 }).superRefine((value, ctx) => {
   const existingSecret = getStoredSecret(
     props.provider?.config as Record<string, unknown> | undefined,
@@ -442,6 +499,7 @@ watch(() => props.provider, (newVal) => {
       base_url: (cfg?.base_url as string) ?? '',
       api_key: '',
       client_type: newVal.client_type || 'openai-completions',
+      prompt_cache_ttl: normalizeCacheTtl(cfg?.prompt_cache_ttl as string | undefined),
     })
   }
 }, { immediate: true })
@@ -482,7 +540,10 @@ const hasChanges = computed(() => {
   })
 
   const apiKeyChanged = Boolean(form.values.api_key && form.values.api_key.trim() !== '')
-  return baseChanged || apiKeyChanged
+  const cacheChanged = supportsPromptCache(form.values.client_type)
+    && normalizeCacheTtl(form.values.prompt_cache_ttl)
+      !== normalizeCacheTtl(cfg?.prompt_cache_ttl as string | undefined)
+  return baseChanged || apiKeyChanged || cacheChanged
 })
 
 const editProvider = form.handleSubmit(async (value) => {
@@ -494,6 +555,9 @@ const editProvider = form.handleSubmit(async (value) => {
     if (value.client_type !== 'github-copilot') {
       config.api_key = value.api_key.trim()
     }
+  }
+  if (supportsPromptCache(value.client_type)) {
+    config.prompt_cache_ttl = normalizeCacheTtl(value.prompt_cache_ttl)
   }
   const metadata = {
     ...((props.provider?.metadata as Record<string, unknown> | undefined) ?? {}),

--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -1085,11 +1085,12 @@ func (c *lazyLLMClient) resolve(ctx context.Context, botID string) (memprovider.
 		return nil, err
 	}
 	return memllm.New(memllm.Config{
-		ModelID:    memoryModel.ModelID,
-		BaseURL:    strings.TrimRight(providers.ProviderConfigString(memoryProvider, "base_url"), "/"),
-		APIKey:     providers.ProviderConfigString(memoryProvider, "api_key"),
-		ClientType: memoryProvider.ClientType,
-		Timeout:    c.timeout,
+		ModelID:        memoryModel.ModelID,
+		BaseURL:        strings.TrimRight(providers.ProviderConfigString(memoryProvider, "base_url"), "/"),
+		APIKey:         providers.ProviderConfigString(memoryProvider, "api_key"),
+		ClientType:     memoryProvider.ClientType,
+		Timeout:        c.timeout,
+		PromptCacheTTL: providers.ProviderConfigString(memoryProvider, "prompt_cache_ttl"),
 	}), nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -664,10 +664,13 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (*GenerateResult
 }
 
 func (*Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, prepareStep func(*sdk.GenerateParams) *sdk.GenerateParams) []sdk.GenerateOption {
+	system, messages, tools := models.ApplyPromptCache(
+		cfg.Model, cfg.PromptCacheTTL, cfg.System, cfg.Messages, tools,
+	)
 	opts := []sdk.GenerateOption{
 		sdk.WithModel(cfg.Model),
-		sdk.WithMessages(cfg.Messages),
-		sdk.WithSystem(cfg.System),
+		sdk.WithMessages(messages),
+		sdk.WithSystem(system),
 		sdk.WithMaxSteps(-1),
 	}
 	if len(tools) > 0 && cfg.SupportsToolCall {

--- a/internal/agent/spawn_adapter.go
+++ b/internal/agent/spawn_adapter.go
@@ -39,6 +39,7 @@ func (s *SpawnAdapter) Generate(ctx context.Context, cfg tools.SpawnRunConfig) (
 		SessionType:      cfg.SessionType,
 		Messages:         messages,
 		ReasoningEffort:  cfg.ReasoningEffort,
+		PromptCacheTTL:   cfg.PromptCacheTTL,
 		SupportsToolCall: true,
 		Identity: SessionContext{
 			BotID:             cfg.Identity.BotID,
@@ -86,6 +87,7 @@ func (s *SpawnAdapter) GenerateWithWatchdog(ctx context.Context, cfg tools.Spawn
 		SessionType:      cfg.SessionType,
 		Messages:         messages,
 		ReasoningEffort:  cfg.ReasoningEffort,
+		PromptCacheTTL:   cfg.PromptCacheTTL,
 		SupportsToolCall: true,
 		Identity: SessionContext{
 			BotID:             cfg.Identity.BotID,

--- a/internal/agent/tools/image_gen.go
+++ b/internal/agent/tools/image_gen.go
@@ -135,11 +135,17 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 	})
 
 	userMsg := fmt.Sprintf("Generate an image with the following description. Size: %s\n\n%s", size, prompt)
+	system, messages, _ := models.ApplyPromptCache(
+		sdkModel,
+		providers.ProviderConfigString(provider, "prompt_cache_ttl"),
+		"",
+		[]sdk.Message{{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: userMsg}}}},
+		nil,
+	)
 	result, err := sdk.GenerateTextResult(ctx,
 		sdk.WithModel(sdkModel),
-		sdk.WithMessages([]sdk.Message{
-			{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: userMsg}}},
-		}),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("image generation failed: %w", err)

--- a/internal/agent/tools/subagent.go
+++ b/internal/agent/tools/subagent.go
@@ -41,6 +41,7 @@ type SpawnRunConfig struct {
 	LoopDetection   SpawnLoopConfig
 	Messages        []sdk.Message
 	ReasoningEffort string
+	PromptCacheTTL  string
 }
 
 // SpawnIdentity mirrors agent.SessionContext fields needed by spawn.
@@ -329,7 +330,7 @@ func (p *SpawnProvider) execSpawn(ctx context.Context, session SessionContext, a
 	// prevent the spawn from completing and returning its results.
 	sessionCtx := context.WithoutCancel(ctx)
 
-	sdkModel, modelID, err := p.resolveModel(sessionCtx, botID)
+	sdkModel, modelID, promptCacheTTL, err := p.resolveModel(sessionCtx, botID)
 	if err != nil {
 		return nil, fmt.Errorf("resolve model: %w", err)
 	}
@@ -353,7 +354,7 @@ func (p *SpawnProvider) execSpawn(ctx context.Context, session SessionContext, a
 	for i, task := range tasks {
 		go func(idx int, query string) {
 			defer wg.Done()
-			results[idx] = p.runSubagentTask(sessionCtx, session, sdkModel, modelID, systemPrompt, query)
+			results[idx] = p.runSubagentTask(sessionCtx, session, sdkModel, modelID, promptCacheTTL, systemPrompt, query)
 		}(i, task)
 	}
 	wg.Wait()
@@ -394,6 +395,7 @@ func (p *SpawnProvider) runSubagentTask(
 	parentSession SessionContext,
 	model *sdk.Model,
 	modelID string,
+	promptCacheTTL string,
 	systemPrompt string,
 	query string,
 ) spawnResult {
@@ -416,10 +418,11 @@ func (p *SpawnProvider) runSubagentTask(
 	}
 
 	cfg := SpawnRunConfig{
-		Model:       model,
-		System:      systemPrompt,
-		Query:       query,
-		SessionType: sessionpkg.TypeSubagent,
+		Model:          model,
+		System:         systemPrompt,
+		Query:          query,
+		SessionType:    sessionpkg.TypeSubagent,
+		PromptCacheTTL: promptCacheTTL,
 		Identity: SpawnIdentity{
 			BotID:             parentSession.BotID,
 			ChatID:            parentSession.ChatID,
@@ -596,33 +599,33 @@ func (p *SpawnProvider) SetModelCreator(fn ModelCreator) {
 	p.modelCreator = fn
 }
 
-func (p *SpawnProvider) resolveModel(ctx context.Context, botID string) (*sdk.Model, string, error) {
+func (p *SpawnProvider) resolveModel(ctx context.Context, botID string) (*sdk.Model, string, string, error) {
 	if p.settings == nil || p.models == nil || p.queries == nil {
-		return nil, "", errors.New("model resolution services not configured")
+		return nil, "", "", errors.New("model resolution services not configured")
 	}
 	botSettings, err := p.settings.GetBot(ctx, botID)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	chatModelID := strings.TrimSpace(botSettings.ChatModelID)
 	if chatModelID == "" {
-		return nil, "", errors.New("no chat model configured for bot")
+		return nil, "", "", errors.New("no chat model configured for bot")
 	}
 	modelInfo, err := p.models.GetByID(ctx, chatModelID)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	provider, err := models.FetchProviderByID(ctx, p.queries, modelInfo.ProviderID)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if p.modelCreator == nil {
-		return nil, "", errors.New("model creator not configured")
+		return nil, "", "", errors.New("model creator not configured")
 	}
 	authResolver := providers.NewService(nil, p.queries, "")
 	creds, err := authResolver.ResolveModelCredentials(ctx, provider)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	sdkModel := p.modelCreator(
 		modelInfo.ModelID,
@@ -632,7 +635,8 @@ func (p *SpawnProvider) resolveModel(ctx context.Context, botID string) (*sdk.Mo
 		providers.ProviderConfigString(provider, "base_url"),
 		nil,
 	)
-	return sdkModel, modelInfo.ID, nil
+	cacheTTL := providers.ProviderConfigString(provider, "prompt_cache_ttl")
+	return sdkModel, modelInfo.ID, cacheTTL, nil
 }
 
 func toStringSlice(v any) ([]string, error) {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -76,6 +76,13 @@ type RunConfig struct {
 	LoopDetection      LoopDetectionConfig
 	Retry              RetryConfig
 
+	// PromptCacheTTL controls prompt caching for this run. Empty or
+	// unrecognized values default to 5m. Use "1h" for the long-cache tier
+	// or "off" to disable caching entirely. The TTL is honored only when
+	// the resolved model's vendor implements prompt caching (currently
+	// Anthropic Messages); for other vendors the value is ignored.
+	PromptCacheTTL string
+
 	// MidTaskPruneThreshold is the minimum number of messages before mid-task
 	// pruning kicks in. When the accumulated message count reaches this
 	// threshold, older tool-result pairs are pruned to keep the context

--- a/internal/command/compact.go
+++ b/internal/command/compact.go
@@ -86,6 +86,7 @@ func (h *Handler) buildCompactConfig(cc CommandContext, sessionID string) (compa
 		BaseURL:          providers.ProviderConfigString(compactProvider, "base_url"),
 		Ratio:            100,
 		TotalInputTokens: 1,
+		PromptCacheTTL:   providers.ProviderConfigString(compactProvider, "prompt_cache_ttl"),
 	}
 	if compactModel.Config.ContextWindow != nil && *compactModel.Config.ContextWindow > 0 {
 		cfg.MaxCompactTokens = *compactModel.Config.ContextWindow * 90 / 100

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -147,10 +147,15 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		HTTPClient:     cfg.HTTPClient,
 	})
 
+	systemPromptDecorated, sdkMessages, _ := models.ApplyPromptCache(
+		model, cfg.PromptCacheTTL,
+		systemPrompt, []sdk.Message{sdk.UserMessage(userPrompt)}, nil,
+	)
+
 	result, err := sdk.GenerateTextResult(ctx,
 		sdk.WithModel(model),
-		sdk.WithSystem(systemPrompt),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage(userPrompt)}),
+		sdk.WithSystem(systemPromptDecorated),
+		sdk.WithMessages(sdkMessages),
 	)
 	if err != nil {
 		return err

--- a/internal/compaction/types.go
+++ b/internal/compaction/types.go
@@ -40,4 +40,5 @@ type TriggerConfig struct {
 	TotalInputTokens int
 	MaxCompactTokens int // if > 0, cap compaction input to this many tokens (e.g. 90% of model window)
 	TargetTokens     int // if > 0, compaction goal: reduce context to this many tokens (used by sync compaction)
+	PromptCacheTTL   string
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,6 +157,7 @@ func TestLoadAppLocalTemplate(t *testing.T) {
 	}
 	rendered := strings.ReplaceAll(string(raw), "__PROJECT_ROOT__", filepath.ToSlash(filepath.Join("..", "..")))
 	configPath := filepath.Join(t.TempDir(), "app.local.toml")
+	//nolint:gosec // configPath is rooted at t.TempDir() with a literal filename; the rendered template content is not used as a path.
 	if err := os.WriteFile(configPath, []byte(rendered), 0o600); err != nil {
 		t.Fatalf("write rendered app.local.toml: %v", err)
 	}

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -582,6 +582,7 @@ func (r *Resolver) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams
 	cfg := agentpkg.RunConfig{
 		Model:              sdkModel,
 		ReasoningEffort:    reasoningEffort,
+		PromptCacheTTL:     providers.ProviderConfigString(provider, "prompt_cache_ttl"),
 		SessionType:        p.SessionType,
 		SupportsImageInput: chatModel.HasCompatibility(models.CompatVision),
 		SupportsToolCall:   chatModel.HasCompatibility(models.CompatToolCall),

--- a/internal/conversation/flow/resolver_compaction.go
+++ b/internal/conversation/flow/resolver_compaction.go
@@ -133,6 +133,7 @@ func (r *Resolver) buildCompactionConfig(ctx context.Context, req conversation.C
 		Ratio:            ratio,
 		TotalInputTokens: inputTokens,
 		HTTPClient:       r.streamHTTPClient,
+		PromptCacheTTL:   providers.ProviderConfigString(compactProvider, "prompt_cache_ttl"),
 	}
 
 	// Cap compaction input to 90% of the compaction model's context window.

--- a/internal/conversation/flow/resolver_title.go
+++ b/internal/conversation/flow/resolver_title.go
@@ -126,10 +126,16 @@ func (r *Resolver) generateTitle(ctx context.Context, userID string, model model
 	genCtx, cancel := context.WithTimeout(ctx, titleGenerateTimeout)
 	defer cancel()
 
+	cacheTTL := providers.ProviderConfigString(provider, "prompt_cache_ttl")
+	system, messages, _ := models.ApplyPromptCache(
+		sdkModel, cacheTTL, "", []sdk.Message{sdk.UserMessage(prompt)}, nil,
+	)
+
 	client := sdk.NewClient()
 	text, err := client.GenerateText(genCtx,
 		sdk.WithModel(sdkModel),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage(prompt)}),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
 	)
 	if err != nil {
 		r.logger.Warn("title gen: LLM call failed", slog.Any("error", err))

--- a/internal/handlers/compaction.go
+++ b/internal/handlers/compaction.go
@@ -207,6 +207,7 @@ func (h *CompactionHandler) buildTriggerConfig(ctx context.Context, botID, sessi
 		BaseURL:          providers.ProviderConfigString(compactProvider, "base_url"),
 		Ratio:            100,
 		TotalInputTokens: 1,
+		PromptCacheTTL:   providers.ProviderConfigString(compactProvider, "prompt_cache_ttl"),
 	}
 	if compactModel.Config.ContextWindow != nil && *compactModel.Config.ContextWindow > 0 {
 		cfg.MaxCompactTokens = *compactModel.Config.ContextWindow * 90 / 100

--- a/internal/memory/memllm/client.go
+++ b/internal/memory/memllm/client.go
@@ -22,11 +22,12 @@ const (
 
 // Config holds model resolution details for the memory LLM.
 type Config struct {
-	ModelID    string
-	BaseURL    string
-	APIKey     string `json:"-"`
-	ClientType string
-	Timeout    time.Duration
+	ModelID        string
+	BaseURL        string
+	APIKey         string `json:"-"`
+	ClientType     string
+	Timeout        time.Duration
+	PromptCacheTTL string
 }
 
 // Client implements adapters.LLM using the Twilight AI SDK.
@@ -85,10 +86,15 @@ func (c *Client) Extract(ctx context.Context, req adapters.ExtractRequest) (adap
 	}
 	systemPrompt := strings.ReplaceAll(agent.MemoryExtractPrompt, "{{today}}", now.Format("2006-01-02"))
 
+	model := c.model()
+	system, messages, _ := models.ApplyPromptCache(
+		model, c.cfg.PromptCacheTTL,
+		systemPrompt, []sdk.Message{sdk.UserMessage(transcript)}, nil,
+	)
 	result, err := sdk.GenerateTextResult(ctx,
-		sdk.WithModel(c.model()),
-		sdk.WithSystem(systemPrompt),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage(transcript)}),
+		sdk.WithModel(model),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
 	)
 	if err != nil {
 		return adapters.ExtractResponse{}, fmt.Errorf("extract: %w", err)
@@ -111,10 +117,15 @@ func (c *Client) Decide(ctx context.Context, req adapters.DecideRequest) (adapte
 
 	userMessage := buildUpdateUserMessage(req.Candidates, req.Facts)
 
+	model := c.model()
+	system, messages, _ := models.ApplyPromptCache(
+		model, c.cfg.PromptCacheTTL,
+		agent.MemoryUpdatePrompt, []sdk.Message{sdk.UserMessage(userMessage)}, nil,
+	)
 	result, err := sdk.GenerateTextResult(ctx,
-		sdk.WithModel(c.model()),
-		sdk.WithSystem(agent.MemoryUpdatePrompt),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage(userMessage)}),
+		sdk.WithModel(model),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
 	)
 	if err != nil {
 		return adapters.DecideResponse{}, fmt.Errorf("decide: %w", err)
@@ -142,10 +153,15 @@ func (c *Client) Compact(ctx context.Context, req adapters.CompactRequest) (adap
 	if err != nil {
 		return adapters.CompactResponse{}, fmt.Errorf("compact: marshal input: %w", err)
 	}
+	model := c.model()
+	system, messages, _ := models.ApplyPromptCache(
+		model, c.cfg.PromptCacheTTL,
+		compactSystemPrompt, []sdk.Message{sdk.UserMessage(string(payload))}, nil,
+	)
 	result, err := sdk.GenerateTextResult(ctx,
-		sdk.WithModel(c.model()),
-		sdk.WithSystem(compactSystemPrompt),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage(string(payload))}),
+		sdk.WithModel(model),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
 	)
 	if err != nil {
 		return adapters.CompactResponse{}, fmt.Errorf("compact: %w", err)

--- a/internal/models/prompt_cache.go
+++ b/internal/models/prompt_cache.go
@@ -1,0 +1,131 @@
+package models
+
+import (
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// Prompt cache TTL options accepted in Provider config.
+//
+// The values are vendor-neutral; ApplyPromptCache dispatches to the
+// vendor-specific decoration based on the resolved client type. Today only
+// Anthropic Messages implements caching, but the public API stays stable
+// when other vendors gain similar support.
+const (
+	// PromptCacheTTL5m enables prompt caching with a short (~5 minute)
+	// TTL. Recommended default.
+	PromptCacheTTL5m = "5m"
+	// PromptCacheTTL1h enables prompt caching with a 1-hour TTL. Some
+	// vendors (e.g. Anthropic) bill 1h cache writes at a higher rate
+	// than the default short TTL.
+	PromptCacheTTL1h = "1h"
+	// PromptCacheTTLOff disables prompt caching for the provider. Not
+	// recommended: every request rebuilds the prefix without cache.
+	PromptCacheTTLOff = "off"
+)
+
+// DefaultPromptCacheTTL is the value used when a provider does not
+// explicitly configure a cache policy.
+const DefaultPromptCacheTTL = PromptCacheTTL5m
+
+// NormalizePromptCacheTTL coerces an arbitrary user-provided value to one
+// of the accepted TTL constants. Empty or unrecognized values fall back to
+// the recommended short-TTL default.
+func NormalizePromptCacheTTL(s string) string {
+	switch s {
+	case PromptCacheTTL1h:
+		return PromptCacheTTL1h
+	case PromptCacheTTLOff:
+		return PromptCacheTTLOff
+	default:
+		return DefaultPromptCacheTTL
+	}
+}
+
+// ApplyPromptCache returns a request payload decorated with provider-specific
+// prompt cache breakpoints. The dispatch is keyed off the resolved client
+// type, so the call site does not need to know which vendor (if any) supports
+// caching for the active model.
+//
+// For models whose vendor does not implement caching, or when the requested
+// TTL is "off", the inputs are returned unchanged.
+func ApplyPromptCache(
+	model *sdk.Model,
+	ttl string,
+	system string,
+	messages []sdk.Message,
+	tools []sdk.Tool,
+) (string, []sdk.Message, []sdk.Tool) {
+	if model == nil {
+		return system, messages, tools
+	}
+	normalized := NormalizePromptCacheTTL(ttl)
+	if normalized == PromptCacheTTLOff {
+		return system, messages, tools
+	}
+	switch ResolveClientType(model) {
+	case string(ClientTypeAnthropicMessages):
+		return applyAnthropicPromptCache(normalized, system, messages, tools)
+	default:
+		return system, messages, tools
+	}
+}
+
+// applyAnthropicPromptCache decorates the request with Anthropic's
+// cache_control breakpoints, mirroring the recommended structural cache
+// layout:
+//
+//   - The system prompt is moved out of the dedicated `system` parameter
+//     into the leading message slot as a SystemMessage with cache_control
+//     on its TextPart, because Twilight's WithSystem accepts only a plain
+//     string and does not propagate cache_control metadata.
+//   - The final tool definition receives cache_control, which causes
+//     Anthropic to cache the entire tool list up to and including that
+//     tool.
+func applyAnthropicPromptCache(
+	ttl string,
+	system string,
+	messages []sdk.Message,
+	tools []sdk.Tool,
+) (string, []sdk.Message, []sdk.Tool) {
+	cc := anthropicCacheControl(ttl)
+	if cc == nil {
+		return system, messages, tools
+	}
+
+	newMessages := messages
+	newSystem := system
+	if system != "" {
+		systemMsg := sdk.Message{
+			Role: sdk.MessageRoleSystem,
+			Content: []sdk.MessagePart{
+				sdk.TextPart{Text: system, CacheControl: cc},
+			},
+		}
+		newMessages = make([]sdk.Message, 0, len(messages)+1)
+		newMessages = append(newMessages, systemMsg)
+		newMessages = append(newMessages, messages...)
+		newSystem = ""
+	}
+
+	newTools := tools
+	if len(tools) > 0 {
+		newTools = make([]sdk.Tool, len(tools))
+		copy(newTools, tools)
+		newTools[len(newTools)-1].CacheControl = cc
+	}
+
+	return newSystem, newMessages, newTools
+}
+
+// anthropicCacheControl returns the SDK cache_control payload for Anthropic
+// Messages requests for the given normalized TTL.
+func anthropicCacheControl(ttl string) *sdk.CacheControl {
+	switch ttl {
+	case PromptCacheTTL1h:
+		return &sdk.CacheControl{Type: "ephemeral", TTL: "1h"}
+	case PromptCacheTTLOff:
+		return nil
+	default:
+		return &sdk.CacheControl{Type: "ephemeral"}
+	}
+}

--- a/internal/models/prompt_cache_test.go
+++ b/internal/models/prompt_cache_test.go
@@ -1,0 +1,172 @@
+package models
+
+import (
+	"testing"
+
+	anthropicmessages "github.com/memohai/twilight-ai/provider/anthropic/messages"
+	openaicompletions "github.com/memohai/twilight-ai/provider/openai/completions"
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestNormalizePromptCacheTTL(t *testing.T) {
+	cases := map[string]string{
+		"":         PromptCacheTTL5m,
+		"5m":       PromptCacheTTL5m,
+		"1h":       PromptCacheTTL1h,
+		"off":      PromptCacheTTLOff,
+		"garbage":  PromptCacheTTL5m,
+		"DISABLED": PromptCacheTTL5m,
+	}
+	for input, want := range cases {
+		if got := NormalizePromptCacheTTL(input); got != want {
+			t.Errorf("NormalizePromptCacheTTL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func newAnthropicTestModel(t *testing.T) *sdk.Model {
+	t.Helper()
+	provider := anthropicmessages.New(anthropicmessages.WithAPIKey("test"))
+	return provider.ChatModel("claude-test")
+}
+
+func newOpenAITestModel(t *testing.T) *sdk.Model {
+	t.Helper()
+	provider := openaicompletions.New(openaicompletions.WithAPIKey("test"))
+	return provider.ChatModel("gpt-test")
+}
+
+func textCacheControl(t *testing.T, msg sdk.Message) *sdk.CacheControl {
+	t.Helper()
+	if len(msg.Content) == 0 {
+		return nil
+	}
+	tp, ok := msg.Content[0].(sdk.TextPart)
+	if !ok {
+		return nil
+	}
+	return tp.CacheControl
+}
+
+func TestApplyPromptCache_AnthropicDefaultMovesSystemAndCachesLastTool(t *testing.T) {
+	model := newAnthropicTestModel(t)
+	system := "you are a helpful bot"
+	messages := []sdk.Message{sdk.UserMessage("hi")}
+	tools := []sdk.Tool{
+		{Name: "first"},
+		{Name: "second"},
+	}
+
+	gotSystem, gotMessages, gotTools := ApplyPromptCache(model, "", system, messages, tools)
+
+	if gotSystem != "" {
+		t.Fatalf("system should be cleared after promotion, got %q", gotSystem)
+	}
+	if len(gotMessages) != len(messages)+1 {
+		t.Fatalf("messages length: got %d, want %d", len(gotMessages), len(messages)+1)
+	}
+	if gotMessages[0].Role != sdk.MessageRoleSystem {
+		t.Errorf("first message role: got %q, want %q", gotMessages[0].Role, sdk.MessageRoleSystem)
+	}
+	cc := textCacheControl(t, gotMessages[0])
+	if cc == nil || cc.Type != "ephemeral" || cc.TTL != "" {
+		t.Errorf("system message cache: got %+v, want ephemeral 5m default", cc)
+	}
+	if got := gotTools[0].CacheControl; got != nil {
+		t.Errorf("first tool should not be cached, got %+v", got)
+	}
+	if got := gotTools[1].CacheControl; got == nil || got.TTL != "" {
+		t.Errorf("last tool cache: got %+v, want ephemeral 5m default", got)
+	}
+}
+
+func TestApplyPromptCache_AnthropicOneHourTTL(t *testing.T) {
+	model := newAnthropicTestModel(t)
+	gotSystem, gotMessages, gotTools := ApplyPromptCache(
+		model,
+		PromptCacheTTL1h,
+		"system text",
+		[]sdk.Message{sdk.UserMessage("hi")},
+		[]sdk.Tool{{Name: "only"}},
+	)
+	if gotSystem != "" {
+		t.Fatalf("system should be cleared, got %q", gotSystem)
+	}
+	cc := textCacheControl(t, gotMessages[0])
+	if cc == nil || cc.TTL != "1h" {
+		t.Errorf("system cache TTL: got %+v, want 1h", cc)
+	}
+	if got := gotTools[0].CacheControl; got == nil || got.TTL != "1h" {
+		t.Errorf("tool cache TTL: got %+v, want 1h", got)
+	}
+}
+
+func TestApplyPromptCache_OffLeavesPayloadUnchanged(t *testing.T) {
+	model := newAnthropicTestModel(t)
+	system := "system text"
+	messages := []sdk.Message{sdk.UserMessage("hi")}
+	tools := []sdk.Tool{{Name: "first"}, {Name: "second"}}
+
+	gotSystem, gotMessages, gotTools := ApplyPromptCache(
+		model,
+		PromptCacheTTLOff,
+		system,
+		messages,
+		tools,
+	)
+
+	if gotSystem != system {
+		t.Errorf("system: got %q, want %q", gotSystem, system)
+	}
+	if len(gotMessages) != len(messages) {
+		t.Errorf("messages length: got %d, want %d", len(gotMessages), len(messages))
+	}
+	for i, tool := range gotTools {
+		if tool.CacheControl != nil {
+			t.Errorf("tool %d should not be cached when ttl=off, got %+v", i, tool.CacheControl)
+		}
+	}
+}
+
+func TestApplyPromptCache_NonAnthropicNoop(t *testing.T) {
+	model := newOpenAITestModel(t)
+	system := "system text"
+	messages := []sdk.Message{sdk.UserMessage("hi")}
+	tools := []sdk.Tool{{Name: "only"}}
+
+	gotSystem, gotMessages, gotTools := ApplyPromptCache(model, "", system, messages, tools)
+	if gotSystem != system {
+		t.Errorf("system should be untouched for non-anthropic, got %q", gotSystem)
+	}
+	if len(gotMessages) != len(messages) {
+		t.Errorf("messages should be untouched for non-anthropic, len=%d", len(gotMessages))
+	}
+	if gotTools[0].CacheControl != nil {
+		t.Errorf("tool should not be cached for non-anthropic, got %+v", gotTools[0].CacheControl)
+	}
+}
+
+func TestApplyPromptCache_AnthropicEmptySystemSkipsPromotion(t *testing.T) {
+	model := newAnthropicTestModel(t)
+	messages := []sdk.Message{sdk.UserMessage("hi")}
+	gotSystem, gotMessages, _ := ApplyPromptCache(model, "", "", messages, nil)
+	if gotSystem != "" {
+		t.Errorf("system: got %q, want empty", gotSystem)
+	}
+	if len(gotMessages) != len(messages) {
+		t.Fatalf("messages length: got %d, want %d", len(gotMessages), len(messages))
+	}
+	if cc := textCacheControl(t, gotMessages[0]); cc != nil {
+		t.Errorf("user message should not be decorated, got %+v", cc)
+	}
+}
+
+func TestApplyPromptCache_AnthropicDoesNotMutateInput(t *testing.T) {
+	model := newAnthropicTestModel(t)
+	tools := []sdk.Tool{{Name: "first"}, {Name: "second"}}
+	messages := []sdk.Message{sdk.UserMessage("hi")}
+	_, _, _ = ApplyPromptCache(model, "", "system", messages, tools)
+	if tools[1].CacheControl != nil {
+		t.Errorf("source tool slice was mutated: %+v", tools[1].CacheControl)
+	}
+}


### PR DESCRIPTION
## Summary

Add a generic provider-level prompt cache TTL knob and wire it through every Anthropic call path. Defaults to 5m (recommended), with `1h` and `off` (not recommended) as alternatives. The public API is vendor-neutral so future providers can plug in without touching call sites.

## Changes

- **Generic cache helper** (`internal/models/prompt_cache.go`): `PromptCacheTTL5m / 1h / Off`, `NormalizePromptCacheTTL`, and `ApplyPromptCache(model, ttl, system, messages, tools)`. Dispatches by client type; today only Anthropic Messages decorates the payload (system prompt promoted to a SystemMessage with `cache_control`, `cache_control` set on the last tool). Other vendors are no-ops.
- **Threaded through all Anthropic-capable call sites**: main chat (`agent.RunConfig.PromptCacheTTL`), title generation, sync/async compaction (`compaction.TriggerConfig.PromptCacheTTL`), memory extract/decide/compact (`memllm.Config.PromptCacheTTL`), image-gen tool, and sub-agents (`SpawnRunConfig.PromptCacheTTL`).
- **Config key**: `provider.config.prompt_cache_ttl`. Missing/empty defaults to 5m, so existing Anthropic providers gain caching automatically.
- **Web UI**: provider edit form shows the TTL select only for client types in `PROMPT_CACHE_CLIENT_TYPES` (currently `anthropic-messages`); `off` carries a "not recommended" hint. New i18n namespace `provider.promptCache` (zh/en).
- **Twilight AI** bumped to `v0.3.4` for the per-block `cache_control` API.
- Drive-by: silence a pre-existing gosec G703 false positive in `internal/config/config_test.go`.

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `vue-tsc -p apps/web/tsconfig.app.json` (no new diagnostics)
- [x] New unit tests in `internal/models/prompt_cache_test.go` cover default 5m, 1h, off, non-Anthropic no-op, empty system, and input-mutation guard
- [ ] Manual: edit an Anthropic provider, switch between 5m / 1h / off, send a chat, verify `cache_read_tokens` / `cache_write_tokens` in usage stats