### PR TITLE
fix: refresh sidebar i18n and swagger docs

### DIFF
--- a/apps/web/src/components/settings-sidebar/index.vue
+++ b/apps/web/src/components/settings-sidebar/index.vue
@@ -110,7 +110,9 @@ function isItemActive(name: string): boolean {
   return route.name === name
 }
 
-const allNavItems: { title: string; name: string; icon: Component }[] = [
+type NavItem = { title: string; name: string; icon: Component }
+
+const allNavItems = computed<NavItem[]>(() => [
   { title: t('sidebar.bots'), name: 'bots', icon: Bot },
   { title: t('sidebar.providers'), name: 'providers', icon: Boxes },
   { title: t('sidebar.webSearch'), name: 'web-search', icon: Globe },
@@ -123,11 +125,11 @@ const allNavItems: { title: string; name: string; icon: Component }[] = [
   { title: t('sidebar.appearance'), name: 'appearance', icon: Palette },
   { title: t('sidebar.profile'), name: 'profile', icon: User },
   { title: t('sidebar.about'), name: 'about', icon: Info },
-]
+])
 
 const navItems = computed(() =>
   props.excludeItems.length > 0
-    ? allNavItems.filter(item => !props.excludeItems.includes(item.name))
-    : allNavItems,
+    ? allNavItems.value.filter(item => !props.excludeItems.includes(item.name))
+    : allNavItems.value,
 )
 </script>

--- a/apps/web/src/pages/home/components/chat-sidebar.vue
+++ b/apps/web/src/pages/home/components/chat-sidebar.vue
@@ -111,7 +111,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeUnmount, nextTick, type Component } from 'vue'
+import { ref, computed, onBeforeUnmount, nextTick, type Component } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
@@ -135,18 +135,18 @@ const { t } = useI18n()
 const chatStore = useChatStore()
 const { currentBotId } = storeToRefs(chatStore)
 
-const activityTabs: ActivityTab[] = [
+const activityTabs = computed<ActivityTab[]>(() => [
   { id: 'sessions', label: t('chat.activityTabSessions'), icon: MessageSquare },
   { id: 'files', label: t('chat.activityTabFiles'), icon: Folder },
   { id: 'skills', label: t('chat.activityTabSkills'), icon: Sparkles },
   { id: 'mcp', label: t('chat.activityTabMcp'), icon: Plug },
   { id: 'schedule', label: t('chat.activityTabSchedule'), icon: CalendarClock },
-]
+])
 
 const activeTab = useLocalStorage<ActivityTabId>('chat-sidebar-active-tab', 'sessions')
 
 // Guard against stale persisted value (e.g. legacy 'terminal' tab).
-if (!activityTabs.some((t) => t.id === activeTab.value)) {
+if (!activityTabs.value.some((t) => t.id === activeTab.value)) {
   activeTab.value = 'sessions'
 }
 

--- a/internal/handlers/swagger.go
+++ b/internal/handlers/swagger.go
@@ -6,10 +6,13 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/labstack/echo/v4"
+	"github.com/swaggo/swag"
+
+	// Register the generated swagger document for swag.ReadDoc.
+	_ "github.com/memohai/memoh/spec"
 )
 
 //go:generate go run github.com/swaggo/swag/cmd/swag@latest init -g swagger.go -o ../../spec --parseDependency --parseInternal
@@ -36,7 +39,9 @@ func (h *SwaggerHandler) Register(e *echo.Echo) {
 
 func (*SwaggerHandler) Spec(c echo.Context) error {
 	swaggerOnce.Do(func() {
-		swaggerSpec, swaggerErr = os.ReadFile("spec/swagger.json")
+		var doc string
+		doc, swaggerErr = swag.ReadDoc()
+		swaggerSpec = []byte(doc)
 	})
 	if swaggerErr != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, swaggerErr.Error())


### PR DESCRIPTION
## Summary
- Refresh web sidebar labels reactively when the active locale changes.
- Serve Swagger JSON from the generated swag spec so desktop/local server does not depend on the process working directory.

## Test plan
- `pnpm exec eslint apps/web/src/components/settings-sidebar/index.vue apps/web/src/pages/home/components/chat-sidebar.vue`
- `go test ./internal/handlers ./internal/server`
- pre-commit hook: `golangci-lint run ./...`, `go test ./...`, `lint-staged`
- `pnpm --filter @memohai/web build`