### PR TITLE
fix: handle Windows desktop paths

### DIFF
--- a/apps/desktop/src/main/local-server.test.ts
+++ b/apps/desktop/src/main/local-server.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { tomlStringLiteral } from './local-server'
+
+describe('tomlStringLiteral', () => {
+  it('escapes Windows paths for TOML basic strings', () => {
+    expect(tomlStringLiteral('C:\\Users\\Dustella\\AppData\\Roaming\\Memoh\\data\\local'))
+      .toBe('"C:\\\\Users\\\\Dustella\\\\AppData\\\\Roaming\\\\Memoh\\\\data\\\\local"')
+  })
+
+  it('escapes quotes and control characters', () => {
+    expect(tomlStringLiteral('quoted "value"\nnext'))
+      .toBe('"quoted \\"value\\"\\nnext"')
+  })
+})

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -277,7 +277,7 @@ function setDockerHostIfEmpty(contents: string, dockerHost: string): string {
       return line
     }
     updated = true
-    return `${match[1]}"${dockerHost}"${match[3]}`
+    return `${match[1]}${tomlStringLiteral(dockerHost)}${match[3]}`
   })
   if (updated) {
     appendLog(`detected Docker host: ${dockerHost}`)
@@ -303,12 +303,35 @@ function setTomlString(contents: string, sectionName: string, key: string, value
       return line
     }
     updated = true
-    return `${match[1]}"${value}"${match[3]}`
+    return `${match[1]}${tomlStringLiteral(value)}${match[3]}`
   })
   if (!updated) {
     throw new Error(`config key not found: [${sectionName}].${key}`)
   }
   return next.join('\n')
+}
+
+export function tomlStringLiteral(value: string): string {
+  return `"${value.replace(/[\b\t\n\f\r"\\\u0000-\u001f\u007f]/g, (char) => {
+    switch (char) {
+      case '\b':
+        return '\\b'
+      case '\t':
+        return '\\t'
+      case '\n':
+        return '\\n'
+      case '\f':
+        return '\\f'
+      case '\r':
+        return '\\r'
+      case '"':
+        return '\\"'
+      case '\\':
+        return '\\\\'
+      default:
+        return `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`
+    }
+  })}"`
 }
 
 function prepareRuntime(command: ServerCommand): void {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -26,14 +26,23 @@ func OpenSQLite(ctx context.Context, cfg config.SQLiteConfig) (*sql.DB, error) {
 
 func SQLiteFileDSN(cfg config.SQLiteConfig) string {
 	if dsn := strings.TrimSpace(cfg.DSN); dsn != "" {
-		return strings.TrimPrefix(dsn, "sqlite://")
+		return sqliteFileDSN(dsn)
 	}
-	path := strings.TrimPrefix(strings.TrimSpace(SQLiteDSN(cfg)), "sqlite://")
-	parsed, err := url.Parse(path)
-	if err != nil || parsed.RawQuery == "" {
+	return sqliteFileDSN(SQLiteDSN(cfg))
+}
+
+func sqliteFileDSN(dsn string) string {
+	path := strings.TrimPrefix(strings.TrimSpace(dsn), "sqlite://")
+	queryStart := strings.IndexByte(path, '?')
+	if queryStart < 0 {
 		return path
 	}
-	query := parsed.Query()
+	filePath := path[:queryStart]
+	rawQuery := path[queryStart+1:]
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return path
+	}
 	if busyTimeout := query.Get("_busy_timeout"); busyTimeout != "" {
 		query.Set("_pragma", "busy_timeout("+busyTimeout+")")
 		query.Del("_busy_timeout")
@@ -42,5 +51,8 @@ func SQLiteFileDSN(cfg config.SQLiteConfig) string {
 		query.Add("_pragma", "journal_mode(WAL)")
 		query.Del("_journal_mode")
 	}
-	return parsed.Path + "?" + query.Encode()
+	if encoded := query.Encode(); encoded != "" {
+		return filePath + "?" + encoded
+	}
+	return filePath
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -1,0 +1,42 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+func TestSQLiteFileDSNPreservesWindowsPath(t *testing.T) {
+	cfg := config.SQLiteConfig{
+		DSN: "sqlite://C:\\Users\\Dustella\\AppData\\Roaming\\Memoh\\data\\local\\memoh.db?_busy_timeout=5000&_journal_mode=WAL",
+	}
+
+	got := SQLiteFileDSN(cfg)
+	if !strings.HasPrefix(got, "C:\\Users\\Dustella\\AppData\\Roaming\\Memoh\\data\\local\\memoh.db?") {
+		t.Fatalf("SQLiteFileDSN() = %q, want Windows file path prefix", got)
+	}
+	if !strings.Contains(got, "_pragma=busy_timeout%285000%29") {
+		t.Fatalf("SQLiteFileDSN() = %q, want busy_timeout pragma", got)
+	}
+	if !strings.Contains(got, "_pragma=journal_mode%28WAL%29") {
+		t.Fatalf("SQLiteFileDSN() = %q, want WAL pragma", got)
+	}
+}
+
+func TestSQLiteFileDSNPreservesUnixPath(t *testing.T) {
+	cfg := config.SQLiteConfig{
+		DSN: "sqlite:///tmp/memoh.db?_busy_timeout=5000&_journal_mode=WAL",
+	}
+
+	got := SQLiteFileDSN(cfg)
+	if !strings.HasPrefix(got, "/tmp/memoh.db?") {
+		t.Fatalf("SQLiteFileDSN() = %q, want Unix file path prefix", got)
+	}
+	if !strings.Contains(got, "_pragma=busy_timeout%285000%29") {
+		t.Fatalf("SQLiteFileDSN() = %q, want busy_timeout pragma", got)
+	}
+	if !strings.Contains(got, "_pragma=journal_mode%28WAL%29") {
+		t.Fatalf("SQLiteFileDSN() = %q, want WAL pragma", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Escape desktop-generated TOML string values so Windows paths like `C:\Users\...` remain valid in `config.toml`.
- Preserve Windows SQLite file paths when converting `sqlite://...` URLs into the driver DSN.
- Add regression coverage for TOML escaping and Windows/Unix SQLite DSN handling.

## Root cause
The desktop main process wrote absolute Windows paths directly into TOML basic strings, so backslashes such as `\U` were parsed as invalid TOML escapes. After that was fixed, the SQLite DSN path still had a Windows-specific risk: `url.Parse` could interpret `C:` as URL syntax instead of a local file path.

## Validation
- `pnpm vitest run apps/desktop/src/main/local-server.test.ts`
- `pnpm --filter @memohai/desktop typecheck:node`
- `go test ./internal/db -run 'TestSQLiteFileDSN' -count=1`
- `go test ./internal/config ./internal/db -count=1`
- Pre-commit hook: Go lint, Go test, eslint staged files
