### PR TITLE
test(dingtalk): cover adapter message handling

### DIFF
--- a/internal/channel/adapters/dingtalk/config_test.go
+++ b/internal/channel/adapters/dingtalk/config_test.go
@@ -1,0 +1,100 @@
+package dingtalk
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestNormalizeConfigSupportsCamelAndSnakeKeys(t *testing.T) {
+	got, err := normalizeConfig(map[string]any{
+		"app_key":    " app-key ",
+		"app_secret": " secret ",
+	})
+	if err != nil {
+		t.Fatalf("normalizeConfig error = %v", err)
+	}
+	if got["appKey"] != "app-key" || got["appSecret"] != "secret" {
+		t.Fatalf("unexpected normalized config: %#v", got)
+	}
+}
+
+func TestNormalizeConfigRequiresCredentials(t *testing.T) {
+	if _, err := normalizeConfig(map[string]any{"appKey": "app"}); err == nil {
+		t.Fatal("expected missing appSecret error")
+	}
+}
+
+func TestNormalizeUserConfigAndResolveTarget(t *testing.T) {
+	raw := map[string]any{
+		"userId":             " user-1 ",
+		"openConversationId": " group-1 ",
+		"displayName":        " Alice ",
+	}
+	got, err := normalizeUserConfig(raw)
+	if err != nil {
+		t.Fatalf("normalizeUserConfig error = %v", err)
+	}
+	if got["user_id"] != "user-1" || got["open_conversation_id"] != "group-1" || got["display_name"] != "Alice" {
+		t.Fatalf("unexpected normalized user config: %#v", got)
+	}
+
+	target, err := resolveTarget(raw)
+	if err != nil {
+		t.Fatalf("resolveTarget error = %v", err)
+	}
+	if target != "group:group-1" {
+		t.Fatalf("target = %q, want group:group-1", target)
+	}
+}
+
+func TestNormalizeUserConfigRequiresDeliveryTarget(t *testing.T) {
+	if _, err := normalizeUserConfig(map[string]any{"displayName": "Alice"}); err == nil {
+		t.Fatal("expected missing delivery target error")
+	}
+}
+
+func TestNormalizeTarget(t *testing.T) {
+	tests := map[string]string{
+		" user:alice ":                    "user:alice",
+		"user_id:bob":                     "user:bob",
+		"group:cid-1":                     "group:cid-1",
+		"open_conversation_id:cid-2":      "group:cid-2",
+		"bare-user-id":                    "user:bare-user-id",
+		"open_conversation_id:   cid-3  ": "group:cid-3",
+	}
+
+	for input, want := range tests {
+		if got := normalizeTarget(input); got != want {
+			t.Fatalf("normalizeTarget(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestMatchBindingAndBuildUserConfig(t *testing.T) {
+	binding := map[string]any{
+		"user_id":              "staff-1",
+		"open_conversation_id": "group-1",
+	}
+	if !matchBinding(binding, channel.BindingCriteria{Attributes: map[string]string{"staff_id": "staff-1"}}) {
+		t.Fatal("expected staff_id to match user binding")
+	}
+	if !matchBinding(binding, channel.BindingCriteria{SubjectID: "group-1"}) {
+		t.Fatal("expected subject id to match group binding")
+	}
+	if matchBinding(binding, channel.BindingCriteria{SubjectID: "other"}) {
+		t.Fatal("did not expect unrelated subject to match")
+	}
+
+	got := buildUserConfig(channel.Identity{
+		DisplayName: "Alice",
+		Attributes: map[string]string{
+			"staff_id":             "staff-2",
+			"user_id":              "union-2",
+			"open_conversation_id": "group-2",
+		},
+	})
+	if got["user_id"] != "staff-2" || got["open_conversation_id"] != "group-2" || got["display_name"] != "Alice" {
+		t.Fatalf("unexpected built user config: %#v", got)
+	}
+}

--- a/internal/channel/adapters/dingtalk/inbound_test.go
+++ b/internal/channel/adapters/dingtalk/inbound_test.go
@@ -1,0 +1,156 @@
+package dingtalk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/memohai/dingtalk-stream-sdk-go/chatbot"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestBuildInboundMessageTextGroup(t *testing.T) {
+	createdAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC).UnixMilli()
+	msg, ok := buildInboundMessage(&chatbot.BotCallbackDataModel{
+		MsgId:             "msg-1",
+		Msgtype:           "text",
+		Text:              chatbot.BotCallbackDataTextModel{Content: " hello "},
+		ConversationType:  "2",
+		ConversationId:    "cid-1",
+		ConversationTitle: "Project Room",
+		SenderId:          "union-1",
+		SenderStaffId:     "staff-1",
+		SenderNick:        "Alice",
+		SenderCorpId:      "corp-1",
+		ChatbotCorpId:     "bot-corp",
+		ChatbotUserId:     "bot-user",
+		CreateAt:          createdAt,
+		IsAdmin:           true,
+	})
+	if !ok {
+		t.Fatal("expected inbound message")
+	}
+	if msg.Channel != Type {
+		t.Fatalf("channel = %q, want %q", msg.Channel, Type)
+	}
+	if msg.Message.ID != "msg-1" || msg.Message.Text != "hello" || msg.Message.Format != channel.MessageFormatPlain {
+		t.Fatalf("unexpected message: %#v", msg.Message)
+	}
+	if msg.ReplyTarget != "group:cid-1" {
+		t.Fatalf("reply target = %q, want group:cid-1", msg.ReplyTarget)
+	}
+	if msg.Sender.SubjectID != "staff-1" || msg.Sender.Attributes["user_id"] != "union-1" {
+		t.Fatalf("unexpected sender: %#v", msg.Sender)
+	}
+	if msg.Conversation.ID != "cid-1" || msg.Conversation.Type != channel.ConversationTypeGroup || msg.Conversation.Name != "Project Room" {
+		t.Fatalf("unexpected conversation: %#v", msg.Conversation)
+	}
+	if got := msg.ReceivedAt; !got.Equal(time.UnixMilli(createdAt).UTC()) {
+		t.Fatalf("received at = %s, want %s", got, time.UnixMilli(createdAt).UTC())
+	}
+	if msg.Metadata["is_admin"] != true || msg.Metadata["conversation_id"] != "cid-1" {
+		t.Fatalf("unexpected metadata: %#v", msg.Metadata)
+	}
+}
+
+func TestBuildInboundMessagePrivatePrefersStaffIDReplyTarget(t *testing.T) {
+	msg, ok := buildInboundMessage(&chatbot.BotCallbackDataModel{
+		MsgId:            "msg-2",
+		Msgtype:          "text",
+		Text:             chatbot.BotCallbackDataTextModel{Content: "ping"},
+		ConversationType: "1",
+		ConversationId:   "private-conv",
+		SenderId:         "union-2",
+		SenderStaffId:    "staff-2",
+	})
+	if !ok {
+		t.Fatal("expected inbound message")
+	}
+	if msg.ReplyTarget != "user:staff-2" {
+		t.Fatalf("reply target = %q, want user:staff-2", msg.ReplyTarget)
+	}
+	if msg.Conversation.Type != channel.ConversationTypePrivate {
+		t.Fatalf("conversation type = %q, want private", msg.Conversation.Type)
+	}
+}
+
+func TestExtractContentAttachments(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     *chatbot.BotCallbackDataModel
+		wantType channel.AttachmentType
+		wantKey  string
+	}{
+		{
+			name: "picture",
+			data: &chatbot.BotCallbackDataModel{
+				Msgtype: "picture",
+				Content: map[string]any{"downloadCode": "dl-img", "width": float64(640), "height": float64(480)},
+			},
+			wantType: channel.AttachmentImage,
+			wantKey:  "dl-img",
+		},
+		{
+			name: "file",
+			data: &chatbot.BotCallbackDataModel{
+				Msgtype: "file",
+				Content: map[string]any{"downloadCode": "dl-file", "fileName": "report.pdf"},
+			},
+			wantType: channel.AttachmentFile,
+			wantKey:  "dl-file",
+		},
+		{
+			name: "video",
+			data: &chatbot.BotCallbackDataModel{
+				Msgtype: "video",
+				Content: map[string]any{"videoMediaId": "video-1", "duration": float64(12)},
+			},
+			wantType: channel.AttachmentVideo,
+			wantKey:  "video-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, _, attachments := extractContent(tt.data)
+			if text != "" {
+				t.Fatalf("text = %q, want empty", text)
+			}
+			if len(attachments) != 1 {
+				t.Fatalf("attachments len = %d, want 1", len(attachments))
+			}
+			if attachments[0].Type != tt.wantType || attachments[0].PlatformKey != tt.wantKey || attachments[0].SourcePlatform != Type.String() {
+				t.Fatalf("unexpected attachment: %#v", attachments[0])
+			}
+		})
+	}
+}
+
+func TestExtractContentAudioRecognitionAndRichText(t *testing.T) {
+	text, format, attachments := extractContent(&chatbot.BotCallbackDataModel{
+		Msgtype: "audio",
+		Content: map[string]any{"recognition": "voice transcript", "downloadCode": "voice-code"},
+	})
+	if text != "voice transcript" || format != channel.MessageFormatPlain || len(attachments) != 0 {
+		t.Fatalf("unexpected audio recognition result: text=%q format=%q attachments=%#v", text, format, attachments)
+	}
+
+	text, format, attachments = extractRichText(map[string]any{
+		"richText": []map[string]any{
+			{"type": "text", "text": "hello"},
+			{"type": "picture", "downloadCode": "pic-1", "width": 320, "height": 200},
+		},
+	})
+	if text != "hello" || format != channel.MessageFormatPlain || len(attachments) != 1 {
+		t.Fatalf("unexpected richtext result: text=%q format=%q attachments=%#v", text, format, attachments)
+	}
+	if attachments[0].Type != channel.AttachmentImage || attachments[0].PlatformKey != "pic-1" {
+		t.Fatalf("unexpected richtext attachment: %#v", attachments[0])
+	}
+}
+
+func TestBuildInboundMessageIgnoresEmptyContent(t *testing.T) {
+	if _, ok := buildInboundMessage(&chatbot.BotCallbackDataModel{Msgtype: "unknown"}); ok {
+		t.Fatal("expected empty callback to be ignored")
+	}
+}

--- a/internal/channel/adapters/dingtalk/outbound_test.go
+++ b/internal/channel/adapters/dingtalk/outbound_test.go
@@ -1,0 +1,136 @@
+package dingtalk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestBuildAPIPayloadTextAndMarkdown(t *testing.T) {
+	msgKey, msgParam, err := buildAPIPayload(channel.Message{
+		Format: channel.MessageFormatPlain,
+		Text:   " hello ",
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildAPIPayload text error = %v", err)
+	}
+	if msgKey != "sampleText" {
+		t.Fatalf("text msgKey = %q, want sampleText", msgKey)
+	}
+	assertJSONField(t, msgParam, "content", "hello")
+
+	msgKey, msgParam, err = buildAPIPayload(channel.Message{
+		Format: channel.MessageFormatMarkdown,
+		Text:   "# Release Notes\n\nShip it",
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildAPIPayload markdown error = %v", err)
+	}
+	if msgKey != "sampleMarkdown" {
+		t.Fatalf("markdown msgKey = %q, want sampleMarkdown", msgKey)
+	}
+	assertJSONField(t, msgParam, "title", "Release Notes")
+	assertJSONField(t, msgParam, "text", "# Release Notes\n\nShip it")
+}
+
+func TestBuildAPIPayloadRejectsEmptyMessage(t *testing.T) {
+	if _, _, err := buildAPIPayload(channel.Message{}, nil); err == nil {
+		t.Fatal("expected empty message error")
+	}
+}
+
+func TestBuildAttachmentPayloadImageURLAndFileRef(t *testing.T) {
+	msgKey, msgParam, err := buildAttachmentPayload(channel.PreparedAttachment{
+		Kind:      channel.PreparedAttachmentPublicURL,
+		PublicURL: "https://example.com/image.png",
+		Logical:   channel.Attachment{Type: channel.AttachmentImage, Name: "image.png"},
+	})
+	if err != nil {
+		t.Fatalf("buildAttachmentPayload image error = %v", err)
+	}
+	if msgKey != "sampleImageMsg" {
+		t.Fatalf("image msgKey = %q, want sampleImageMsg", msgKey)
+	}
+	assertJSONField(t, msgParam, "photoURL", "https://example.com/image.png")
+
+	msgKey, msgParam, err = buildAttachmentPayload(channel.PreparedAttachment{
+		Kind:      channel.PreparedAttachmentNativeRef,
+		NativeRef: "media-1",
+		Logical: channel.Attachment{
+			Type: channel.AttachmentFile,
+			Name: "report.PDF",
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildAttachmentPayload file error = %v", err)
+	}
+	if msgKey != "sampleFile" {
+		t.Fatalf("file msgKey = %q, want sampleFile", msgKey)
+	}
+	assertJSONField(t, msgParam, "mediaId", "media-1")
+	assertJSONField(t, msgParam, "fileName", "report.PDF")
+	assertJSONField(t, msgParam, "fileType", "pdf")
+}
+
+func TestBuildAttachmentPayloadRequiresImageReference(t *testing.T) {
+	if _, _, err := buildAttachmentPayload(channel.PreparedAttachment{
+		Logical: channel.Attachment{Type: channel.AttachmentImage},
+	}); err == nil {
+		t.Fatal("expected missing image reference error")
+	}
+}
+
+func TestBuildWebhookBody(t *testing.T) {
+	body, err := buildWebhookBody(channel.Message{
+		Format: channel.MessageFormatMarkdown,
+		Text:   "## Status\nAll green",
+	})
+	if err != nil {
+		t.Fatalf("buildWebhookBody error = %v", err)
+	}
+	if body["msgtype"] != "markdown" {
+		t.Fatalf("msgtype = %v, want markdown", body["msgtype"])
+	}
+	markdown, ok := body["markdown"].(map[string]string)
+	if !ok {
+		t.Fatalf("markdown body has unexpected shape: %#v", body["markdown"])
+	}
+	if markdown["title"] != "Status" || markdown["text"] != "## Status\nAll green" {
+		t.Fatalf("unexpected markdown payload: %#v", markdown)
+	}
+
+	body, err = buildWebhookBody(channel.Message{
+		Attachments: []channel.Attachment{{Type: channel.AttachmentFile, Name: "report.pdf"}},
+	})
+	if err != nil {
+		t.Fatalf("buildWebhookBody attachment fallback error = %v", err)
+	}
+	text, ok := body["text"].(map[string]string)
+	if !ok || text["content"] != "[attachment]" {
+		t.Fatalf("unexpected attachment fallback body: %#v", body)
+	}
+}
+
+func TestExtractMarkdownTitleAndFileExt(t *testing.T) {
+	if got := extractMarkdownTitle("# 1234567890123456789012345"); got != "12345678901234567890" {
+		t.Fatalf("extractMarkdownTitle = %q, want first 20 runes", got)
+	}
+	if got := fileExtFromName("Report.PDF"); got != "pdf" {
+		t.Fatalf("fileExtFromName = %q, want pdf", got)
+	}
+	if got := resolveFileType(channel.Attachment{Name: "archive.tar.gz"}); got != "gz" {
+		t.Fatalf("resolveFileType = %q, want gz", got)
+	}
+}
+
+func assertJSONField(t *testing.T, raw, key string, want string) {
+	t.Helper()
+	var values map[string]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error = %v", raw, err)
+	}
+	if values[key] != want {
+		t.Fatalf("json field %q = %q, want %q (raw %s)", key, values[key], want, raw)
+	}
+}

--- a/internal/channel/adapters/dingtalk/stream_test.go
+++ b/internal/channel/adapters/dingtalk/stream_test.go
@@ -1,0 +1,130 @@
+package dingtalk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestOutboundStreamSnapshotBuffersVisibleTextAndAttachments(t *testing.T) {
+	reply := &channel.ReplyRef{MessageID: "msg-1", Target: "user:alice"}
+	stream := &dingtalkOutboundStream{
+		target: "user:alice",
+		reply:  reply,
+	}
+
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{
+		Type:  channel.StreamEventDelta,
+		Delta: "Thinking...",
+		Phase: channel.StreamPhaseReasoning,
+	}); err != nil {
+		t.Fatalf("reasoning Push error = %v", err)
+	}
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{
+		Type:  channel.StreamEventDelta,
+		Delta: "Hello ",
+	}); err != nil {
+		t.Fatalf("first delta Push error = %v", err)
+	}
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{
+		Type:  channel.StreamEventDelta,
+		Delta: "world",
+	}); err != nil {
+		t.Fatalf("second delta Push error = %v", err)
+	}
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{
+		Type: channel.StreamEventAttachment,
+		Attachments: []channel.PreparedAttachment{{
+			Kind:    channel.PreparedAttachmentPublicURL,
+			Logical: channel.Attachment{Type: channel.AttachmentImage, URL: "https://example.com/a.png"},
+		}},
+	}); err != nil {
+		t.Fatalf("attachment Push error = %v", err)
+	}
+
+	got := stream.snapshotPrepared()
+	if got.Message.Text != "Hello world" {
+		t.Fatalf("snapshot text = %q, want Hello world", got.Message.Text)
+	}
+	if len(got.Attachments) != 1 || len(got.Message.Attachments) != 1 {
+		t.Fatalf("expected prepared and logical attachments, got prepared=%d logical=%d", len(got.Attachments), len(got.Message.Attachments))
+	}
+	if got.Message.Reply != reply {
+		t.Fatalf("reply was not applied: %#v", got.Message.Reply)
+	}
+}
+
+func TestOutboundStreamSnapshotFinalMessageWinsOverBufferedText(t *testing.T) {
+	stream := &dingtalkOutboundStream{}
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{
+		Type:  channel.StreamEventDelta,
+		Delta: "partial",
+	}); err != nil {
+		t.Fatalf("delta Push error = %v", err)
+	}
+	stream.final = &channel.PreparedMessage{
+		Message: channel.Message{Text: "final"},
+	}
+
+	got := stream.snapshotPrepared()
+	if got.Message.Text != "final" {
+		t.Fatalf("snapshot text = %q, want final", got.Message.Text)
+	}
+}
+
+func TestOutboundStreamRejectsPushAfterClose(t *testing.T) {
+	stream := &dingtalkOutboundStream{}
+	if err := stream.Close(context.Background()); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+	if err := stream.Push(context.Background(), channel.PreparedStreamEvent{Type: channel.StreamEventDelta, Delta: "late"}); err == nil {
+		t.Fatal("expected push after close error")
+	}
+}
+
+func TestSessionWebhookCacheExpiryAndValidity(t *testing.T) {
+	cache := newSessionWebhookCache(time.Hour)
+	cache.put("msg-1", sessionWebhookContext{
+		SessionWebhook: "https://example.com/hook",
+		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
+	})
+	got, ok := cache.get("msg-1")
+	if !ok {
+		t.Fatal("expected cached webhook")
+	}
+	if !got.isValid() {
+		t.Fatal("expected webhook to be valid")
+	}
+
+	cache.put("msg-2", sessionWebhookContext{
+		SessionWebhook: "https://example.com/old",
+		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
+		CreatedAt:      time.Now().Add(-2 * time.Hour),
+	})
+	if _, ok := cache.get("msg-2"); ok {
+		t.Fatal("expected stale webhook to be evicted")
+	}
+
+	if (sessionWebhookContext{SessionWebhook: "https://example.com/expired", ExpiredTime: time.Now().Add(-time.Second).UnixMilli()}).isValid() {
+		t.Fatal("expected expired webhook to be invalid")
+	}
+}
+
+func TestOpenStreamUsesSourceMessageIDAsReply(t *testing.T) {
+	adapter := NewDingTalkAdapter(nil)
+	stream, err := adapter.OpenStream(context.Background(), channel.ChannelConfig{}, "user:alice", channel.StreamOptions{
+		SourceMessageID: "source-1",
+	})
+	if err != nil {
+		t.Fatalf("OpenStream error = %v", err)
+	}
+	dtStream, ok := stream.(*dingtalkOutboundStream)
+	if !ok {
+		t.Fatalf("stream type = %T, want *dingtalkOutboundStream", stream)
+	}
+	if dtStream.reply == nil || dtStream.reply.MessageID != "source-1" || dtStream.reply.Target != "user:alice" {
+		t.Fatalf("unexpected reply: %#v", dtStream.reply)
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit coverage for DingTalk config normalization and delivery target resolution.
- Cover inbound text, group/private routing, attachments, audio recognition, and rich text extraction.
- Cover outbound text, markdown, attachment payloads, webhook fallback, stream buffering, and session webhook cache behavior.

## Validation
- `go test ./internal/channel/adapters/dingtalk`
- `git diff --check`
