### PR TITLE
fix(workspace): fall back to VNC image mirror

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,8 @@ const (
 	DefaultQdrantCollection = "memory"
 	DefaultRuntimeDir       = "/opt/memoh/runtime"
 	DefaultBaseImage        = "debian:bookworm-slim"
+	DefaultVNCImage         = "memohai/vnc:debian"
+	DefaultVNCMirrorImage   = "memoh.cn/memohai/vnc:debian"
 	DefaultTimezone         = "UTC"
 
 	ImagePullPolicyIfNotPresent = "if_not_present"
@@ -252,6 +254,10 @@ func homeDirOrDot() string {
 
 // NormalizeImageRef ensures an image reference is fully qualified for containerd.
 func NormalizeImageRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
 	firstSlash := strings.Index(ref, "/")
 	if firstSlash == -1 {
 		return "docker.io/library/" + ref
@@ -261,6 +267,17 @@ func NormalizeImageRef(ref string) string {
 		return ref
 	}
 	return "docker.io/" + ref
+}
+
+func WorkspaceImagePullCandidates(ref string) []string {
+	normalized := NormalizeImageRef(ref)
+	if normalized == "" {
+		return nil
+	}
+	if normalized == NormalizeImageRef(DefaultVNCImage) {
+		return []string{normalized, DefaultVNCMirrorImage}
+	}
+	return []string{normalized}
 }
 
 type PostgresConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -240,3 +240,23 @@ func TestWorkspaceImagePullPolicyDefaultsAndNormalizes(t *testing.T) {
 		t.Fatalf("invalid policy = %q", got)
 	}
 }
+
+func TestWorkspaceImagePullCandidatesAddsVNCMirror(t *testing.T) {
+	got := WorkspaceImagePullCandidates("memohai/vnc:debian")
+	want := []string{"docker.io/memohai/vnc:debian", "memoh.cn/memohai/vnc:debian"}
+	if len(got) != len(want) {
+		t.Fatalf("candidate count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWorkspaceImagePullCandidatesDoesNotMirrorCustomImages(t *testing.T) {
+	got := WorkspaceImagePullCandidates("debian:bookworm-slim")
+	if len(got) != 1 || got[0] != "docker.io/library/debian:bookworm-slim" {
+		t.Fatalf("unexpected candidates: %v", got)
+	}
+}

--- a/internal/handlers/containerd.go
+++ b/internal/handlers/containerd.go
@@ -357,6 +357,9 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 			sendError("image preparation failed: " + pullErr.Error())
 			return nil
 		}
+		if strings.TrimSpace(prepareResult.ImageRef) != "" {
+			image = prepareResult.ImageRef
+		}
 		switch prepareResult.Mode {
 		case workspace.ImagePrepareSkipped:
 			send(createContainerPullStatusEvent{Type: "pull_skipped", Image: image, Message: prepareResult.Message})

--- a/internal/workspace/image_pull.go
+++ b/internal/workspace/image_pull.go
@@ -18,43 +18,65 @@ const (
 )
 
 type ImagePrepareResult struct {
-	Mode    ImagePrepareMode
-	Image   ctr.ImageInfo
-	Message string
+	Mode     ImagePrepareMode
+	ImageRef string
+	Image    ctr.ImageInfo
+	Message  string
 }
 
 func (m *Manager) PrepareImageForCreate(ctx context.Context, image string, opts *ctr.PullImageOptions) (ImagePrepareResult, error) {
+	candidates := config.WorkspaceImagePullCandidates(image)
+	if len(candidates) == 0 {
+		return ImagePrepareResult{}, ctr.ErrInvalidArgument
+	}
+	primary := candidates[0]
 	policy := m.cfg.EffectiveImagePullPolicy()
 	if policy == config.ImagePullPolicyNever {
-		return ImagePrepareResult{Mode: ImagePrepareSkipped, Message: "image pull disabled by policy"}, nil
+		return ImagePrepareResult{Mode: ImagePrepareSkipped, ImageRef: primary, Message: "image pull disabled by policy"}, nil
 	}
 
 	imageService, ok := m.service.(ctr.ImageService)
 	if !ok {
-		return ImagePrepareResult{Mode: ImagePrepareDelegated, Message: "container backend handles image pulling"}, nil
+		return ImagePrepareResult{Mode: ImagePrepareDelegated, ImageRef: primary, Message: "container backend handles image pulling"}, nil
 	}
 
 	if policy == config.ImagePullPolicyIfNotPresent {
-		info, err := imageService.GetImage(ctx, image)
-		if err == nil {
-			return ImagePrepareResult{Mode: ImagePrepareSkipped, Image: info, Message: "image already present"}, nil
-		}
-		if errors.Is(err, ctr.ErrNotSupported) {
-			return ImagePrepareResult{Mode: ImagePrepareDelegated, Message: "container backend handles image pulling"}, nil
-		}
-		if !ctr.IsNotFound(err) {
-			m.logger.Info("image lookup failed, attempting pull",
-				slog.String("image", image),
-				slog.Any("error", err))
+		for _, candidate := range candidates {
+			info, err := imageService.GetImage(ctx, candidate)
+			if err == nil {
+				return ImagePrepareResult{Mode: ImagePrepareSkipped, ImageRef: candidate, Image: info, Message: "image already present"}, nil
+			}
+			if errors.Is(err, ctr.ErrNotSupported) {
+				return ImagePrepareResult{Mode: ImagePrepareDelegated, ImageRef: primary, Message: "container backend handles image pulling"}, nil
+			}
+			if !ctr.IsNotFound(err) {
+				m.logger.Info("image lookup failed, attempting pull",
+					slog.String("image", candidate),
+					slog.Any("error", err))
+			}
 		}
 	}
 
-	info, err := imageService.PullImage(ctx, image, opts)
-	if err != nil {
-		if errors.Is(err, ctr.ErrNotSupported) {
-			return ImagePrepareResult{Mode: ImagePrepareDelegated, Message: "container backend handles image pulling"}, nil
+	var lastErr error
+	for i, candidate := range candidates {
+		info, err := imageService.PullImage(ctx, candidate, opts)
+		if err == nil {
+			message := "image pulled"
+			if candidate != primary {
+				message = "image pulled from fallback mirror"
+			}
+			return ImagePrepareResult{Mode: ImagePreparePulled, ImageRef: candidate, Image: info, Message: message}, nil
 		}
-		return ImagePrepareResult{}, err
+		if errors.Is(err, ctr.ErrNotSupported) {
+			return ImagePrepareResult{Mode: ImagePrepareDelegated, ImageRef: primary, Message: "container backend handles image pulling"}, nil
+		}
+		lastErr = err
+		if i+1 < len(candidates) {
+			m.logger.Warn("image pull failed, trying fallback image",
+				slog.String("image", candidate),
+				slog.String("fallback_image", candidates[i+1]),
+				slog.Any("error", err))
+		}
 	}
-	return ImagePrepareResult{Mode: ImagePreparePulled, Image: info, Message: "image pulled"}, nil
+	return ImagePrepareResult{}, lastErr
 }

--- a/internal/workspace/image_pull_test.go
+++ b/internal/workspace/image_pull_test.go
@@ -2,6 +2,8 @@ package workspace
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/memohai/memoh/internal/config"
@@ -109,5 +111,81 @@ func TestPrepareImageForCreatePullsThroughRuntimeRouter(t *testing.T) {
 	}
 	if svc.getImageCalls != 1 || svc.pullCalls != 1 {
 		t.Fatalf("unexpected calls: get=%d pull=%d", svc.getImageCalls, svc.pullCalls)
+	}
+}
+
+func TestPrepareImageForCreateFallsBackToVNCMirror(t *testing.T) {
+	primary := "docker.io/memohai/vnc:debian"
+	fallback := "memoh.cn/memohai/vnc:debian"
+	svc := &legacyRouteTestService{
+		getImageErr: ctr.ErrNotFound,
+		pullErrs: map[string]error{
+			primary: ctr.ErrRuntime,
+		},
+	}
+	m := newLegacyRouteTestManager(t, svc, config.WorkspaceConfig{
+		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
+	})
+
+	result, err := m.PrepareImageForCreate(context.Background(), "memohai/vnc:debian", nil)
+	if err != nil {
+		t.Fatalf("PrepareImageForCreate returned error: %v", err)
+	}
+	if result.Mode != ImagePreparePulled {
+		t.Fatalf("expected pulled, got %s", result.Mode)
+	}
+	if result.ImageRef != fallback {
+		t.Fatalf("expected fallback image %q, got %q", fallback, result.ImageRef)
+	}
+	if got := strings.Join(svc.pullRefs, ","); got != primary+","+fallback {
+		t.Fatalf("pull refs = %q, want %q", got, primary+","+fallback)
+	}
+}
+
+func TestPrepareImageForCreateSkipsExistingVNCMirror(t *testing.T) {
+	primary := "docker.io/memohai/vnc:debian"
+	fallback := "memoh.cn/memohai/vnc:debian"
+	svc := &legacyRouteTestService{
+		getImageErrs: map[string]error{
+			primary: ctr.ErrNotFound,
+		},
+	}
+	m := newLegacyRouteTestManager(t, svc, config.WorkspaceConfig{
+		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
+	})
+
+	result, err := m.PrepareImageForCreate(context.Background(), "memohai/vnc:debian", nil)
+	if err != nil {
+		t.Fatalf("PrepareImageForCreate returned error: %v", err)
+	}
+	if result.Mode != ImagePrepareSkipped {
+		t.Fatalf("expected skipped, got %s", result.Mode)
+	}
+	if result.ImageRef != fallback {
+		t.Fatalf("expected fallback image %q, got %q", fallback, result.ImageRef)
+	}
+	if svc.pullCalls != 0 {
+		t.Fatalf("expected no pull calls, got %d", svc.pullCalls)
+	}
+	if got := strings.Join(svc.getImageRefs, ","); got != primary+","+fallback {
+		t.Fatalf("get refs = %q, want %q", got, primary+","+fallback)
+	}
+}
+
+func TestPrepareImageForCreateDoesNotFallbackForCustomImages(t *testing.T) {
+	svc := &legacyRouteTestService{
+		getImageErr: ctr.ErrNotFound,
+		pullErr:     ctr.ErrRuntime,
+	}
+	m := newLegacyRouteTestManager(t, svc, config.WorkspaceConfig{
+		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
+	})
+
+	_, err := m.PrepareImageForCreate(context.Background(), "debian:bookworm-slim", nil)
+	if !errors.Is(err, ctr.ErrRuntime) {
+		t.Fatalf("expected runtime error, got %v", err)
+	}
+	if svc.pullCalls != 1 {
+		t.Fatalf("expected one pull call, got %d", svc.pullCalls)
 	}
 }

--- a/internal/workspace/manager_legacy_test.go
+++ b/internal/workspace/manager_legacy_test.go
@@ -29,15 +29,25 @@ type legacyRouteTestService struct {
 
 	getContainerBeforeCreateErr error
 	getImageErr                 error
+	getImageErrs                map[string]error
 	pullErr                     error
+	pullErrs                    map[string]error
 	pullCalls                   int
+	pullRefs                    []string
 	getImageCalls               int
+	getImageRefs                []string
 	setupNetworkResults         []ctr.NetworkResult
 	setupNetworkErrs            []error
 }
 
 func (s *legacyRouteTestService) PullImage(_ context.Context, ref string, _ *ctr.PullImageOptions) (ctr.ImageInfo, error) {
 	s.pullCalls++
+	s.pullRefs = append(s.pullRefs, ref)
+	if s.pullErrs != nil {
+		if err, ok := s.pullErrs[ref]; ok {
+			return ctr.ImageInfo{}, err
+		}
+	}
 	if s.pullErr != nil {
 		return ctr.ImageInfo{}, s.pullErr
 	}
@@ -46,6 +56,12 @@ func (s *legacyRouteTestService) PullImage(_ context.Context, ref string, _ *ctr
 
 func (s *legacyRouteTestService) GetImage(_ context.Context, ref string) (ctr.ImageInfo, error) {
 	s.getImageCalls++
+	s.getImageRefs = append(s.getImageRefs, ref)
+	if s.getImageErrs != nil {
+		if err, ok := s.getImageErrs[ref]; ok {
+			return ctr.ImageInfo{}, err
+		}
+	}
 	if s.getImageErr != nil {
 		return ctr.ImageInfo{}, s.getImageErr
 	}

--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -343,15 +343,19 @@ func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
 		return err
 	}
 	if workspaceCfg.Backend != bridge.WorkspaceBackendLocal {
-		if _, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
+		result, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
 			Unpack:        true,
 			StorageDriver: m.cfg.Snapshotter,
-		}); err != nil {
+		})
+		if err != nil {
 			m.logger.Error("setup bot container: prepare image failed",
 				slog.String("bot_id", botID),
 				slog.String("image", image),
 				slog.Any("error", err))
 			return err
+		}
+		if strings.TrimSpace(result.ImageRef) != "" {
+			image = result.ImageRef
 		}
 	} else {
 		image = "local"


### PR DESCRIPTION
## Summary
- Fall back from `docker.io/memohai/vnc:debian` to `memoh.cn/memohai/vnc:debian` when preparing the default VNC workspace image.
- Keep custom images and explicit registry configuration unchanged.
- Use the resolved fallback image when creating containers and recording workspace image metadata.

## Test plan
- `go test ./internal/config ./internal/workspace ./internal/handlers`
- pre-commit hook: `golangci-lint run ./...`, `go test ./...`, `lint-staged`