### PR TITLE
fix: normalize weixin QR scanned status typos

### DIFF
--- a/apps/web/src/pages/bots/components/weixin-qr-login.vue
+++ b/apps/web/src/pages/bots/components/weixin-qr-login.vue
@@ -52,7 +52,7 @@
 
         <!-- Overlay for scanned state -->
         <div
-          v-if="pollStatus === 'scaned'"
+          v-if="pollStatus === 'scanned'"
           class="absolute inset-0 flex items-center justify-center rounded-lg bg-background/80"
         >
           <div class="text-center">
@@ -162,7 +162,7 @@ const statusText = computed(() => {
   switch (pollStatus.value) {
     case 'wait':
       return t('bots.channels.weixinQr.waitingScan')
-    case 'scaned':
+    case 'scanned':
       return t('bots.channels.weixinQr.scanned')
     case 'expired':
       return t('bots.channels.weixinQr.expired')
@@ -251,7 +251,7 @@ async function pollOnce() {
       case 'expired':
         return
       case 'wait':
-      case 'scaned':
+      case 'scanned':
         if (!aborted) {
           pollTimer = setTimeout(pollOnce, 1500)
         }

--- a/internal/channel/adapters/weixin/client.go
+++ b/internal/channel/adapters/weixin/client.go
@@ -263,5 +263,8 @@ func (c *Client) PollQRStatus(ctx context.Context, apiBaseURL, qrcode string) (*
 	if err := json.Unmarshal(raw, &status); err != nil {
 		return nil, fmt.Errorf("weixin qrstatus decode: %w", err)
 	}
+	if status.Status == "scaned" {
+		status.Status = "scanned"
+	}
 	return &status, nil
 }

--- a/internal/channel/adapters/weixin/client_test.go
+++ b/internal/channel/adapters/weixin/client_test.go
@@ -1,0 +1,37 @@
+package weixin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPollQRStatusNormalizesLegacyScannedStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/ilink/bot/get_qrcode_status" {
+			t.Fatalf("path = %q, want %q", got, "/ilink/bot/get_qrcode_status")
+		}
+		if got := r.URL.Query().Get("qrcode"); got != "legacy-code" {
+			t.Fatalf("qrcode = %q, want %q", got, "legacy-code")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"scaned","bot_token":"bot-token"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(slog.Default())
+	status, err := client.PollQRStatus(context.Background(), server.URL, "legacy-code")
+	if err != nil {
+		t.Fatalf("PollQRStatus() error = %v", err)
+	}
+	if status.Status != "scanned" {
+		t.Fatalf("status = %q, want %q", status.Status, "scanned")
+	}
+	if status.BotToken != "bot-token" {
+		t.Fatalf("botToken = %q, want %q", status.BotToken, "bot-token")
+	}
+}

--- a/internal/channel/adapters/weixin/qr_handler.go
+++ b/internal/channel/adapters/weixin/qr_handler.go
@@ -77,7 +77,7 @@ type QRPollRequest struct {
 
 // QRPollResponse returns the poll result.
 type QRPollResponse struct {
-	Status  string `json:"status"` // wait, scaned, confirmed, expired
+	Status  string `json:"status"` // wait, scanned, confirmed, expired
 	Message string `json:"message"`
 }
 
@@ -159,7 +159,7 @@ func statusMessage(s string) string {
 	switch s {
 	case "wait":
 		return "Waiting for scan..."
-	case "scaned":
+	case "scanned":
 		return "Scanned — confirm on your phone"
 	case "confirmed":
 		return "Login successful"

--- a/internal/channel/adapters/weixin/types.go
+++ b/internal/channel/adapters/weixin/types.go
@@ -210,7 +210,7 @@ type QRCodeResponse struct {
 
 // QRStatusResponse from get_qrcode_status.
 type QRStatusResponse struct {
-	Status      string `json:"status"` // wait, scaned, confirmed, expired
+	Status      string `json:"status"` // wait, scanned, confirmed, expired
 	BotToken    string `json:"bot_token,omitempty"`
 	ILinkBotID  string `json:"ilink_bot_id,omitempty"`
 	BaseURL     string `json:"baseurl,omitempty"`

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -633,7 +633,7 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 					Sender:  sender,
 					Ident:   identity,
 					Text:    text,
-					Attachs: attachments,
+					Attachments: attachments,
 				})
 				p.sendModeConfirmation(ctx, sender, msg, identity, "queue")
 				return nil

--- a/internal/channel/inbound/dispatcher.go
+++ b/internal/channel/inbound/dispatcher.go
@@ -41,7 +41,7 @@ type QueuedTask struct {
 	Sender  channel.StreamReplySender
 	Ident   InboundIdentity
 	Text    string
-	Attachs []conversation.ChatAttachment
+	Attachments []conversation.ChatAttachment
 }
 
 // PersistFunc is a deferred persistence closure called after the active stream


### PR DESCRIPTION
## Summary
- normalize legacy `scaned` QR status responses to `scanned`
- align Weixin QR UI and handler/type comments on `scanned`
- rename queued inbound attachment field from `Attachs` to `Attachments`
- add a compatibility unit test for legacy `scaned` responses

## Testing
- `go test ./internal/channel/adapters/weixin/...`

## Related
- Fixes #432