### PR TITLE
fix: avoid duplicate provider registry entries

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -16,6 +16,8 @@ import (
 	dbstore "github.com/memohai/memoh/internal/db/store"
 )
 
+const registryMetadataKey = "registry"
+
 // Load reads all .yaml / .yml files from dir and returns parsed provider
 // definitions. It returns nil (no error) when the directory does not exist.
 // Malformed files are skipped with a warning logged via log.
@@ -51,29 +53,36 @@ func Load(log *slog.Logger, dir string) ([]ProviderDefinition, error) {
 		if def.Name == "" {
 			continue
 		}
+		def.Source = registrySource(e.Name())
 		defs = append(defs, def)
 	}
 	return defs, nil
 }
 
 // Sync upserts the given provider definitions into the database. New providers
-// are created with enable=false and an empty API key. Existing providers get
-// their icon and client_type refreshed. Models are upserted by (provider_id,
-// model_id), overwriting name/type/config.
+// are created with enable=false. Existing registry providers are matched by
+// source file, then name, then legacy model fingerprints, so changing a YAML
+// display name updates the existing provider instead of creating a duplicate.
+// Existing enable state, credentials, and custom config values are preserved.
+// Models are upserted by (provider_id, model_id), overwriting name/type/config.
 func Sync(ctx context.Context, logger *slog.Logger, queries dbstore.Queries, defs []ProviderDefinition) error {
+	existingProviders, err := listRegistryProviders(ctx, queries)
+	if err != nil {
+		return fmt.Errorf("list providers: %w", err)
+	}
+	providerIndex, err := newProviderIndex(ctx, queries, existingProviders)
+	if err != nil {
+		return fmt.Errorf("index providers: %w", err)
+	}
+	usedProviders := make(map[string]bool, len(defs))
+
 	for _, def := range defs {
 		var icon pgtype.Text
 		if def.Icon != "" {
 			icon = pgtype.Text{String: def.Icon, Valid: true}
 		}
 
-		providerCfg := make(map[string]any)
-		for k, v := range def.Config {
-			providerCfg[k] = v
-		}
-		if def.BaseURL != "" {
-			providerCfg["base_url"] = def.BaseURL
-		}
+		providerCfg := providerConfigFromDefinition(def)
 		providerConfigJSON, err := json.Marshal(providerCfg)
 		if err != nil {
 			logger.Warn("registry: failed to marshal provider config",
@@ -81,16 +90,13 @@ func Sync(ctx context.Context, logger *slog.Logger, queries dbstore.Queries, def
 			continue
 		}
 
-		provider, err := queries.UpsertRegistryProvider(ctx, sqlc.UpsertRegistryProviderParams{
-			Name:       def.Name,
-			ClientType: def.ClientType,
-			Icon:       icon,
-			Config:     providerConfigJSON,
-		})
+		provider, err := syncProvider(ctx, queries, providerIndex, usedProviders, def, icon, providerCfg, providerConfigJSON)
 		if err != nil {
 			logger.Warn("registry: failed to upsert provider", slog.String("name", def.Name), slog.Any("error", err))
 			continue
 		}
+		providerIndex.add(provider)
+		usedProviders[providerKey(provider)] = true
 
 		for _, m := range def.Models {
 			configJSON, err := json.Marshal(m.Config)
@@ -127,4 +133,294 @@ func Sync(ctx context.Context, logger *slog.Logger, queries dbstore.Queries, def
 		logger.Info("registry: synced provider", slog.String("name", def.Name), slog.Int("models", len(def.Models)))
 	}
 	return nil
+}
+
+type providerIndex struct {
+	bySource  map[string]sqlc.Provider
+	byName    map[string]sqlc.Provider
+	modelIDs  map[string]map[string]bool
+	providers []sqlc.Provider
+}
+
+func newProviderIndex(ctx context.Context, queries dbstore.Queries, providers []sqlc.Provider) (*providerIndex, error) {
+	idx := &providerIndex{
+		bySource:  make(map[string]sqlc.Provider, len(providers)),
+		byName:    make(map[string]sqlc.Provider, len(providers)),
+		modelIDs:  make(map[string]map[string]bool, len(providers)),
+		providers: make([]sqlc.Provider, 0, len(providers)),
+	}
+	for _, provider := range providers {
+		idx.add(provider)
+		models, err := queries.ListModelsByProviderID(ctx, provider.ID)
+		if err != nil {
+			return nil, err
+		}
+		modelIDs := make(map[string]bool, len(models))
+		for _, model := range models {
+			modelID := strings.TrimSpace(model.ModelID)
+			if modelID != "" {
+				modelIDs[modelID] = true
+			}
+		}
+		idx.modelIDs[providerKey(provider)] = modelIDs
+	}
+	return idx, nil
+}
+
+func (idx *providerIndex) add(provider sqlc.Provider) {
+	if idx == nil {
+		return
+	}
+	idx.providers = append(idx.providers, provider)
+	if name := strings.TrimSpace(provider.Name); name != "" {
+		idx.byName[name] = provider
+	}
+	if source := providerRegistrySource(provider); source != "" {
+		idx.bySource[source] = provider
+	}
+}
+
+func syncProvider(
+	ctx context.Context,
+	queries dbstore.Queries,
+	idx *providerIndex,
+	used map[string]bool,
+	def ProviderDefinition,
+	icon pgtype.Text,
+	registryCfg map[string]any,
+	registryConfigJSON []byte,
+) (sqlc.Provider, error) {
+	if existing, ok := matchExistingProvider(idx, used, def, registryCfg); ok {
+		configJSON, err := json.Marshal(mergeRegistryProviderConfig(registryCfg, parseJSONMap(existing.Config)))
+		if err != nil {
+			return sqlc.Provider{}, fmt.Errorf("marshal merged provider config: %w", err)
+		}
+		metadataJSON, err := json.Marshal(withRegistryMetadata(parseJSONMap(existing.Metadata), def.Source))
+		if err != nil {
+			return sqlc.Provider{}, fmt.Errorf("marshal provider metadata: %w", err)
+		}
+		return queries.UpdateProvider(ctx, sqlc.UpdateProviderParams{
+			ID:         existing.ID,
+			Name:       def.Name,
+			ClientType: def.ClientType,
+			Icon:       icon,
+			Enable:     existing.Enable,
+			Config:     configJSON,
+			Metadata:   metadataJSON,
+		})
+	}
+
+	created, err := queries.UpsertRegistryProvider(ctx, sqlc.UpsertRegistryProviderParams{
+		Name:       def.Name,
+		ClientType: def.ClientType,
+		Icon:       icon,
+		Config:     registryConfigJSON,
+	})
+	if err != nil {
+		return sqlc.Provider{}, err
+	}
+	metadataJSON, err := json.Marshal(withRegistryMetadata(parseJSONMap(created.Metadata), def.Source))
+	if err != nil {
+		return sqlc.Provider{}, fmt.Errorf("marshal provider metadata: %w", err)
+	}
+	return queries.UpdateProvider(ctx, sqlc.UpdateProviderParams{
+		ID:         created.ID,
+		Name:       created.Name,
+		ClientType: created.ClientType,
+		Icon:       created.Icon,
+		Enable:     created.Enable,
+		Config:     created.Config,
+		Metadata:   metadataJSON,
+	})
+}
+
+func matchExistingProvider(idx *providerIndex, used map[string]bool, def ProviderDefinition, registryCfg map[string]any) (sqlc.Provider, bool) {
+	if idx == nil {
+		return sqlc.Provider{}, false
+	}
+	if source := registrySource(def.Source); source != "" {
+		if provider, ok := idx.bySource[source]; ok && !used[providerKey(provider)] {
+			return provider, true
+		}
+	}
+	if provider, ok := idx.byName[def.Name]; ok && !used[providerKey(provider)] {
+		return provider, true
+	}
+	return matchLegacyProviderByModels(idx, used, def, registryCfg)
+}
+
+func matchLegacyProviderByModels(idx *providerIndex, used map[string]bool, def ProviderDefinition, registryCfg map[string]any) (sqlc.Provider, bool) {
+	defModelIDs := definitionModelIDs(def)
+	if len(defModelIDs) == 0 {
+		return sqlc.Provider{}, false
+	}
+	baseURL := normalizedBaseURL(configString(registryCfg, "base_url"))
+	var best sqlc.Provider
+	bestScore := 0
+	tied := false
+	for _, provider := range idx.providers {
+		key := providerKey(provider)
+		if used[key] || provider.ClientType != def.ClientType {
+			continue
+		}
+		if providerRegistrySource(provider) != "" {
+			continue
+		}
+		overlap := modelOverlap(defModelIDs, idx.modelIDs[key])
+		if overlap == 0 {
+			continue
+		}
+		score := overlap
+		if baseURL != "" && normalizedBaseURL(configString(parseJSONMap(provider.Config), "base_url")) == baseURL {
+			score += 1000
+		}
+		if score > bestScore {
+			best = provider
+			bestScore = score
+			tied = false
+			continue
+		}
+		if score == bestScore {
+			tied = true
+		}
+	}
+	if bestScore == 0 || tied {
+		return sqlc.Provider{}, false
+	}
+	return best, true
+}
+
+func definitionModelIDs(def ProviderDefinition) map[string]bool {
+	modelIDs := make(map[string]bool, len(def.Models))
+	for _, model := range def.Models {
+		modelID := strings.TrimSpace(model.ModelID)
+		if modelID != "" {
+			modelIDs[modelID] = true
+		}
+	}
+	return modelIDs
+}
+
+func modelOverlap(left, right map[string]bool) int {
+	if len(left) == 0 || len(right) == 0 {
+		return 0
+	}
+	overlap := 0
+	for modelID := range left {
+		if right[modelID] {
+			overlap++
+		}
+	}
+	return overlap
+}
+
+func listRegistryProviders(ctx context.Context, queries dbstore.Queries) ([]sqlc.Provider, error) {
+	var out []sqlc.Provider
+	seen := make(map[string]bool)
+	for _, list := range []func(context.Context) ([]sqlc.Provider, error){
+		queries.ListProviders,
+		queries.ListSpeechProviders,
+		queries.ListTranscriptionProviders,
+	} {
+		providers, err := list(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, provider := range providers {
+			key := providerKey(provider)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, provider)
+		}
+	}
+	return out, nil
+}
+
+func providerConfigFromDefinition(def ProviderDefinition) map[string]any {
+	providerCfg := make(map[string]any, len(def.Config)+1)
+	for k, v := range def.Config {
+		providerCfg[k] = v
+	}
+	if def.BaseURL != "" {
+		providerCfg["base_url"] = def.BaseURL
+	}
+	return providerCfg
+}
+
+func mergeRegistryProviderConfig(registryCfg, existingCfg map[string]any) map[string]any {
+	merged := make(map[string]any, len(registryCfg)+len(existingCfg))
+	for k, v := range registryCfg {
+		merged[k] = v
+	}
+	for k, v := range existingCfg {
+		merged[k] = v
+	}
+	return merged
+}
+
+func withRegistryMetadata(metadata map[string]any, source string) map[string]any {
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	source = registrySource(source)
+	if source == "" {
+		return metadata
+	}
+	registryMeta, _ := metadata[registryMetadataKey].(map[string]any)
+	if registryMeta == nil {
+		registryMeta = map[string]any{}
+	}
+	registryMeta["source"] = source
+	metadata[registryMetadataKey] = registryMeta
+	return metadata
+}
+
+func providerRegistrySource(provider sqlc.Provider) string {
+	metadata := parseJSONMap(provider.Metadata)
+	registryMeta, _ := metadata[registryMetadataKey].(map[string]any)
+	if registryMeta == nil {
+		return ""
+	}
+	return registrySource(configString(registryMeta, "source"))
+}
+
+func parseJSONMap(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func configString(cfg map[string]any, key string) string {
+	if cfg == nil {
+		return ""
+	}
+	value, _ := cfg[key].(string)
+	return value
+}
+
+func normalizedBaseURL(value string) string {
+	return strings.TrimRight(strings.TrimSpace(value), "/")
+}
+
+func registrySource(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	base := strings.TrimSpace(filepath.Base(value))
+	if base == "." {
+		return ""
+	}
+	return strings.ToLower(base)
+}
+
+func providerKey(provider sqlc.Provider) string {
+	return provider.ID.String()
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,245 @@
+package registry
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/db"
+	sqlitestore "github.com/memohai/memoh/internal/db/sqlite/store"
+)
+
+func TestSyncUpdatesProviderWhenRegistryNameChanges(t *testing.T) {
+	ctx := context.Background()
+	conn, queries := newRegistryTestQueries(t)
+	logger := slog.New(slog.DiscardHandler)
+
+	initial := ProviderDefinition{
+		Name:       "OpenAI",
+		ClientType: "openai-responses",
+		Icon:       "openai",
+		BaseURL:    "https://api.openai.com/v1",
+		Source:     "openai.yaml",
+		Models: []ModelDefinition{{
+			ModelID: "gpt-test",
+			Name:    "GPT Test",
+			Type:    "chat",
+			Config:  map[string]any{"context_window": 128000},
+		}},
+	}
+	if err := Sync(ctx, logger, queries, []ProviderDefinition{initial}); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	providers, err := queries.ListProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(providers))
+	}
+	providerID := providers[0].ID.String()
+	_, err = conn.ExecContext(ctx,
+		`UPDATE providers SET enable = 1, config = ? WHERE id = ?`,
+		`{"base_url":"https://custom.example/v1","api_key":"sk-existing","prompt_cache_ttl":"5m"}`,
+		providerID,
+	)
+	if err != nil {
+		t.Fatalf("seed provider config: %v", err)
+	}
+
+	renamed := initial
+	renamed.Name = "OpenAI Responses"
+	renamed.Models[0].Name = "GPT Test Updated"
+	renamed.Models[0].Config = map[string]any{"context_window": 256000}
+	if err := Sync(ctx, logger, queries, []ProviderDefinition{renamed}); err != nil {
+		t.Fatalf("renamed sync: %v", err)
+	}
+
+	providers, err = queries.ListProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers after rename: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count after rename = %d, want 1", len(providers))
+	}
+	got := providers[0]
+	if got.ID.String() != providerID {
+		t.Fatalf("provider id = %s, want existing %s", got.ID.String(), providerID)
+	}
+	if got.Name != "OpenAI Responses" {
+		t.Fatalf("provider name = %q, want renamed value", got.Name)
+	}
+	if !got.Enable {
+		t.Fatalf("provider enable = false, want preserved true")
+	}
+	cfg := jsonMap(t, got.Config)
+	if cfg["api_key"] != "sk-existing" {
+		t.Fatalf("api_key = %#v, want preserved secret", cfg["api_key"])
+	}
+	if cfg["base_url"] != "https://custom.example/v1" {
+		t.Fatalf("base_url = %#v, want preserved custom value", cfg["base_url"])
+	}
+	if cfg["prompt_cache_ttl"] != "5m" {
+		t.Fatalf("prompt_cache_ttl = %#v, want preserved custom value", cfg["prompt_cache_ttl"])
+	}
+	assertRegistrySource(t, got.Metadata, "openai.yaml")
+
+	models, err := queries.ListModelsByProviderID(ctx, got.ID)
+	if err != nil {
+		t.Fatalf("list models: %v", err)
+	}
+	if len(models) != 1 || models[0].Name.String != "GPT Test Updated" {
+		t.Fatalf("models = %+v, want updated model", models)
+	}
+	modelCfg := jsonMap(t, models[0].Config)
+	if value := modelCfg["context_window"]; value != float64(256000) {
+		t.Fatalf("model context_window = %#v, want 256000", value)
+	}
+}
+
+func TestSyncMatchesLegacyProviderByBaseURL(t *testing.T) {
+	ctx := context.Background()
+	conn, queries := newRegistryTestQueries(t)
+	logger := slog.New(slog.DiscardHandler)
+
+	const providerID = "00000000-0000-0000-0000-000000000001"
+	_, err := conn.ExecContext(ctx, `
+INSERT INTO providers (id, name, client_type, icon, enable, config, metadata)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		providerID,
+		"OpenAI Legacy",
+		"openai-responses",
+		"openai",
+		1,
+		`{"base_url":"https://api.openai.com/v1","api_key":"sk-legacy"}`,
+		`{}`,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy provider: %v", err)
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO models (id, model_id, name, provider_id, type, config)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		"00000000-0000-0000-0000-000000000002",
+		"gpt-test",
+		"GPT Test Legacy",
+		providerID,
+		"chat",
+		`{"context_window":64000}`,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy model: %v", err)
+	}
+
+	def := ProviderDefinition{
+		Name:       "OpenAI Responses",
+		ClientType: "openai-responses",
+		Icon:       "openai",
+		BaseURL:    "https://api.openai.com/v1",
+		Source:     "openai.yaml",
+		Models: []ModelDefinition{{
+			ModelID: "gpt-test",
+			Name:    "GPT Test",
+			Type:    "chat",
+			Config:  map[string]any{"context_window": 128000},
+		}},
+	}
+	if err := Sync(ctx, logger, queries, []ProviderDefinition{def}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	providers, err := queries.ListProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(providers))
+	}
+	got := providers[0]
+	if got.ID.String() != providerID {
+		t.Fatalf("provider id = %s, want legacy %s", got.ID.String(), providerID)
+	}
+	if got.Name != "OpenAI Responses" {
+		t.Fatalf("provider name = %q, want registry name", got.Name)
+	}
+	cfg := jsonMap(t, got.Config)
+	if cfg["api_key"] != "sk-legacy" {
+		t.Fatalf("api_key = %#v, want preserved legacy secret", cfg["api_key"])
+	}
+	assertRegistrySource(t, got.Metadata, "openai.yaml")
+}
+
+func newRegistryTestQueries(t *testing.T) (*sql.DB, *sqlitestore.Queries) {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	execRegistrySchema(t, conn)
+	store, err := sqlitestore.New(conn)
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	return conn, sqlitestore.NewQueries(store)
+}
+
+func execRegistrySchema(t *testing.T, conn *sql.DB) {
+	t.Helper()
+	_, err := conn.ExecContext(context.Background(), `
+CREATE TABLE providers (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  client_type TEXT NOT NULL DEFAULT 'openai-completions',
+  icon TEXT,
+  enable INTEGER NOT NULL DEFAULT 1,
+  config TEXT NOT NULL DEFAULT '{}',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT providers_name_unique UNIQUE (name)
+);
+
+CREATE TABLE models (
+  id TEXT PRIMARY KEY,
+  model_id TEXT NOT NULL,
+  name TEXT,
+  provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT 'chat',
+  config TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT models_provider_id_model_id_unique UNIQUE (provider_id, model_id)
+);
+`)
+	if err != nil {
+		t.Fatalf("exec registry schema: %v", err)
+	}
+}
+
+func jsonMap(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal json map: %v", err)
+	}
+	return out
+}
+
+func assertRegistrySource(t *testing.T, raw []byte, want string) {
+	t.Helper()
+	metadata := jsonMap(t, raw)
+	registryMeta, ok := metadata[registryMetadataKey].(map[string]any)
+	if !ok {
+		t.Fatalf("registry metadata missing: %#v", metadata)
+	}
+	if registryMeta["source"] != want {
+		t.Fatalf("registry source = %#v, want %q", registryMeta["source"], want)
+	}
+}

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -8,6 +8,7 @@ type ProviderDefinition struct {
 	BaseURL    string            `yaml:"base_url,omitempty"`
 	Config     map[string]any    `yaml:"config,omitempty"`
 	Models     []ModelDefinition `yaml:"models"`
+	Source     string            `yaml:"-"`
 }
 
 // ModelDefinition describes a model within a provider definition.


### PR DESCRIPTION
## Summary
- 为 provider registry 定义记录来源文件名，并写入 `providers.metadata.registry.source`
- 同步时优先按 source/name/旧模型指纹匹配已有 provider，避免 YAML `name` 变动后重复创建
- 保留已有 provider 的 `enable`、凭据和自定义 config，同时继续更新 registry 模型配置
- 补充 SQLite-backed registry 同步测试覆盖重命名和旧数据迁移场景

## Tests
- `go test ./cmd/agent ./internal/registry`
- 提交前 hook 的全量 Go test 已通过；Go lint 被既有 `internal/channel/adapters/slack/slack_test.go` 与 `internal/channel/adapters/telegram/telegram_test.go` 的 SA5011 报警阻塞，和本次改动无关。