### PR TITLE
remove an unusable button.

### DIFF
--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -96,14 +96,6 @@
                 </FormControl>
               </FormItem>
             </FormField>
-            <div class="flex">
-              <a
-                href="#"
-                class="ml-auto inline-block text-xs underline mt-2"
-              >
-                {{ $t('auth.forgotPassword') }}
-              </a>
-            </div>
           </CardContent>
 
           <CardFooter>


### PR DESCRIPTION
remove an unusable button.

`href = #` does nothing but surprises the user.

rather remove it (or place a todo) than having a broken link there.