### PR TITLE
fix(desktop): bundle slim Windows GStreamer runtime

### DIFF
--- a/.github/workflows/electron-ci.yml
+++ b/.github/workflows/electron-ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Typecheck desktop
         run: pnpm --filter @memohai/desktop typecheck
 
+      - name: Cache desktop GStreamer runtime
+        uses: actions/cache@v4
+        with:
+          path: apps/desktop/resources/gstreamer
+          key: ${{ runner.os }}-desktop-gstreamer-${{ hashFiles('apps/desktop/scripts/prepare-gstreamer.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-desktop-gstreamer-
+
       - name: Prepare macOS code signing
         id: mac-signing
         if: ${{ startsWith(matrix.platform, 'macos-') && github.event_name != 'pull_request' && env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,13 @@ jobs:
           cache: true
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
+      - name: Cache desktop GStreamer runtime
+        uses: actions/cache@v4
+        with:
+          path: apps/desktop/resources/gstreamer
+          key: ${{ runner.os }}-desktop-gstreamer-${{ hashFiles('apps/desktop/scripts/prepare-gstreamer.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-desktop-gstreamer-
       - name: Require macOS signing and notarization secrets
         if: ${{ startsWith(matrix.platform, 'macos-') }}
         shell: bash

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -400,6 +400,10 @@ Ports / hosts during dev come from the same `config.toml` the rest of the
 stack reads (via `@memohai/config`). The repo-level `mise run desktop:dev`
 task is the recommended entrypoint when contributing.
 
+Packaged macOS and Windows x64 builds prepare and include the display
+GStreamer runtime under `Resources/gstreamer`. Linux builds currently rely on
+system GStreamer when available.
+
 ## Bundled CLI
 
 The Memoh CLI (Go, source at `cmd/memoh/`) ships inside the desktop

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -39,6 +39,10 @@ pnpm --filter @memohai/desktop build:dir       # unpacked app dir (CI smoke test
 
 Output goes to `apps/desktop/dist/`.
 
+Packaged macOS and Windows x64 builds include the display GStreamer runtime used
+by the local server. Linux builds continue to use system GStreamer when
+available.
+
 ## Icons
 
 All app icons are generated from `apps/web/public/logo.svg` (the brand mark) by

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -35,7 +35,7 @@ function resolveGStreamerTarget(target) {
   if (target.startsWith('darwin-')) {
     return 'darwin-universal'
   }
-  if (target === 'win32-x64' && process.env.GSTREAMER_ENABLE_WINDOWS_BUNDLE) {
+  if (target === 'win32-x64') {
     return 'win32-x64'
   }
   return '__none__'

--- a/apps/desktop/scripts/prepare-gstreamer.mjs
+++ b/apps/desktop/scripts/prepare-gstreamer.mjs
@@ -62,7 +62,7 @@ const displayInspectionElements = [
 
 const runtimeProfile = `display-${createHash('sha256')
   .update(JSON.stringify({
-    layout: 2,
+    layout: 3,
     packages: [...macOSRuntimePackages].sort(),
     plugins: [...displayPluginNames].sort(),
     elements: [...displayInspectionElements].sort(),
@@ -582,6 +582,42 @@ function pruneWindowsLibraries(targetDir, spec) {
       rmSync(resolve(binDir, entry), { force: true })
     }
   }
+  pruneWindowsLibDirectory(targetDir)
+}
+
+function isDisplayPlugin(pluginName) {
+  return displayPluginNames.has(pluginName) || displayPluginNames.has(pluginName.toLowerCase())
+}
+
+function pruneWindowsPluginDirectory(pluginDir) {
+  if (!existsSync(pluginDir)) {
+    return
+  }
+  for (const entry of readdirSync(pluginDir, { withFileTypes: true })) {
+    const entryPath = resolve(pluginDir, entry.name)
+    if (!entry.isFile()) {
+      rmSync(entryPath, { recursive: true, force: true })
+      continue
+    }
+    if (!entry.name.toLowerCase().endsWith('.dll') || !isDisplayPlugin(entry.name)) {
+      rmSync(entryPath, { force: true })
+    }
+  }
+}
+
+function pruneWindowsLibDirectory(targetDir) {
+  const libDir = resolve(targetDir, 'lib')
+  if (!existsSync(libDir)) {
+    return
+  }
+
+  const pluginDirName = 'gstreamer-1.0'
+  for (const entry of readdirSync(libDir)) {
+    if (entry !== pluginDirName) {
+      rmSync(resolve(libDir, entry), { recursive: true, force: true })
+    }
+  }
+  pruneWindowsPluginDirectory(resolve(libDir, pluginDirName))
 }
 
 function pruneRuntimeLayout(targetDir, spec) {

--- a/apps/desktop/scripts/prepare-gstreamer.mjs
+++ b/apps/desktop/scripts/prepare-gstreamer.mjs
@@ -84,7 +84,7 @@ const targetSpecs = {
     binary: 'bin/gst-launch-1.0.exe',
     inspect: 'bin/gst-inspect-1.0.exe',
     scanner: 'libexec/gstreamer-1.0/gst-plugin-scanner.exe',
-    kind: 'windows-nsis',
+    kind: 'windows-inno',
     officialPath: `windows/${gstreamerVersion}/msvc`,
   },
 }
@@ -672,7 +672,18 @@ function findFile(root, fileName) {
   return null
 }
 
-function extractWindowsInstaller(archivePath, targetDir, spec) {
+function windowsInnoInstallerArgs(stagingDir) {
+  return [
+    '/VERYSILENT',
+    '/SUPPRESSMSGBOXES',
+    '/NORESTART',
+    '/SP-',
+    '/NOICONS',
+    `/DIR=${stagingDir}`,
+  ]
+}
+
+function extractWindowsInnoInstaller(archivePath, targetDir, spec) {
   if (process.platform !== 'win32') {
     throw new Error('Preparing the Windows GStreamer runtime requires running the official installer on Windows.')
   }
@@ -680,7 +691,7 @@ function extractWindowsInstaller(archivePath, targetDir, spec) {
   const stagingDir = resolve(tmpdir(), `memoh-gstreamer-runtime-${Date.now()}`)
   rmSync(stagingDir, { recursive: true, force: true })
   mkdirSync(stagingDir, { recursive: true })
-  execFileSync(archivePath, ['/S', `/D=${stagingDir}`], { stdio: 'inherit' })
+  execFileSync(archivePath, windowsInnoInstallerArgs(stagingDir), { stdio: 'inherit' })
 
   const binary = findFile(stagingDir, basename(spec.binary))
   if (!binary) {
@@ -752,8 +763,8 @@ async function prepareTarget(target) {
 
   if (spec.kind === 'macos-pkg') {
     extractMacOSPackage(archivePath, targetDir)
-  } else if (spec.kind === 'windows-nsis') {
-    extractWindowsInstaller(archivePath, targetDir, spec)
+  } else if (spec.kind === 'windows-inno') {
+    extractWindowsInnoInstaller(archivePath, targetDir, spec)
   } else {
     throw new Error(`Unsupported GStreamer package kind: ${spec.kind}`)
   }

--- a/apps/desktop/scripts/prepare-gstreamer.mjs
+++ b/apps/desktop/scripts/prepare-gstreamer.mjs
@@ -62,6 +62,7 @@ const displayInspectionElements = [
 
 const runtimeProfile = `display-${createHash('sha256')
   .update(JSON.stringify({
+    layout: 2,
     packages: [...macOSRuntimePackages].sort(),
     plugins: [...displayPluginNames].sort(),
     elements: [...displayInspectionElements].sort(),
@@ -92,7 +93,7 @@ function currentTarget() {
   if (process.platform === 'darwin') {
     return 'darwin-universal'
   }
-  if (process.platform === 'win32' && process.arch === 'x64' && process.env.GSTREAMER_ENABLE_WINDOWS_BUNDLE) {
+  if (process.platform === 'win32' && process.arch === 'x64') {
     return 'win32-x64'
   }
   return null
@@ -347,6 +348,23 @@ function syncDarwinSymlinkClosure(libDir, neededLibraries) {
   }
 }
 
+function displayRuntimeSeedPaths(targetDir, spec, pluginExtension) {
+  const pluginDir = resolve(targetDir, 'lib', 'gstreamer-1.0')
+  const seedPaths = [
+    resolve(targetDir, spec.binary),
+    resolve(targetDir, spec.inspect),
+    resolve(targetDir, spec.scanner),
+  ]
+  if (existsSync(pluginDir)) {
+    for (const pluginName of readdirSync(pluginDir)) {
+      if (pluginName.endsWith(pluginExtension)) {
+        seedPaths.push(resolve(pluginDir, pluginName))
+      }
+    }
+  }
+  return seedPaths
+}
+
 function collectDarwinLibraryDependencies(targetDir, seedPaths) {
   const libDir = resolve(targetDir, 'lib')
   const neededLibraries = new Set()
@@ -382,20 +400,7 @@ function pruneDarwinLibraries(targetDir, spec) {
   }
 
   const libDir = resolve(targetDir, 'lib')
-  const pluginDir = resolve(libDir, 'gstreamer-1.0')
-  const seedPaths = [
-    resolve(targetDir, spec.binary),
-    resolve(targetDir, spec.inspect),
-    resolve(targetDir, spec.scanner),
-  ]
-  if (existsSync(pluginDir)) {
-    for (const pluginName of readdirSync(pluginDir)) {
-      if (pluginName.endsWith('.dylib')) {
-        seedPaths.push(resolve(pluginDir, pluginName))
-      }
-    }
-  }
-
+  const seedPaths = displayRuntimeSeedPaths(targetDir, spec, '.dylib')
   const neededLibraries = collectDarwinLibraryDependencies(targetDir, seedPaths)
   for (const entry of readdirSync(libDir)) {
     if (entry === 'gstreamer-1.0') {
@@ -409,6 +414,173 @@ function pruneDarwinLibraries(targetDir, spec) {
       continue
     }
     rmSync(entryPath, { recursive: true, force: true })
+  }
+}
+
+function readCString(buffer, offset) {
+  if (offset < 0 || offset >= buffer.length) {
+    return null
+  }
+  let end = offset
+  while (end < buffer.length && buffer[end] !== 0) {
+    end += 1
+  }
+  return buffer.subarray(offset, end).toString('ascii')
+}
+
+function parsePEImage(buffer) {
+  if (buffer.length < 0x40 || buffer.toString('ascii', 0, 2) !== 'MZ') {
+    return null
+  }
+  const peOffset = buffer.readUInt32LE(0x3c)
+  if (peOffset + 24 > buffer.length || buffer.readUInt32LE(peOffset) !== 0x00004550) {
+    return null
+  }
+
+  const sectionCount = buffer.readUInt16LE(peOffset + 6)
+  const optionalHeaderSize = buffer.readUInt16LE(peOffset + 20)
+  const optionalHeaderOffset = peOffset + 24
+  if (optionalHeaderOffset + optionalHeaderSize > buffer.length) {
+    return null
+  }
+
+  const optionalMagic = buffer.readUInt16LE(optionalHeaderOffset)
+  const dataDirectoryOffset = optionalHeaderOffset + (
+    optionalMagic === 0x20b ? 112 : optionalMagic === 0x10b ? 96 : 0
+  )
+  if (dataDirectoryOffset === optionalHeaderOffset || dataDirectoryOffset + 14 * 8 > buffer.length) {
+    return null
+  }
+
+  const sectionTableOffset = optionalHeaderOffset + optionalHeaderSize
+  const sections = []
+  for (let index = 0; index < sectionCount; index += 1) {
+    const sectionOffset = sectionTableOffset + index * 40
+    if (sectionOffset + 40 > buffer.length) {
+      break
+    }
+    sections.push({
+      virtualSize: buffer.readUInt32LE(sectionOffset + 8),
+      virtualAddress: buffer.readUInt32LE(sectionOffset + 12),
+      rawSize: buffer.readUInt32LE(sectionOffset + 16),
+      rawOffset: buffer.readUInt32LE(sectionOffset + 20),
+    })
+  }
+
+  return {
+    dataDirectoryOffset,
+    rvaToOffset(rva) {
+      for (const section of sections) {
+        const size = Math.max(section.virtualSize, section.rawSize)
+        if (rva >= section.virtualAddress && rva < section.virtualAddress + size) {
+          const offset = section.rawOffset + rva - section.virtualAddress
+          return offset >= 0 && offset < buffer.length ? offset : null
+        }
+      }
+      return rva >= 0 && rva < buffer.length ? rva : null
+    },
+  }
+}
+
+function descriptorIsEmpty(buffer, offset, size) {
+  for (let index = 0; index < size; index += 4) {
+    if (buffer.readUInt32LE(offset + index) !== 0) {
+      return false
+    }
+  }
+  return true
+}
+
+function collectPEImportNames(filePath) {
+  const buffer = readFileSync(filePath)
+  const image = parsePEImage(buffer)
+  if (!image) {
+    return []
+  }
+
+  const names = new Set()
+  const readDirectory = (directoryIndex, descriptorSize, nameRvaOffset) => {
+    const directoryOffset = image.dataDirectoryOffset + directoryIndex * 8
+    const rva = buffer.readUInt32LE(directoryOffset)
+    const size = buffer.readUInt32LE(directoryOffset + 4)
+    if (!rva || !size) {
+      return
+    }
+
+    let descriptorOffset = image.rvaToOffset(rva)
+    if (descriptorOffset === null) {
+      return
+    }
+    const descriptorEnd = Math.min(buffer.length, descriptorOffset + size)
+    while (descriptorOffset + descriptorSize <= descriptorEnd) {
+      if (descriptorIsEmpty(buffer, descriptorOffset, descriptorSize)) {
+        break
+      }
+      const nameRva = buffer.readUInt32LE(descriptorOffset + nameRvaOffset)
+      const nameOffset = image.rvaToOffset(nameRva)
+      const name = nameOffset === null ? null : readCString(buffer, nameOffset)
+      if (name) {
+        names.add(name)
+      }
+      descriptorOffset += descriptorSize
+    }
+  }
+
+  readDirectory(1, 20, 12)
+  readDirectory(13, 32, 4)
+  return [...names]
+}
+
+function collectWindowsLibraryDependencies(targetDir, seedPaths) {
+  const binDir = resolve(targetDir, 'bin')
+  const availableLibraries = new Map()
+  for (const entry of readdirSync(binDir)) {
+    if (entry.toLowerCase().endsWith('.dll')) {
+      availableLibraries.set(entry.toLowerCase(), entry)
+    }
+  }
+
+  const neededLibraries = new Set()
+  const queue = seedPaths.filter(existsSync)
+  for (let index = 0; index < queue.length; index += 1) {
+    const binaryPath = queue[index]
+    let imports
+    try {
+      imports = collectPEImportNames(binaryPath)
+    } catch (error) {
+      console.warn(
+        `Could not inspect Windows GStreamer dependencies for ${basename(binaryPath)}: ${formatDownloadError(error)}`,
+      )
+      continue
+    }
+    for (const dependency of imports) {
+      const libraryName = availableLibraries.get(dependency.toLowerCase())
+      if (!libraryName || neededLibraries.has(libraryName)) {
+        continue
+      }
+      neededLibraries.add(libraryName)
+      queue.push(resolve(binDir, libraryName))
+    }
+  }
+  return neededLibraries
+}
+
+function pruneWindowsLibraries(targetDir, spec) {
+  if (process.env.GSTREAMER_KEEP_ALL_LIBS || process.platform !== 'win32') {
+    return
+  }
+
+  const binDir = resolve(targetDir, 'bin')
+  if (!existsSync(binDir)) {
+    return
+  }
+
+  const seedPaths = displayRuntimeSeedPaths(targetDir, spec, '.dll')
+  const neededLibraries = collectWindowsLibraryDependencies(targetDir, seedPaths)
+  for (const entry of readdirSync(binDir)) {
+    if (entry.toLowerCase().endsWith('.dll') && !neededLibraries.has(entry)) {
+      rmSync(resolve(binDir, entry), { force: true })
+    }
   }
 }
 
@@ -479,6 +651,7 @@ function stripDarwinBinaries(targetDir) {
 function pruneDisplayRuntime(targetDir, spec) {
   pruneDisplayPlugins(targetDir)
   pruneDarwinLibraries(targetDir, spec)
+  pruneWindowsLibraries(targetDir, spec)
   pruneRuntimeLayout(targetDir, spec)
   stripDarwinBinaries(targetDir)
 }

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -441,6 +441,7 @@ function spawnServer(command: ServerCommand): ChildProcess {
     cwd: command.cwd,
     detached: true,
     stdio: 'ignore',
+    windowsHide: process.platform === 'win32',
     env: serverEnv(command),
   })
   child.unref()
@@ -493,6 +494,7 @@ function runServerCommand(
   const result = spawnSync(command.command, serverArgs, {
     cwd: command.cwd,
     encoding: 'utf8',
+    windowsHide: process.platform === 'win32',
     env: serverEnv(command),
   })
   appendLog(`$ ${command.command} ${serverArgs.join(' ')}\nstatus=${String(result.status)} error=${result.error?.message ?? ''}\nstdout:\n${result.stdout ?? ''}\nstderr:\n${result.stderr ?? ''}`)

--- a/apps/desktop/src/main/qdrant.ts
+++ b/apps/desktop/src/main/qdrant.ts
@@ -251,6 +251,7 @@ async function spawnQdrant(binaryPath: string, ports: QdrantPorts, releaseReserv
         cwd: qdrantRootPath(),
         detached: true,
         stdio: ['ignore', logFd, logFd],
+        windowsHide: process.platform === 'win32',
         env: {
           ...process.env,
           QDRANT__TELEMETRY_DISABLED: 'true',

--- a/internal/display/service.go
+++ b/internal/display/service.go
@@ -1236,12 +1236,22 @@ func resolveExecutable(candidate string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		if !isUsableExecutable(info, runtime.GOOS) {
 			return "", fmt.Errorf("%s is not executable", cleanPath)
 		}
 		return cleanPath, nil
 	}
 	return exec.LookPath(candidate)
+}
+
+func isUsableExecutable(info os.FileInfo, goos string) bool {
+	if info.IsDir() {
+		return false
+	}
+	if goos == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
 }
 
 func isSocketReady(ctx context.Context, path string) bool {

--- a/internal/display/service.go
+++ b/internal/display/service.go
@@ -318,6 +318,7 @@ func (s *Service) Screenshot(ctx context.Context, botID string) ([]byte, string,
 
 	proxyPort := proxy.Addr().(*net.TCPAddr).Port
 	cmd := exec.CommandContext(runCtx, gstLaunch, gstreamerScreenshotArgs(proxyPort, outputPath)...) //nolint:gosec // executable is resolved from PATH or explicit admin env.
+	hideCommandWindow(cmd)
 	cmd.Stdout = processLogWriter{logger: s.logger, botID: botID}
 	cmd.Stderr = processLogWriter{logger: s.logger, botID: botID}
 	if err := cmd.Run(); err != nil {
@@ -524,6 +525,7 @@ func (s *session) start(ctx context.Context) error {
 	rtpPort := udp.LocalAddr().(*net.UDPAddr).Port
 	args := gstreamerArgs(s.codec, proxyPort, rtpPort)
 	cmd := exec.CommandContext(runCtx, s.gstLaunch, args...) //nolint:gosec // executable is resolved from PATH or explicit admin env.
+	hideCommandWindow(cmd)
 	cmd.Stdout = processLogWriter{logger: s.service.logger, botID: s.botID}
 	cmd.Stderr = processLogWriter{logger: s.service.logger, botID: s.botID}
 	if err := cmd.Start(); err != nil {

--- a/internal/display/service_other.go
+++ b/internal/display/service_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package display
+
+import "os/exec"
+
+func hideCommandWindow(_ *exec.Cmd) {}

--- a/internal/display/service_test.go
+++ b/internal/display/service_test.go
@@ -237,6 +237,32 @@ func TestNegotiateCodecNoMatch(t *testing.T) {
 	}
 }
 
+func TestIsUsableExecutableAllowsWindowsFilesWithoutExecuteBits(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gst-launch-1.0.exe")
+	if err := os.WriteFile(path, []byte("fake exe"), 0o600); err != nil {
+		t.Fatalf("write test executable: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat test executable: %v", err)
+	}
+	if !isUsableExecutable(info, "windows") {
+		t.Fatal("Windows absolute executable paths must not require Unix execute bits")
+	}
+	if isUsableExecutable(info, "linux") {
+		t.Fatal("non-Windows executable paths must still require Unix execute bits")
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	if isUsableExecutable(dirInfo, "windows") {
+		t.Fatal("directories must not be treated as Windows executables")
+	}
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {

--- a/internal/display/service_windows.go
+++ b/internal/display/service_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package display
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func hideCommandWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
## Summary
- Bundle the display GStreamer runtime for Windows x64 desktop packages by default.
- Prune the Windows GStreamer bundle to the display plugin set and recursively keep only imported DLL dependencies.
- Document the desktop packaging behavior for bundled GStreamer runtimes.

## Test plan
- [x] `node --check apps/desktop/scripts/prepare-gstreamer.mjs`
- [x] `node --check apps/desktop/scripts/build.mjs`
- [x] `node apps/desktop/scripts/prepare-gstreamer.mjs --targets=none`
- [x] Commit hook Go test suite and staged ESLint checks

## Notes
- Draft until Windows package preparation is validated on a Windows builder, because the official GStreamer installer extraction must run on Windows.