### PR TITLE
fix(desktop): proxy Codex OAuth callback

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,7 +5,15 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import iconPng from '../../resources/icon.png?asset'
 import trayIconPng from '../../resources/tray-icon.png?asset'
 import { stopEmbeddedQdrant } from './qdrant'
-import { defaultWorkspacePath, ensureLocalServer, getDesktopAuthToken, getLocalServerStatus, stopManagedServer } from './local-server'
+import {
+  defaultWorkspacePath,
+  ensureLocalServer,
+  ensureProviderOAuthCallbackProxy,
+  getDesktopAuthToken,
+  getLocalServerStatus,
+  stopManagedServer,
+  stopProviderOAuthCallbackProxy,
+} from './local-server'
 import {
   detectCliState,
   installCli,
@@ -78,6 +86,7 @@ const pendingSettingsNavigate = new Map<number, string>()
 let stoppingLocalProcesses = false
 
 async function stopLocalProcesses(): Promise<void> {
+  await stopProviderOAuthCallbackProxy()
   await stopManagedServer()
   await stopEmbeddedQdrant()
 }
@@ -478,6 +487,7 @@ async function rebuildAppMenu(): Promise<void> {
 app.whenReady().then(async () => {
   electronApp.setAppUserModelId('ai.memoh.desktop')
   await ensureLocalServer()
+  await ensureProviderOAuthCallbackProxy()
 
   if (process.platform === 'darwin' && app.dock && is.dev) {
     app.dock.setIcon(iconPng)

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -1,6 +1,7 @@
 import { app, dialog } from 'electron'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer, request, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { join } from 'node:path'
 import { ensureEmbeddedQdrant, getEmbeddedQdrantStatus } from './qdrant'
 import {
@@ -16,12 +17,14 @@ import { desktopResourcePath, desktopServerWorkDir, repoRoot } from './paths'
 
 export const LOCAL_SERVER_PORT = 18731
 export const LOCAL_SERVER_BASE_URL = `http://127.0.0.1:${LOCAL_SERVER_PORT}`
+const PROVIDER_OAUTH_CALLBACK_PORT = 1455
 
 let startedProcess: ChildProcess | null = null
 let serverReady = false
 let serverError: string | null = null
 let desktopAuthToken: string | null = null
 let preparedServerCommand: ServerCommand | null = null
+let providerOAuthCallbackProxies: Server[] = []
 
 export interface LocalServerStatus {
   baseUrl: string
@@ -122,6 +125,82 @@ function pidPath(): string {
 
 function appendLog(message: string): void {
   appendLineLog(logPath(), message)
+}
+
+function proxyProviderOAuthCallback(req: IncomingMessage, res: ServerResponse): void {
+  const target = new URL(req.url ?? '/', LOCAL_SERVER_BASE_URL)
+  const headers = { ...req.headers }
+  delete headers.host
+  delete headers.connection
+
+  const upstream = request({
+    protocol: target.protocol,
+    hostname: target.hostname,
+    port: target.port,
+    method: req.method,
+    path: `${target.pathname}${target.search}`,
+    headers,
+  }, (upstreamRes) => {
+    res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
+    upstreamRes.pipe(res)
+  })
+
+  upstream.once('error', (error) => {
+    appendLog(`provider oauth callback proxy error: ${error.message}`)
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' })
+    }
+    res.end('Memoh local server is not available')
+  })
+
+  req.pipe(upstream)
+}
+
+function listen(server: Server, host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(PROVIDER_OAUTH_CALLBACK_PORT, host, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+export async function ensureProviderOAuthCallbackProxy(): Promise<void> {
+  if (providerOAuthCallbackProxies.length > 0) {
+    return
+  }
+
+  for (const host of ['127.0.0.1', '::1']) {
+    const server = createServer(proxyProviderOAuthCallback)
+    try {
+      await listen(server, host)
+      providerOAuthCallbackProxies.push(server)
+      appendLog(`provider oauth callback proxy listening on ${host}:${PROVIDER_OAUTH_CALLBACK_PORT}`)
+    } catch (error) {
+      appendLog(`provider oauth callback proxy failed on ${host}:${PROVIDER_OAUTH_CALLBACK_PORT}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+}
+
+export async function stopProviderOAuthCallbackProxy(): Promise<void> {
+  const proxies = providerOAuthCallbackProxies
+  providerOAuthCallbackProxies = []
+  await Promise.all(proxies.map(server => closeServer(server).catch((error: unknown) => {
+    appendLog(`provider oauth callback proxy close failed: ${error instanceof Error ? error.message : String(error)}`)
+  })))
 }
 
 function prepareConfig(cwd: string, sourcePath: string, qdrantGrpcBaseUrl: string | undefined, providersDir: string): string {

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -405,7 +405,10 @@ const oauthStatus = ref<ProvidersOAuthStatus | null>(null)
 const oauthStatusLoading = ref(false)
 const authorizeLoading = ref(false)
 const revokeLoading = ref(false)
-const pollTimer = ref<number | null>(null)
+const devicePollTimer = ref<number | null>(null)
+const webPollTimer = ref<number | null>(null)
+const webOAuthPollIntervalMs = 2000
+const webOAuthPollTimeoutMs = 5 * 60 * 1000
 
 async function runTest() {
   if (!props.provider?.id) return
@@ -559,25 +562,40 @@ const editProvider = form.handleSubmit(async (value) => {
 
 const oauthExpired = computed(() => Boolean(oauthStatus.value?.has_token && oauthStatus.value?.expired))
 
-function clearPollTimer() {
-  if (pollTimer.value !== null) {
-    window.clearTimeout(pollTimer.value)
-    pollTimer.value = null
+function clearDevicePollTimer() {
+  if (devicePollTimer.value !== null) {
+    window.clearTimeout(devicePollTimer.value)
+    devicePollTimer.value = null
   }
 }
 
-async function fetchOAuthStatus() {
-  if (!props.provider?.id) return
+function clearWebPollTimer() {
+  if (webPollTimer.value !== null) {
+    window.clearTimeout(webPollTimer.value)
+    webPollTimer.value = null
+  }
+}
+
+function clearPollTimers() {
+  clearDevicePollTimer()
+  clearWebPollTimer()
+}
+
+async function fetchOAuthStatus(): Promise<ProvidersOAuthStatus | null> {
+  if (!props.provider?.id) return null
   oauthStatusLoading.value = true
   try {
     const { data } = await getProvidersByIdOauthStatus({
       path: { id: props.provider.id },
       throwOnError: true,
     })
-    oauthStatus.value = data ?? null
+    const nextStatus = data ?? null
+    oauthStatus.value = nextStatus
+    return nextStatus
   } catch (error) {
     oauthStatus.value = null
     console.error('failed to load provider oauth status', error)
+    return null
   } finally {
     oauthStatusLoading.value = false
   }
@@ -598,13 +616,13 @@ async function pollOAuthAuthorization(notifyOnSuccess = false) {
       toast.success(t('provider.oauth.authorizeSuccess'))
     }
   } catch (error) {
-    clearPollTimer()
+    clearDevicePollTimer()
     toast.error(error instanceof Error ? error.message : t('provider.oauth.authorizeFailed'))
   }
 }
 
 watch(oauthStatus, (status) => {
-  clearPollTimer()
+  clearDevicePollTimer()
   if (form.values.client_type !== 'github-copilot') {
     return
   }
@@ -612,14 +630,32 @@ watch(oauthStatus, (status) => {
     return
   }
   const intervalSeconds = Math.max(status.device.interval_seconds ?? 5, 1)
-  pollTimer.value = window.setTimeout(() => {
+  devicePollTimer.value = window.setTimeout(() => {
     void pollOAuthAuthorization(true)
   }, intervalSeconds * 1000)
 })
 
 onBeforeUnmount(() => {
-  clearPollTimer()
+  clearPollTimers()
 })
+
+function scheduleWebOAuthStatusPoll(startedAt: number, onAuthorized: () => Promise<void>) {
+  clearWebPollTimer()
+  webPollTimer.value = window.setTimeout(() => {
+    void (async () => {
+      const status = await fetchOAuthStatus()
+      if (status?.has_token && !status.expired) {
+        await onAuthorized()
+        return
+      }
+      if (Date.now() - startedAt >= webOAuthPollTimeoutMs) {
+        authorizeLoading.value = false
+        return
+      }
+      scheduleWebOAuthStatusPoll(startedAt, onAuthorized)
+    })()
+  }, webOAuthPollIntervalMs)
+}
 
 async function handleAuthorize() {
   if (!props.provider?.id) return
@@ -640,21 +676,31 @@ async function handleAuthorize() {
         callback_url: '',
         device: result.device,
       }
+      authorizeLoading.value = false
       return
     }
     if (!result.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
     const popup = window.open(result.auth_url, 'provider-oauth', 'width=600,height=720')
-    const listener = async (event: MessageEvent) => {
-      if (event.data?.type !== 'memoh-provider-oauth-success') return
+    let completed = false
+    const completeAuthorization = async () => {
+      if (completed) return
+      completed = true
+      clearWebPollTimer()
       window.removeEventListener('message', listener)
       popup?.close()
       toast.success(t('provider.oauth.authorizeSuccess'))
       await fetchOAuthStatus()
+      authorizeLoading.value = false
+    }
+    const listener = async (event: MessageEvent) => {
+      if (event.data?.type !== 'memoh-provider-oauth-success') return
+      await completeAuthorization()
     }
     window.addEventListener('message', listener)
+    scheduleWebOAuthStatusPoll(Date.now(), completeAuthorization)
   } catch (error) {
+    clearWebPollTimer()
     toast.error(error instanceof Error ? error.message : t('provider.oauth.authorizeFailed'))
-  } finally {
     authorizeLoading.value = false
   }
 }
@@ -686,7 +732,7 @@ async function handleCopyDeviceCode() {
 
 async function handleRevoke() {
   if (!props.provider?.id) return
-  clearPollTimer()
+  clearPollTimers()
   revokeLoading.value = true
   try {
     await deleteProvidersByIdOauthToken({


### PR DESCRIPTION
## Summary
- Add a desktop-local OAuth callback proxy on loopback port 1455 so Codex OAuth redirects reach the managed local server.
- Stop the callback proxy alongside the managed local server and embedded Qdrant.
- Poll provider OAuth status after web authorization so desktop UI updates even when the callback opens in an external browser.

## Test plan
- pnpm --filter @memohai/desktop typecheck:node
- pnpm --filter @memohai/desktop typecheck:web
- Commit hook ran Go tests and ESLint staged checks
- Verified localhost:1455/auth/callback forwards to the desktop local server and returns the server-side callback response
- Verified Codex OAuth token is persisted and /providers/:id/oauth/status returns has_token=true