### PR TITLE
fix(workspace): normalize local docker paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,20 +120,20 @@ type LocalConfig struct {
 
 func (c LocalConfig) WorkspaceParent() string {
 	if strings.TrimSpace(c.DefaultWorkspaceParent) != "" {
-		return expandHome(strings.TrimSpace(c.DefaultWorkspaceParent))
+		return absPath(expandHome(strings.TrimSpace(c.DefaultWorkspaceParent)))
 	}
-	return filepath.Join(homeDirOrDot(), ".memoh", "workspaces")
+	return absPath(filepath.Join(homeDirOrDot(), ".memoh", "workspaces"))
 }
 
 func (c LocalConfig) MetadataPath(dataRoot string) string {
 	if strings.TrimSpace(c.MetadataRoot) != "" {
-		return expandHome(strings.TrimSpace(c.MetadataRoot))
+		return absPath(expandHome(strings.TrimSpace(c.MetadataRoot)))
 	}
 	root := strings.TrimSpace(dataRoot)
 	if root == "" {
 		root = DefaultDataRoot
 	}
-	return filepath.Join(root, "local", "containers")
+	return filepath.Join(absPath(root), "local", "containers")
 }
 
 type KubernetesConfig struct {
@@ -196,9 +196,16 @@ func (c WorkspaceConfig) ImageRef() string {
 // RuntimePath returns the path to the workspace runtime directory.
 func (c WorkspaceConfig) RuntimePath() string {
 	if c.RuntimeDir != "" {
-		return c.RuntimeDir
+		return absPath(c.RuntimeDir)
 	}
 	return DefaultRuntimeDir
+}
+
+func (c WorkspaceConfig) DataRootPath() string {
+	if strings.TrimSpace(c.DataRoot) != "" {
+		return absPath(c.DataRoot)
+	}
+	return absPath(DefaultDataRoot)
 }
 
 func (c WorkspaceConfig) EffectiveImagePullPolicy() string {
@@ -222,6 +229,18 @@ func expandHome(path string) string {
 		return filepath.Join(homeDirOrDot(), path[2:])
 	}
 	return path
+}
+
+func absPath(path string) string {
+	path = strings.TrimSpace(expandHome(path))
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return abs
 }
 
 func homeDirOrDot() string {
@@ -260,6 +279,13 @@ type SQLiteConfig struct {
 	BusyTimeoutMS int    `toml:"busy_timeout_ms"`
 }
 
+func (c SQLiteConfig) PathOrDefault() string {
+	if path := strings.TrimSpace(c.Path); path != "" {
+		return absPath(path)
+	}
+	return absPath(DefaultSQLitePath)
+}
+
 type QdrantConfig struct {
 	BaseURL        string `toml:"base_url"`
 	APIKey         string `toml:"api_key" json:"-"`
@@ -279,9 +305,9 @@ type RegistryConfig struct {
 // ProvidersPath returns the configured providers directory or the default.
 func (c RegistryConfig) ProvidersPath() string {
 	if c.ProvidersDir != "" {
-		return c.ProvidersDir
+		return absPath(c.ProvidersDir)
 	}
-	return DefaultProvidersDir
+	return absPath(DefaultProvidersDir)
 }
 
 const DefaultSupermarketBaseURL = "https://supermarket.memoh.ai"
@@ -360,6 +386,7 @@ func Load(path string) (Config, error) {
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
+			cfg.resolvePaths()
 			return cfg, nil
 		}
 		return cfg, err
@@ -397,8 +424,24 @@ func Load(path string) (Config, error) {
 	} else {
 		cfg.Workspace = cfg.Container.WorkspaceConfig
 	}
+	cfg.resolvePaths()
 
 	return cfg, nil
+}
+
+func (cfg *Config) resolvePaths() {
+	cfg.Container.DataRoot = cfg.Container.DataRootPath()
+	cfg.Container.RuntimeDir = cfg.Container.RuntimePath()
+	cfg.Workspace = cfg.Container.WorkspaceConfig
+	if strings.TrimSpace(cfg.Local.MetadataRoot) != "" {
+		cfg.Local.MetadataRoot = cfg.Local.MetadataPath(cfg.Workspace.DataRoot)
+	}
+	if strings.TrimSpace(cfg.SQLite.DSN) == "" {
+		cfg.SQLite.Path = cfg.SQLite.PathOrDefault()
+	}
+	if strings.TrimSpace(cfg.Registry.ProvidersDir) != "" {
+		cfg.Registry.ProvidersDir = cfg.Registry.ProvidersPath()
+	}
 }
 
 func containerHasWorkspaceFields(values map[string]any) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,10 +155,9 @@ func TestLoadAppLocalTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read app.local.toml: %v", err)
 	}
-	rendered := strings.ReplaceAll(string(raw), "__PROJECT_ROOT__", filepath.ToSlash(filepath.Join("..", "..")))
 	configPath := filepath.Join(t.TempDir(), "app.local.toml")
 	//nolint:gosec // configPath is rooted at t.TempDir() with a literal filename; the rendered template content is not used as a path.
-	if err := os.WriteFile(configPath, []byte(rendered), 0o600); err != nil {
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
 		t.Fatalf("write rendered app.local.toml: %v", err)
 	}
 	cfg, err := Load(configPath)
@@ -173,6 +172,60 @@ func TestLoadAppLocalTemplate(t *testing.T) {
 	}
 	if cfg.Database.DriverOrDefault() != "sqlite" {
 		t.Fatalf("database driver = %q, want sqlite", cfg.Database.DriverOrDefault())
+	}
+	if !filepath.IsAbs(cfg.Workspace.DataRoot) {
+		t.Fatalf("workspace data_root = %q, want absolute path", cfg.Workspace.DataRoot)
+	}
+	if !filepath.IsAbs(cfg.Workspace.RuntimeDir) {
+		t.Fatalf("workspace runtime_dir = %q, want absolute path", cfg.Workspace.RuntimeDir)
+	}
+	if !filepath.IsAbs(cfg.SQLite.Path) {
+		t.Fatalf("sqlite path = %q, want absolute path", cfg.SQLite.Path)
+	}
+	if !filepath.IsAbs(cfg.Registry.ProvidersPath()) {
+		t.Fatalf("providers path = %q, want absolute path", cfg.Registry.ProvidersPath())
+	}
+}
+
+func TestLoadResolvesRelativeLocalPaths(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	data := []byte(`
+[database]
+driver = "sqlite"
+
+[container]
+data_root = "data/local"
+runtime_dir = "data/runtime"
+
+[local]
+metadata_root = "data/local/containers"
+
+[sqlite]
+path = "data/local/memoh.db"
+
+[registry]
+providers_dir = "conf/providers"
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	for name, path := range map[string]string{
+		"data_root":     cfg.Workspace.DataRoot,
+		"runtime_dir":   cfg.Workspace.RuntimeDir,
+		"metadata_root": cfg.Local.MetadataRoot,
+		"sqlite.path":   cfg.SQLite.Path,
+		"providers_dir": cfg.Registry.ProvidersPath(),
+	} {
+		if !filepath.IsAbs(path) {
+			t.Fatalf("%s = %q, want absolute path", name, path)
+		}
 	}
 }
 

--- a/internal/db/target.go
+++ b/internal/db/target.go
@@ -39,11 +39,7 @@ func SQLiteDSN(cfg config.SQLiteConfig) string {
 	if dsn := strings.TrimSpace(cfg.DSN); dsn != "" {
 		return dsn
 	}
-	path := strings.TrimSpace(cfg.Path)
-	if path == "" {
-		path = config.DefaultSQLitePath
-	}
-	path = filepath.Clean(path)
+	path := filepath.Clean(cfg.PathOrDefault())
 	query := url.Values{}
 	if cfg.WAL {
 		query.Set("_journal_mode", "WAL")

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -596,10 +596,7 @@ func (m *Manager) Delete(ctx context.Context, botID string, preserveData bool) e
 }
 
 func (m *Manager) dataRoot() string {
-	if m.cfg.DataRoot == "" {
-		return config.DefaultDataRoot
-	}
-	return m.cfg.DataRoot
+	return m.cfg.DataRootPath()
 }
 
 func (m *Manager) imageRef() string {

--- a/mise.toml
+++ b/mise.toml
@@ -157,7 +157,15 @@ RUNTIME_DIR="${MEMOH_LOCAL_RUNTIME_DIR:-data/runtime}"
 PROJECT_ROOT="$(pwd)"
 
 mkdir -p data/local "$RUNTIME_DIR"
-go build -o "$RUNTIME_DIR/bridge" ./cmd/bridge
+DOCKER_OS="$(docker info 2>/dev/null | awk -F': ' '$1 == "OSType" || $1 == " OSType" { print $2; exit }')"
+DOCKER_ARCH="$(docker info 2>/dev/null | awk -F': ' '$1 == "Architecture" || $1 == " Architecture" { print $2; exit }')"
+DOCKER_OS="${DOCKER_OS:-$(go env GOHOSTOS)}"
+DOCKER_ARCH="${DOCKER_ARCH:-$(go env GOHOSTARCH)}"
+case "$DOCKER_ARCH" in
+  x86_64) DOCKER_ARCH="amd64" ;;
+  aarch64) DOCKER_ARCH="arm64" ;;
+esac
+CGO_ENABLED=0 GOOS="$DOCKER_OS" GOARCH="$DOCKER_ARCH" go build -o "$RUNTIME_DIR/bridge" ./cmd/bridge
 sed "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" "$TEMPLATE_CONFIG" > "$GENERATED_CONFIG"
 
 if [ -d ".toolkit" ]; then


### PR DESCRIPTION
## Summary
- Resolve local deployment paths to absolute paths before Docker uses them.
- Build the workspace bridge for the Docker engine OS/arch during `mise run local:dev`.
- Keep config templates relative while normalizing paths in code.

## Test plan
- `go test ./internal/config ./internal/db ./internal/container/docker ./internal/workspace`
- Verified local macOS bare-metal deployment with Docker backend and `/ping`.