### PR TITLE
fix(kubernetes): harden workspace deployment defaults

### DIFF
--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: memoh
 resources:
   - namespace.yaml
   - rbac.yaml
+  - network-policy.yaml
   - config-secret.yaml
   - runtime-installer.yaml
   - postgres.yaml

--- a/deploy/kubernetes/network-policy.yaml
+++ b/deploy/kubernetes/network-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: memoh-workspace-bridge-ingress
+  namespace: memoh
+spec:
+  podSelector:
+    matchLabels:
+      memoh.workspace: v3
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: memoh-server
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/deploy/kubernetes/postgres.yaml
+++ b/deploy/kubernetes/postgres.yaml
@@ -27,10 +27,23 @@ spec:
       labels:
         app.kubernetes.io/name: memoh-postgres
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgres
           image: postgres:18-alpine
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           envFrom:
             - secretRef:
                 name: memoh-postgres

--- a/deploy/kubernetes/qdrant.yaml
+++ b/deploy/kubernetes/qdrant.yaml
@@ -30,10 +30,18 @@ spec:
       labels:
         app.kubernetes.io/name: memoh-qdrant
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: qdrant
           image: qdrant/qdrant:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 6333

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -9,6 +9,7 @@ kind: ServiceAccount
 metadata:
   name: memoh-workspace
   namespace: memoh
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -17,11 +18,17 @@ metadata:
   namespace: memoh
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "persistentvolumeclaims", "services"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "services"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/kubernetes/server.yaml
+++ b/deploy/kubernetes/server.yaml
@@ -38,11 +38,19 @@ spec:
         app.kubernetes.io/name: memoh-server
     spec:
       serviceAccountName: memoh-server
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: migrate
           image: memohai/server:latest
           imagePullPolicy: IfNotPresent
           command: ["/app/memoh-server", "migrate", "up"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: config
               mountPath: /app/config.toml
@@ -53,6 +61,10 @@ spec:
           image: memohai/server:latest
           imagePullPolicy: IfNotPresent
           command: ["/app/memoh-server", "serve"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/web.yaml
+++ b/deploy/kubernetes/web.yaml
@@ -26,16 +26,43 @@ spec:
       labels:
         app.kubernetes.io/name: memoh-web
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: web
           image: memohai/web:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 8082
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /health
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,20 +120,20 @@ type LocalConfig struct {
 
 func (c LocalConfig) WorkspaceParent() string {
 	if strings.TrimSpace(c.DefaultWorkspaceParent) != "" {
-		return expandHome(strings.TrimSpace(c.DefaultWorkspaceParent))
+		return absPath(expandHome(strings.TrimSpace(c.DefaultWorkspaceParent)))
 	}
-	return filepath.Join(homeDirOrDot(), ".memoh", "workspaces")
+	return absPath(filepath.Join(homeDirOrDot(), ".memoh", "workspaces"))
 }
 
 func (c LocalConfig) MetadataPath(dataRoot string) string {
 	if strings.TrimSpace(c.MetadataRoot) != "" {
-		return expandHome(strings.TrimSpace(c.MetadataRoot))
+		return absPath(expandHome(strings.TrimSpace(c.MetadataRoot)))
 	}
 	root := strings.TrimSpace(dataRoot)
 	if root == "" {
 		root = DefaultDataRoot
 	}
-	return filepath.Join(root, "local", "containers")
+	return filepath.Join(absPath(root), "local", "containers")
 }
 
 type KubernetesConfig struct {
@@ -195,10 +195,17 @@ func (c WorkspaceConfig) ImageRef() string {
 
 // RuntimePath returns the path to the workspace runtime directory.
 func (c WorkspaceConfig) RuntimePath() string {
-	if c.RuntimeDir != "" {
-		return c.RuntimeDir
+	if strings.TrimSpace(c.RuntimeDir) != "" {
+		return absPath(c.RuntimeDir)
 	}
 	return DefaultRuntimeDir
+}
+
+func (c WorkspaceConfig) DataRootPath() string {
+	if strings.TrimSpace(c.DataRoot) != "" {
+		return absPath(c.DataRoot)
+	}
+	return absPath(DefaultDataRoot)
 }
 
 func (c WorkspaceConfig) EffectiveImagePullPolicy() string {
@@ -222,6 +229,21 @@ func expandHome(path string) string {
 		return filepath.Join(homeDirOrDot(), path[2:])
 	}
 	return path
+}
+
+func absPath(path string) string {
+	path = strings.TrimSpace(expandHome(path))
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return abs
 }
 
 func homeDirOrDot() string {
@@ -260,6 +282,13 @@ type SQLiteConfig struct {
 	BusyTimeoutMS int    `toml:"busy_timeout_ms"`
 }
 
+func (c SQLiteConfig) PathOrDefault() string {
+	if path := strings.TrimSpace(c.Path); path != "" {
+		return absPath(path)
+	}
+	return absPath(DefaultSQLitePath)
+}
+
 type QdrantConfig struct {
 	BaseURL        string `toml:"base_url"`
 	APIKey         string `toml:"api_key" json:"-"`
@@ -279,9 +308,9 @@ type RegistryConfig struct {
 // ProvidersPath returns the configured providers directory or the default.
 func (c RegistryConfig) ProvidersPath() string {
 	if c.ProvidersDir != "" {
-		return c.ProvidersDir
+		return absPath(c.ProvidersDir)
 	}
-	return DefaultProvidersDir
+	return absPath(DefaultProvidersDir)
 }
 
 const DefaultSupermarketBaseURL = "https://supermarket.memoh.ai"
@@ -360,6 +389,7 @@ func Load(path string) (Config, error) {
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
+			cfg.resolvePaths()
 			return cfg, nil
 		}
 		return cfg, err
@@ -397,8 +427,24 @@ func Load(path string) (Config, error) {
 	} else {
 		cfg.Workspace = cfg.Container.WorkspaceConfig
 	}
+	cfg.resolvePaths()
 
 	return cfg, nil
+}
+
+func (cfg *Config) resolvePaths() {
+	cfg.Container.DataRoot = cfg.Container.DataRootPath()
+	cfg.Container.RuntimeDir = cfg.Container.RuntimePath()
+	cfg.Workspace = cfg.Container.WorkspaceConfig
+	if strings.TrimSpace(cfg.Local.MetadataRoot) != "" {
+		cfg.Local.MetadataRoot = cfg.Local.MetadataPath(cfg.Workspace.DataRoot)
+	}
+	if strings.TrimSpace(cfg.SQLite.DSN) == "" {
+		cfg.SQLite.Path = cfg.SQLite.PathOrDefault()
+	}
+	if strings.TrimSpace(cfg.Registry.ProvidersDir) != "" {
+		cfg.Registry.ProvidersDir = cfg.Registry.ProvidersPath()
+	}
 }
 
 func containerHasWorkspaceFields(values map[string]any) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -174,6 +174,60 @@ func TestLoadAppLocalTemplate(t *testing.T) {
 	if cfg.Database.DriverOrDefault() != "sqlite" {
 		t.Fatalf("database driver = %q, want sqlite", cfg.Database.DriverOrDefault())
 	}
+	if !filepath.IsAbs(cfg.Workspace.DataRoot) {
+		t.Fatalf("workspace data_root = %q, want absolute path", cfg.Workspace.DataRoot)
+	}
+	if !filepath.IsAbs(cfg.Workspace.RuntimeDir) {
+		t.Fatalf("workspace runtime_dir = %q, want absolute path", cfg.Workspace.RuntimeDir)
+	}
+	if !filepath.IsAbs(cfg.SQLite.Path) {
+		t.Fatalf("sqlite path = %q, want absolute path", cfg.SQLite.Path)
+	}
+	if !filepath.IsAbs(cfg.Registry.ProvidersPath()) {
+		t.Fatalf("providers path = %q, want absolute path", cfg.Registry.ProvidersPath())
+	}
+}
+
+func TestLoadResolvesRelativeLocalPaths(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	data := []byte(`
+[database]
+driver = "sqlite"
+
+[container]
+data_root = "data/local"
+runtime_dir = "data/runtime"
+
+[local]
+metadata_root = "data/local/containers"
+
+[sqlite]
+path = "data/local/memoh.db"
+
+[registry]
+providers_dir = "conf/providers"
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	for name, path := range map[string]string{
+		"data_root":     cfg.Workspace.DataRoot,
+		"runtime_dir":   cfg.Workspace.RuntimeDir,
+		"metadata_root": cfg.Local.MetadataRoot,
+		"sqlite.path":   cfg.SQLite.Path,
+		"providers_dir": cfg.Registry.ProvidersPath(),
+	} {
+		if !filepath.IsAbs(path) {
+			t.Fatalf("%s = %q, want absolute path", name, path)
+		}
+	}
 }
 
 func TestWorkspaceImagePullPolicyDefaultsAndNormalizes(t *testing.T) {

--- a/internal/container/k8s/service.go
+++ b/internal/container/k8s/service.go
@@ -35,6 +35,7 @@ import (
 const (
 	runtimeName          = "kubernetes"
 	workspaceContainer   = "workspace"
+	workspaceServiceAcct = "memoh-workspace"
 	dataVolumeName       = "workspace-data"
 	dataMountPath        = "/data"
 	defaultWorkspacePref = "workspace-"
@@ -662,6 +663,13 @@ func (s *Service) namespace() string { return s.cfg.Kubernetes.EffectiveNamespac
 
 func (s *Service) bridgePort() int { return s.cfg.Kubernetes.EffectiveBridgePort() }
 
+func (s *Service) workspaceServiceAccountName() string {
+	if name := strings.TrimSpace(s.cfg.Kubernetes.ServiceAccountName); name != "" {
+		return name
+	}
+	return workspaceServiceAcct
+}
+
 func (s *Service) ensurePVC(ctx context.Context, namespace, name string, req containerapi.CreateContainerRequest) error {
 	if existing, err := s.client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
 		if existing.Annotations == nil {
@@ -729,12 +737,27 @@ func (s *Service) ensurePod(ctx context.Context, namespace, pvcName string, req 
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:                 corev1.RestartPolicyAlways,
-			ServiceAccountName:            strings.TrimSpace(s.cfg.Kubernetes.ServiceAccountName),
-			ImagePullSecrets:              imagePullSecrets(s.cfg.Kubernetes.ImagePullSecret),
-			DNSPolicy:                     corev1.DNSClusterFirst,
-			Volumes:                       []corev1.Volume{{Name: dataVolumeName, VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName}}}},
-			Containers:                    []corev1.Container{{Name: workspaceContainer, Image: req.ImageRef, ImagePullPolicy: imagePullPolicy(req.ImagePullPolicy), Command: req.Spec.Cmd, Env: env, WorkingDir: req.Spec.WorkDir, TTY: req.Spec.TTY, VolumeMounts: []corev1.VolumeMount{{Name: dataVolumeName, MountPath: dataMountPath}}, Ports: []corev1.ContainerPort{{Name: "bridge", ContainerPort: int32(s.bridgePort())}}}}, //nolint:gosec // bridge_port is validated as an operator-controlled small TCP port.
+			RestartPolicy:                corev1.RestartPolicyAlways,
+			ServiceAccountName:           s.workspaceServiceAccountName(),
+			AutomountServiceAccountToken: boolPtr(false),
+			ImagePullSecrets:             imagePullSecrets(s.cfg.Kubernetes.ImagePullSecret),
+			DNSPolicy:                    corev1.DNSClusterFirst,
+			SecurityContext:              workspacePodSecurityContext(),
+			Volumes: []corev1.Volume{
+				{Name: dataVolumeName, VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName}}},
+			},
+			Containers: []corev1.Container{{
+				Name:            workspaceContainer,
+				Image:           req.ImageRef,
+				ImagePullPolicy: imagePullPolicy(req.ImagePullPolicy),
+				Command:         req.Spec.Cmd,
+				Env:             env,
+				WorkingDir:      req.Spec.WorkDir,
+				TTY:             req.Spec.TTY,
+				SecurityContext: workspaceContainerSecurityContext(),
+				VolumeMounts:    []corev1.VolumeMount{{Name: dataVolumeName, MountPath: dataMountPath}},
+				Ports:           []corev1.ContainerPort{{Name: "bridge", ContainerPort: int32(s.bridgePort())}}, //nolint:gosec // bridge_port is validated as an operator-controlled small TCP port.
+			}},
 			TerminationGracePeriodSeconds: int64Ptr(10),
 		},
 	}
@@ -1083,6 +1106,21 @@ func addSpecMounts(pod *corev1.Pod, mounts []containerapi.MountSpec) {
 	}
 }
 
+func workspacePodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}
+
+func workspaceContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}
+
 func imagePullSecrets(name string) []corev1.LocalObjectReference {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -1138,6 +1176,8 @@ func mapK8sMetricsErr(err error) error {
 }
 
 func stringPtr(v string) *string { return &v }
+
+func boolPtr(v bool) *bool { return &v }
 
 func int64Ptr(v int64) *int64 { return &v }
 

--- a/internal/container/k8s/service_test.go
+++ b/internal/container/k8s/service_test.go
@@ -70,6 +70,22 @@ func TestCreateContainerCreatesPVCAndPod(t *testing.T) {
 	if got := pod.Spec.Containers[0].ImagePullPolicy; got != corev1.PullIfNotPresent {
 		t.Fatalf("ImagePullPolicy = %q, want %q", got, corev1.PullIfNotPresent)
 	}
+	if got := pod.Spec.ServiceAccountName; got != workspaceServiceAcct {
+		t.Fatalf("ServiceAccountName = %q, want %q", got, workspaceServiceAcct)
+	}
+	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
+		t.Fatalf("AutomountServiceAccountToken = %v, want false", pod.Spec.AutomountServiceAccountToken)
+	}
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.SeccompProfile == nil || pod.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("pod seccomp profile = %#v, want RuntimeDefault", pod.Spec.SecurityContext)
+	}
+	securityContext := pod.Spec.Containers[0].SecurityContext
+	if securityContext == nil || securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation {
+		t.Fatalf("AllowPrivilegeEscalation = %#v, want false", securityContext)
+	}
+	if securityContext.Capabilities == nil || len(securityContext.Capabilities.Drop) != 1 || securityContext.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("capabilities drop = %#v, want ALL", securityContext.Capabilities)
+	}
 }
 
 func TestCreateContainerMapsImagePullPolicy(t *testing.T) {

--- a/internal/db/target.go
+++ b/internal/db/target.go
@@ -39,11 +39,7 @@ func SQLiteDSN(cfg config.SQLiteConfig) string {
 	if dsn := strings.TrimSpace(cfg.DSN); dsn != "" {
 		return dsn
 	}
-	path := strings.TrimSpace(cfg.Path)
-	if path == "" {
-		path = config.DefaultSQLitePath
-	}
-	path = filepath.Clean(path)
+	path := filepath.Clean(cfg.PathOrDefault())
 	query := url.Values{}
 	if cfg.WAL {
 		query.Set("_journal_mode", "WAL")


### PR DESCRIPTION
## Summary
- Use the intended `memoh-workspace` ServiceAccount for Kubernetes workspace pods when no explicit override is configured, and disable automatic token mounting for workspace pods.
- Harden the starter Kubernetes manifests with least-privilege RBAC, pod/container security contexts, writable nginx scratch volumes, and a workspace bridge ingress NetworkPolicy.
- Resolve local workspace, runtime, provider, and SQLite paths to absolute paths so bare-metal SQLite runs build stable DSNs from config defaults and relative paths.

## Test plan
- [x] `go test ./internal/config ./internal/container/k8s ./internal/db`
- [x] Pre-commit Go lint and full Go test hooks

## Split-out work
- Runtime image injection/publishing, Docker/containerd runtime delivery, display tunnel changes, CI image publishing, and `workspace/runtime` assets were moved out of this PR and preserved locally on `feat/workspace-runtime-image-full`.