### PR TITLE
fix: make nginx upstream configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
   web:
     image: memohai/web:latest
     container_name: memoh-web
+    environment:
+      MEMOH_SERVER_UPSTREAM: ${MEMOH_SERVER_UPSTREAM:-server:8080}
     ports:
       - "8082:8082"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     image: memohai/web:latest
     container_name: memoh-web
     environment:
-      MEMOH_SERVER_UPSTREAM: ${MEMOH_SERVER_UPSTREAM:-server:8080}
+      MEMOH_SERVER_UPSTREAM: ${MEMOH_SERVER_UPSTREAM:-memoh-server:8080}
     ports:
       - "8082:8082"
     depends_on:

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -24,7 +24,9 @@ FROM nginx:alpine
 
 COPY --from=builder /build/apps/web/dist /usr/share/nginx/html
 
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+ENV MEMOH_SERVER_UPSTREAM=server:8080
+
+COPY docker/nginx.conf /etc/nginx/templates/default.conf.template
 
 EXPOSE 8082
 

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -24,7 +24,7 @@ FROM nginx:alpine
 
 COPY --from=builder /build/apps/web/dist /usr/share/nginx/html
 
-ENV MEMOH_SERVER_UPSTREAM=server:8080
+ENV MEMOH_SERVER_UPSTREAM=memoh-server:8080
 
 COPY docker/nginx.conf /etc/nginx/templates/default.conf.template
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,12 +40,12 @@ server {
 
     # Swagger 文档（保留 /api 前缀）
     location ~ ^/api/(docs(?:/.*)?|swagger\.json)$ {
-        proxy_pass http://memoh-server:8080;
+        proxy_pass http://${MEMOH_SERVER_UPSTREAM};
     }
 
     # API 代理（其余 /api/* 去掉 /api 前缀转发）
     location /api/ {
-        proxy_pass http://memoh-server:8080/;
+        proxy_pass http://${MEMOH_SERVER_UPSTREAM}/;
     }
 
     # 静态资源缓存


### PR DESCRIPTION
## Summary
- Make the web Nginx API upstream configurable via `MEMOH_SERVER_UPSTREAM`.
- Keep the default upstream compatible with the previous `memoh-server:8080` target.
- Render `docker/nginx.conf` through the official Nginx template path so deployments can override the backend target.

Fixes #428

## Validation
- `nginx -t` after rendering `docker/nginx.conf` with `MEMOH_SERVER_UPSTREAM=memoh-server:8080`
- `git diff --check`
