### PR TITLE
feat: Improve WebUI stream error handling

### DIFF
--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -164,7 +164,13 @@ export interface UIAttachmentsMessage {
   attachments: UIAttachment[]
 }
 
-export type UIMessage = UITextMessage | UIReasoningMessage | UIToolMessage | UIAttachmentsMessage
+export interface UIErrorMessage {
+  id: number
+  type: 'error'
+  content: string
+}
+
+export type UIMessage = UITextMessage | UIReasoningMessage | UIToolMessage | UIAttachmentsMessage | UIErrorMessage
 
 export interface UIUserTurn {
   role: 'user'

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -159,6 +159,7 @@
     "readonlyHint": "This chat is read-only",
     "readonlyPlaceholder": "This chat is read-only. Sending messages is disabled.",
     "send": "Send",
+    "sendFailed": "Message failed to send",
     "startChat": "Start Chat",
     "noBot": "No bots available, please create a bot first",
     "newChat": "New Chat",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -155,6 +155,7 @@
     "readonlyHint": "该聊天为只读",
     "readonlyPlaceholder": "该聊天为只读，无法发送消息",
     "send": "发送",
+    "sendFailed": "消息发送失败",
     "startChat": "开始聊天",
     "noBot": "暂无可用 Bot，请先创建 Bot",
     "newChat": "开启新对话",

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -119,6 +119,13 @@
             @change="handleFileInputChange"
           >
           <section>
+            <div
+              v-if="composerError"
+              class="mb-2 flex items-start gap-2 rounded-md border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            >
+              <CircleAlert class="mt-0.5 size-3.5 shrink-0" />
+              <span class="min-w-0 break-words">{{ composerError }}</span>
+            </div>
             <InputGroup class="bg-transparent overflow-hidden shadow-none! ring-0! border-border!">
               <InputGroupTextarea
                 v-model="inputText"
@@ -246,7 +253,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, useTemplateRef, watchEffect, watch, nextTick } from 'vue'
-import { LoaderCircle, Image as ImageIcon, File as FileIcon, X, Paperclip, Send, ChevronDown, Lightbulb } from 'lucide-vue-next'
+import { LoaderCircle, Image as ImageIcon, File as FileIcon, X, Paperclip, Send, ChevronDown, Lightbulb, CircleAlert } from 'lucide-vue-next'
 import { ScrollArea, Button, InputGroup, InputGroupAddon, InputGroupTextarea, Popover, PopoverContent, PopoverTrigger } from '@memohai/ui'
 import { useChatStore } from '@/store/chat-list'
 import { storeToRefs } from 'pinia'
@@ -276,6 +283,7 @@ const { t } = useI18n()
 const chatStore = useChatStore()
 const fileInput = ref<HTMLInputElement | null>(null)
 const pendingFiles = ref<File[]>([])
+const composerError = ref('')
 const modelPopoverOpen = ref(false)
 const reasoningPopoverOpen = ref(false)
 const inputDrafts = useStorage<Record<string, string>>('chat-input-drafts', {})
@@ -612,15 +620,28 @@ async function handleSend() {
   if ((!text && !files.length) || streaming.value || activeChatReadOnly.value) return
 
   const sentDraftKey = inputDraftKey.value
+  composerError.value = ''
   inputText.value = ''
   saveInputDraft(sentDraftKey, '')
   pendingFiles.value = []
 
   let attachments: ChatAttachment[] | undefined
-  if (files.length) {
-    attachments = await Promise.all(files.map(fileToAttachment))
+  try {
+    if (files.length) {
+      attachments = await Promise.all(files.map(fileToAttachment))
+    }
+  } catch (error) {
+    inputText.value = text
+    pendingFiles.value = files
+    composerError.value = error instanceof Error ? error.message : t('chat.sendFailed')
+    return
   }
 
-  chatStore.sendMessage(text, attachments)
+  const result = await chatStore.sendMessage(text, attachments)
+  if (!result.ok && result.stage === 'startup') {
+    inputText.value = result.restoreInput ?? text
+    pendingFiles.value = files
+    composerError.value = result.error || t('chat.sendFailed')
+  }
 }
 </script>

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -223,6 +223,15 @@
             />
           </div>
 
+          <!-- Error block -->
+          <div
+            v-else-if="block.type === 'error' && block.content"
+            class="flex items-start gap-2 rounded-md border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+          >
+            <CircleAlert class="mt-0.5 size-3.5 shrink-0" />
+            <span class="min-w-0 whitespace-pre-wrap break-words">{{ block.content }}</span>
+          </div>
+
           <!-- Attachment block -->
           <AttachmentBlock
             v-else-if="block.type === 'attachments'"
@@ -254,7 +263,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { LoaderCircle } from 'lucide-vue-next'
+import { CircleAlert, LoaderCircle } from 'lucide-vue-next'
 import { formatRelativeTime, formatDateTime } from '@/utils/date-time'
 import { Avatar, AvatarImage, AvatarFallback } from '@memohai/ui'
 import MarkdownRender, { enableKatex, enableMermaid } from 'markstream-vue'

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -15,6 +15,7 @@ import {
   type ChatWebSocket,
   type UIAttachment,
   type UIAttachmentsMessage,
+  type UIErrorMessage,
   type UIBackgroundTask,
   type UIMessage,
   type UIReasoningMessage,
@@ -36,6 +37,7 @@ export type TextBlock = UITextMessage
 export type ThinkingBlock = UIReasoningMessage
 export type AttachmentItem = UIAttachment
 export type AttachmentBlock = UIAttachmentsMessage
+export type ErrorBlock = UIErrorMessage
 
 export interface ToolCallBlock extends UIToolMessage {
   toolCallId: string
@@ -46,7 +48,7 @@ export interface ToolCallBlock extends UIToolMessage {
   backgroundTask?: BackgroundTask
 }
 
-export type ContentBlock = TextBlock | ThinkingBlock | ToolCallBlock | AttachmentBlock
+export type ContentBlock = TextBlock | ThinkingBlock | ToolCallBlock | AttachmentBlock | ErrorBlock
 
 export interface ChatUserTurn {
   id: string
@@ -106,6 +108,27 @@ interface PendingAssistantStream {
   done: boolean
   resolve: () => void
   reject: (err: Error) => void
+  streamError?: StreamFailureError
+}
+
+export type SendMessageStage = 'startup' | 'stream'
+
+export interface SendMessageResult {
+  ok: boolean
+  stage?: SendMessageStage
+  error?: string
+  restoreInput?: string
+  restoreAttachments?: ChatAttachment[]
+}
+
+class StreamFailureError extends Error {
+  stage: SendMessageStage
+
+  constructor(message: string, stage: SendMessageStage) {
+    super(message)
+    this.name = 'StreamFailureError'
+    this.stage = stage
+  }
 }
 
 interface SessionMessageState {
@@ -156,6 +179,7 @@ export const useChatStore = defineStore('chat', () => {
   // Switching tabs saves/restores from here; the active session remains the
   // only live `messages` array rendered by ChatPane.
   const sessionMessageStates = new Map<string, SessionMessageState>()
+  const ephemeralAssistantErrors = new Map<string, string[]>()
   const messageEventsStream = useRetryingStream()
 
   const activeSession = computed(() =>
@@ -379,6 +403,8 @@ export const useChatStore = defineStore('chat', () => {
           ...msg,
           attachments: msg.attachments.map(normalizeAttachment),
         }
+      case 'error':
+        return { ...msg }
       default:
         return { ...msg }
     }
@@ -468,9 +494,29 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function normalizeTurns(items: UITurn[]): ChatMessage[] {
+  function appendEphemeralErrors(items: ChatMessage[], targetSessionId?: string) {
+    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
+    if (!sid) return
+    const errors = ephemeralAssistantErrors.get(sid)
+    if (!errors?.length) return
+    const assistantTurn = [...items].reverse().find((item): item is ChatAssistantTurn => item.role === 'assistant')
+    if (!assistantTurn) return
+    for (const error of errors) {
+      const text = error.trim()
+      if (!text) continue
+      if (assistantTurn.messages.some(block => block.type === 'error' && block.content === text)) continue
+      assistantTurn.messages.push({
+        id: nextAssistantMessageId(assistantTurn),
+        type: 'error',
+        content: text,
+      })
+    }
+  }
+
+  function normalizeTurns(items: UITurn[], targetSessionId?: string): ChatMessage[] {
     const normalized = items.map(normalizeTurn)
     reconcileBackgroundTasksInMessages(normalized)
+    appendEphemeralErrors(normalized, targetSessionId)
     return normalized
   }
 
@@ -479,8 +525,8 @@ export const useChatStore = defineStore('chat', () => {
     updateSinceFromMessages(items)
   }
 
-  function replaceMessages(items: UITurn[]) {
-    setMessages(normalizeTurns(items))
+  function replaceMessages(items: UITurn[], targetSessionId?: string) {
+    setMessages(normalizeTurns(items, targetSessionId))
   }
 
   function sessionMessageKey(botId?: string | null, sid?: string | null): string {
@@ -571,6 +617,10 @@ export const useChatStore = defineStore('chat', () => {
     session.assistantTurn.streaming = false
     session.done = true
     pendingAssistantStream = null
+    if (session.streamError) {
+      session.reject(session.streamError)
+      return
+    }
     session.resolve()
   }
 
@@ -603,25 +653,28 @@ export const useChatStore = defineStore('chat', () => {
     return turn.messages.reduce((maxId, message) => Math.max(maxId, message.id), -1) + 1
   }
 
+  function hasVisibleAssistantBlocks(turn: ChatAssistantTurn): boolean {
+    return turn.messages.some(block => block.type !== 'error')
+  }
+
+  function rememberAssistantError(errorMessage: string) {
+    const sid = (streamingSessionId.value ?? sessionId.value ?? '').trim()
+    const text = errorMessage.trim()
+    if (!sid || !text) return
+    const current = ephemeralAssistantErrors.get(sid) ?? []
+    if (current.includes(text)) return
+    ephemeralAssistantErrors.set(sid, [...current, text].slice(-5))
+  }
+
   function appendAssistantError(session: PendingAssistantStream, errorMessage: string) {
     const text = errorMessage.trim()
     if (!text) return
 
-    for (let index = session.assistantTurn.messages.length - 1; index >= 0; index -= 1) {
-      const current = session.assistantTurn.messages[index]
-      if (current?.type === 'text') {
-        session.assistantTurn.messages[index] = {
-          ...current,
-          content: `${current.content}\n\n**Error:** ${text}`.trim(),
-        }
-        return
-      }
-    }
-
+    rememberAssistantError(text)
     session.assistantTurn.messages.push({
       id: nextAssistantMessageId(session.assistantTurn),
-      type: 'text',
-      content: `**Error:** ${text}`,
+      type: 'error',
+      content: text,
     })
   }
 
@@ -657,11 +710,22 @@ export const useChatStore = defineStore('chat', () => {
         break
       case 'error': {
         const session = ensureDiscussStream()
-        appendAssistantError(session, event.message || 'stream error')
-        rejectPendingAssistantStream(new Error(event.message || 'stream error'))
-        streamingSessionId.value = null
+        const message = event.message || 'stream error'
+        const stage: SendMessageStage = hasVisibleAssistantBlocks(session.assistantTurn) ? 'stream' : 'startup'
+        if (stage === 'stream') {
+          appendAssistantError(session, message)
+          session.assistantTurn.streaming = false
+          session.streamError = new StreamFailureError(message, stage)
+        } else {
+          const idx = messages.indexOf(session.assistantTurn)
+          if (idx >= 0) messages.splice(idx, 1)
+          rejectPendingAssistantStream(new StreamFailureError(message, stage))
+        }
         loading.value = false
-        abortFn = null
+        if (stage === 'startup') {
+          streamingSessionId.value = null
+          abortFn = null
+        }
         break
       }
     }
@@ -710,7 +774,7 @@ export const useChatStore = defineStore('chat', () => {
 
     const promise = (async () => {
       const turns = await fetchMessagesUI(bid, sid, { limit: PAGE_SIZE })
-      const normalized = normalizeTurns(turns)
+      const normalized = normalizeTurns(turns, sid)
       const moreOlder = turns.length > 0
       if (currentBotId.value === bid && sessionId.value === sid) {
         setMessages(normalized)
@@ -1118,12 +1182,13 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function sendMessage(text: string, attachments?: ChatAttachment[]) {
+  async function sendMessage(text: string, attachments?: ChatAttachment[]): Promise<SendMessageResult> {
     const trimmed = text.trim()
-    if ((!trimmed && !attachments?.length) || streaming.value || !currentBotId.value) return
+    if ((!trimmed && !attachments?.length) || streaming.value || !currentBotId.value) return { ok: false, stage: 'startup' }
 
     loading.value = true
     let assistantTurn: ChatAssistantTurn | null = null
+    let userTurn: ChatUserTurn | null = null
 
     try {
       await ensureActiveSession()
@@ -1132,7 +1197,8 @@ export const useChatStore = defineStore('chat', () => {
       const sid = sessionId.value!
       streamingSessionId.value = sid
 
-      messages.push(createOptimisticUserTurn(trimmed, attachments))
+      userTurn = createOptimisticUserTurn(trimmed, attachments)
+      messages.push(userTurn)
       messages.push(createOptimisticAssistantTurn())
       assistantTurn = messages[messages.length - 1] as ChatAssistantTurn
 
@@ -1142,6 +1208,9 @@ export const useChatStore = defineStore('chat', () => {
 
       const ws = ensureWebSocket(bid)
       if (ws) {
+        if (!ws.connected) {
+          throw new StreamFailureError('WebSocket is not connected', 'startup')
+        }
         const completion = createCompletionForAssistantTurn(assistantTurn)
         abortFn = () => {
           const abortError = new Error('aborted')
@@ -1170,15 +1239,27 @@ export const useChatStore = defineStore('chat', () => {
       loading.value = false
       abortFn = null
       touchSession(sid)
+      return { ok: true }
     } catch (error) {
       const isAbort = error instanceof Error && error.name === 'AbortError'
       const reason = error instanceof Error ? error.message : 'Unknown error'
-      if (!isAbort && assistantTurn) {
-        assistantTurn.messages = [{
-          id: 0,
-          type: 'text',
-          content: `Failed to send message: ${reason}`,
-        }]
+      const stage: SendMessageStage = error instanceof StreamFailureError
+        ? error.stage
+        : (assistantTurn && hasVisibleAssistantBlocks(assistantTurn) ? 'stream' : 'startup')
+
+      if (!isAbort && stage === 'startup') {
+        if (assistantTurn) {
+          const idx = messages.indexOf(assistantTurn)
+          if (idx >= 0) messages.splice(idx, 1)
+        }
+        if (userTurn) {
+          const idx = messages.indexOf(userTurn)
+          if (idx >= 0) messages.splice(idx, 1)
+        }
+      } else if (!isAbort && assistantTurn && stage === 'stream') {
+        if (!assistantTurn.messages.some(block => block.type === 'error')) {
+          appendAssistantError({ assistantTurn, done: false, resolve: () => {}, reject: () => {} }, reason)
+        }
         assistantTurn.streaming = false
       } else if (!isAbort) {
         messages.push({
@@ -1186,8 +1267,8 @@ export const useChatStore = defineStore('chat', () => {
           role: 'assistant',
           messages: [{
             id: 0,
-            type: 'text',
-            content: `Failed to send message: ${reason}`,
+            type: 'error',
+            content: reason,
           }],
           timestamp: new Date().toISOString(),
           streaming: false,
@@ -1197,6 +1278,17 @@ export const useChatStore = defineStore('chat', () => {
       streamingSessionId.value = null
       loading.value = false
       abortFn = null
+      if (isAbort) return { ok: false, stage: 'stream', error: reason }
+      if (stage === 'startup') {
+        return {
+          ok: false,
+          stage,
+          error: reason,
+          restoreInput: text,
+          restoreAttachments: attachments,
+        }
+      }
+      return { ok: false, stage, error: reason }
     }
   }
 

--- a/internal/conversation/flow/resolver_stream.go
+++ b/internal/conversation/flow/resolver_stream.go
@@ -26,6 +26,27 @@ type terminalSnapshot struct {
 	approvalID  string
 }
 
+func isVisibleAgentStreamEvent(event agentpkg.StreamEvent) bool {
+	switch event.Type {
+	case agentpkg.EventTextStart,
+		agentpkg.EventTextDelta,
+		agentpkg.EventTextEnd,
+		agentpkg.EventReasoningStart,
+		agentpkg.EventReasoningDelta,
+		agentpkg.EventReasoningEnd,
+		agentpkg.EventToolCallStart,
+		agentpkg.EventToolCallProgress,
+		agentpkg.EventToolCallEnd,
+		agentpkg.EventToolApprovalRequest,
+		agentpkg.EventAttachment,
+		agentpkg.EventReaction,
+		agentpkg.EventSpeech:
+		return true
+	default:
+		return false
+	}
+}
+
 // extractTerminalSnapshot decodes a terminal stream event payload into the
 // raw SDK messages plus auxiliary metadata. Returns ok=false when the event
 // has no usable messages.
@@ -94,6 +115,7 @@ func (r *Resolver) StreamChat(ctx context.Context, req conversation.ChatRequest)
 		var lastSnapshot terminalSnapshot
 		var hasSnapshot bool
 		var toolCallCount int
+		var hasVisibleOutput bool
 		for event := range eventCh {
 			idleCancel.Reset() // each event resets the idle timer
 
@@ -110,6 +132,9 @@ func (r *Resolver) StreamChat(ctx context.Context, req conversation.ChatRequest)
 					slog.String("model_id", rc.model.ID),
 					slog.String("error", event.Error),
 				)
+			}
+			if isVisibleAgentStreamEvent(event) {
+				hasVisibleOutput = true
 			}
 
 			data, err := json.Marshal(event)
@@ -146,17 +171,22 @@ func (r *Resolver) StreamChat(ctx context.Context, req conversation.ChatRequest)
 			}
 		}
 
-		// Intermediate persistence on abort/error: if stream ended without
-		// storing results, persist whatever partial messages we managed to
-		// capture so the user can see what was accomplished and ask the bot
-		// to continue. Falls back to a synthetic placeholder only when no
-		// partial messages are available at all.
+		// Intermediate persistence on abort/error: if stream ended after
+		// visible output, persist whatever partial messages we managed to
+		// capture. Startup failures with no visible output are left out of
+		// history so the Web UI can restore the draft instead.
 		if !stored {
-			var partial []sdk.Message
-			if hasSnapshot {
-				partial = lastSnapshot.sdkMessages
+			switch {
+			case hasSnapshot:
+				r.persistPartialResult(ctx, streamReq, rc, lastSnapshot.sdkMessages, toolCallCount, idleCancel.DidFire(), hasVisibleOutput)
+			case hasVisibleOutput:
+				r.persistUserOnlyResult(context.WithoutCancel(ctx), streamReq, rc)
+			default:
+				r.logger.Info("skip persisting failed startup stream",
+					slog.String("bot_id", streamReq.BotID),
+					slog.String("chat_id", streamReq.ChatID),
+				)
 			}
-			r.persistPartialResult(ctx, streamReq, rc, partial, toolCallCount, idleCancel.DidFire())
 		}
 
 		if idleCancel.DidFire() {
@@ -235,6 +265,7 @@ func (r *Resolver) StreamChatWS(
 	var lastSnapshot terminalSnapshot
 	var hasSnapshot bool
 	var toolCallCount int
+	var hasVisibleOutput bool
 	for event := range agentEventCh {
 		idleCancel.Reset() // each event resets the idle timer
 
@@ -251,6 +282,9 @@ func (r *Resolver) StreamChatWS(
 				slog.String("model_id", modelID),
 				slog.String("error", event.Error),
 			)
+		}
+		if isVisibleAgentStreamEvent(event) {
+			hasVisibleOutput = true
 		}
 
 		data, err := json.Marshal(event)
@@ -283,11 +317,17 @@ func (r *Resolver) StreamChatWS(
 
 	// Intermediate persistence on abort/error
 	if !stored {
-		var partial []sdk.Message
-		if hasSnapshot {
-			partial = lastSnapshot.sdkMessages
+		switch {
+		case hasSnapshot:
+			r.persistPartialResult(ctx, req, rc, lastSnapshot.sdkMessages, toolCallCount, idleCancel.DidFire(), hasVisibleOutput)
+		case hasVisibleOutput:
+			r.persistUserOnlyResult(context.WithoutCancel(ctx), req, rc)
+		default:
+			r.logger.Info("skip persisting failed startup ws stream",
+				slog.String("bot_id", req.BotID),
+				slog.String("chat_id", req.ChatID),
+			)
 		}
-		r.persistPartialResult(ctx, req, rc, partial, toolCallCount, idleCancel.DidFire())
 	}
 
 	if idleCancel.DidFire() {
@@ -345,8 +385,9 @@ func (r *Resolver) persistTerminalSnapshot(ctx context.Context, req conversation
 // orphaned tool_calls get repaired with synthetic error tool_results, keeping
 // the conversation coherent for "ask the bot to continue".
 //
-// Only when no partial messages are available at all does it write a synthetic
-// placeholder so the user can see something happened.
+// When no partial messages are available, startup failures are not persisted;
+// streams that already produced visible output keep at most the user turn so
+// the Web UI can show its temporary error block without creating history noise.
 func (r *Resolver) persistPartialResult(
 	ctx context.Context,
 	req conversation.ChatRequest,
@@ -354,6 +395,7 @@ func (r *Resolver) persistPartialResult(
 	partialMessages []sdk.Message,
 	toolCallCount int,
 	wasIdleTimeout bool,
+	hasVisibleOutput bool,
 ) {
 	persistCtx := context.WithoutCancel(ctx)
 
@@ -380,31 +422,39 @@ func (r *Resolver) persistPartialResult(
 			}
 			return
 		}
-		r.logger.Error("failed to persist partial agent messages, falling back to placeholder",
+		r.logger.Error("failed to persist partial agent messages, falling back to user-only result",
 			slog.String("bot_id", req.BotID),
 			slog.Any("error", err),
 		)
 	}
 
-	reason := "provider error"
-	if wasIdleTimeout {
-		reason = "provider idle timeout"
-	}
-	syntheticMsg := fmt.Sprintf("[Agent interrupted after %d tool calls: %s. Partial results saved — ask the bot to continue.]", toolCallCount, reason)
-
-	roundMessages := prependUserMessage(req.Query, []conversation.ModelMessage{
-		{Role: "assistant", Content: conversation.NewTextContent(syntheticMsg)},
-	})
-
-	if err := r.storeRound(persistCtx, req, roundMessages, rc.model.ID); err != nil {
-		r.logger.Error("failed to persist partial result placeholder",
+	if hasVisibleOutput {
+		r.persistUserOnlyResult(persistCtx, req, rc)
+	} else {
+		r.logger.Info("skip persisting partial result without visible output",
 			slog.String("bot_id", req.BotID),
-			slog.Any("error", err),
+			slog.Int("tool_calls", toolCallCount),
+			slog.Bool("idle_timeout", wasIdleTimeout),
 		)
 	}
 
 	if rc.estimatedTokens > 0 {
 		r.maybeCompact(persistCtx, req, rc, rc.estimatedTokens)
+	}
+}
+
+func (r *Resolver) persistUserOnlyResult(ctx context.Context, req conversation.ChatRequest, rc resolvedContext) {
+	query := strings.TrimSpace(req.Query)
+	if query == "" {
+		return
+	}
+	if err := r.storeRound(ctx, req, []conversation.ModelMessage{
+		{Role: "user", Content: conversation.NewTextContent(query)},
+	}, rc.model.ID); err != nil {
+		r.logger.Error("failed to persist user-only interrupted stream",
+			slog.String("bot_id", req.BotID),
+			slog.Any("error", err),
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- distinguish startup failures from mid-stream failures in conversation streaming persistence
- preserve partial assistant/tool output for mid-stream errors while skipping user persistence for startup failures with no visible output
- render transient WebUI error blocks and restore composer input on startup failure

## Tests

- `pnpm --dir apps/web exec vue-tsc --noEmit`
- `pnpm exec vitest run apps/web/src/store/chat-list.utils.test.ts apps/web/src/composables/api/useChat.sse.test.ts apps/web/src/composables/api/useChat.ws.test.ts`
- `pnpm exec eslint apps/web/src/store/chat-list.ts apps/web/src/pages/home/components/chat-pane.vue apps/web/src/pages/home/components/message-item.vue apps/web/src/composables/api/useChat.types.ts`
- `go test ./internal/conversation/flow`
- pre-commit hook: Go lint, Go tests, staged frontend eslint