### PR TITLE
fix(desktop): add docker host detection

### DIFF
--- a/apps/desktop/src/main/docker-host.test.ts
+++ b/apps/desktop/src/main/docker-host.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { join } from 'node:path'
+import { detectDockerHost } from './docker-host'
+
+function detectDockerHostWithFixtures(
+  home: string,
+  fixtures: {
+    dirs?: Record<string, string[]>
+    env?: NodeJS.ProcessEnv
+    files?: Record<string, string>
+    inspectDockerContext?: () => string
+    platform?: NodeJS.Platform
+    sockets?: string[]
+  },
+): string {
+  return detectDockerHost(home, {
+    env: fixtures.env ?? {},
+    exists: path => fixtures.sockets?.includes(path) ?? false,
+    inspectDockerContext: fixtures.inspectDockerContext ?? (() => ''),
+    platform: fixtures.platform ?? 'darwin',
+    readDir: path => fixtures.dirs?.[path] ?? [],
+    readTextFile: path => fixtures.files?.[path],
+  })
+}
+
+describe('detectDockerHost', () => {
+  const home = '/Users/ran'
+  const metaRoot = join(home, '.docker', 'contexts', 'meta')
+
+  it('uses DOCKER_HOST before probing contexts or socket paths', () => {
+    expect(detectDockerHostWithFixtures(home, {
+      env: { DOCKER_HOST: 'tcp://docker.example.test:2376' },
+      inspectDockerContext: () => 'unix:///should-not-be-used.sock',
+      sockets: ['/var/run/docker.sock'],
+    })).toBe('tcp://docker.example.test:2376')
+  })
+
+  it('uses the current Docker context metadata before stale macOS sockets', () => {
+    expect(detectDockerHostWithFixtures(home, {
+      dirs: { [metaRoot]: ['orbstack-context'] },
+      files: {
+        [join(home, '.docker', 'config.json')]: JSON.stringify({ currentContext: 'orbstack' }),
+        [join(metaRoot, 'orbstack-context', 'meta.json')]: JSON.stringify({
+          Name: 'orbstack',
+          Endpoints: { docker: { Host: 'unix:///Users/ran/.orbstack/run/docker.sock' } },
+        }),
+      },
+      sockets: [
+        join(home, '.docker', 'run', 'docker.sock'),
+        '/var/run/docker.sock',
+      ],
+    })).toBe('unix:///Users/ran/.orbstack/run/docker.sock')
+  })
+
+  it('lets DOCKER_CONTEXT override the configured current context', () => {
+    expect(detectDockerHostWithFixtures(home, {
+      dirs: { [metaRoot]: ['desktop', 'orbstack'] },
+      env: { DOCKER_CONTEXT: 'orbstack' },
+      files: {
+        [join(home, '.docker', 'config.json')]: JSON.stringify({ currentContext: 'desktop-linux' }),
+        [join(metaRoot, 'desktop', 'meta.json')]: JSON.stringify({
+          Name: 'desktop-linux',
+          Endpoints: { docker: { Host: 'unix:///Users/ran/.docker/run/docker.sock' } },
+        }),
+        [join(metaRoot, 'orbstack', 'meta.json')]: JSON.stringify({
+          Name: 'orbstack',
+          Endpoints: { docker: { Host: 'unix:///Users/ran/.orbstack/run/docker.sock' } },
+        }),
+      },
+    })).toBe('unix:///Users/ran/.orbstack/run/docker.sock')
+  })
+
+  it('reads Docker context data from DOCKER_CONFIG when present', () => {
+    const dockerConfig = '/tmp/custom-docker-config'
+    const customMetaRoot = join(dockerConfig, 'contexts', 'meta')
+
+    expect(detectDockerHostWithFixtures(home, {
+      dirs: { [customMetaRoot]: ['colima'] },
+      env: { DOCKER_CONFIG: dockerConfig },
+      files: {
+        [join(dockerConfig, 'config.json')]: JSON.stringify({ currentContext: 'colima' }),
+        [join(customMetaRoot, 'colima', 'meta.json')]: JSON.stringify({
+          Name: 'colima',
+          Endpoints: { docker: { Host: 'unix:///Users/ran/.colima/default/docker.sock' } },
+        }),
+      },
+    })).toBe('unix:///Users/ran/.colima/default/docker.sock')
+  })
+
+  it('falls back to /var/run/docker.sock before Docker Desktop user sockets on macOS', () => {
+    expect(detectDockerHostWithFixtures(home, {
+      sockets: [
+        join(home, '.docker', 'run', 'docker.sock'),
+        '/var/run/docker.sock',
+      ],
+    })).toBe('unix:///var/run/docker.sock')
+  })
+
+  it('falls back to rootless Docker sockets on Linux', () => {
+    expect(detectDockerHostWithFixtures('/home/ran', {
+      env: { XDG_RUNTIME_DIR: '/run/user/501' },
+      platform: 'linux',
+      sockets: ['/run/user/501/docker.sock'],
+    })).toBe('unix:///run/user/501/docker.sock')
+  })
+
+  it('keeps Windows on Docker defaults unless env or context provides a host', () => {
+    expect(detectDockerHostWithFixtures('C:\\Users\\ran', {
+      platform: 'win32',
+      sockets: ['C:\\Users\\ran\\.docker\\run\\docker.sock'],
+    })).toBe('')
+  })
+
+  it('supports Windows named pipe hosts from Docker context metadata', () => {
+    const windowsHome = 'C:\\Users\\ran'
+    const windowsMetaRoot = join(windowsHome, '.docker', 'contexts', 'meta')
+
+    expect(detectDockerHostWithFixtures(windowsHome, {
+      dirs: { [windowsMetaRoot]: ['desktop'] },
+      env: { DOCKER_CONTEXT: 'desktop-linux' },
+      files: {
+        [join(windowsMetaRoot, 'desktop', 'meta.json')]: JSON.stringify({
+          Name: 'desktop-linux',
+          Endpoints: { docker: { Host: 'npipe:////./pipe/dockerDesktopLinuxEngine' } },
+        }),
+      },
+      platform: 'win32',
+    })).toBe('npipe:////./pipe/dockerDesktopLinuxEngine')
+  })
+})

--- a/apps/desktop/src/main/docker-host.ts
+++ b/apps/desktop/src/main/docker-host.ts
@@ -1,0 +1,162 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface DockerHostDetectionOptions {
+  env?: NodeJS.ProcessEnv
+  exists?: (path: string) => boolean
+  inspectDockerContext?: () => string
+  platform?: NodeJS.Platform
+  readDir?: (path: string) => string[]
+  readTextFile?: (path: string) => string | undefined
+}
+
+export function detectDockerHost(home: string, options: DockerHostDetectionOptions = {}): string {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const exists = options.exists ?? existsSync
+  const envHost = normalizeDockerHost(env.DOCKER_HOST)
+  if (envHost) {
+    return envHost
+  }
+
+  const contextHost = detectDockerContextHost(home, { ...options, env })
+  if (contextHost) {
+    return contextHost
+  }
+
+  const inspectedHost = normalizeDockerHost((options.inspectDockerContext ?? inspectDockerContextHost)())
+  if (inspectedHost) {
+    return inspectedHost
+  }
+
+  const candidates = dockerSocketCandidates(home, platform, env)
+  for (const socketPath of candidates) {
+    if (exists(socketPath)) {
+      return `unix://${socketPath}`
+    }
+  }
+  return ''
+}
+
+function detectDockerContextHost(home: string, options: DockerHostDetectionOptions): string {
+  const contextName = normalizeDockerContextName(options.env?.DOCKER_CONTEXT)
+    || dockerCurrentContextFromConfig(home, options)
+  if (!contextName || contextName === 'default') {
+    return ''
+  }
+  return dockerHostFromContextMetadata(home, contextName, options)
+}
+
+function dockerCurrentContextFromConfig(home: string, options: DockerHostDetectionOptions): string {
+  const raw = readDockerTextFile(join(dockerConfigDir(home, options), 'config.json'), options)
+  if (!raw) {
+    return ''
+  }
+  try {
+    const parsed = JSON.parse(raw) as { currentContext?: unknown }
+    return normalizeDockerContextName(parsed.currentContext)
+  } catch {
+    return ''
+  }
+}
+
+function dockerHostFromContextMetadata(home: string, contextName: string, options: DockerHostDetectionOptions): string {
+  const metaRoot = join(dockerConfigDir(home, options), 'contexts', 'meta')
+  for (const entry of readDockerDir(metaRoot, options)) {
+    const raw = readDockerTextFile(join(metaRoot, entry, 'meta.json'), options)
+    if (!raw) {
+      continue
+    }
+    try {
+      const parsed = JSON.parse(raw) as {
+        Endpoints?: { docker?: { Host?: unknown } }
+        Name?: unknown
+      }
+      if (parsed.Name !== contextName) {
+        continue
+      }
+      return normalizeDockerHost(parsed.Endpoints?.docker?.Host)
+    } catch {
+      continue
+    }
+  }
+  return ''
+}
+
+function dockerConfigDir(home: string, options: DockerHostDetectionOptions): string {
+  return options.env?.DOCKER_CONFIG?.trim() || join(home, '.docker')
+}
+
+function inspectDockerContextHost(): string {
+  const result = spawnSync('docker', ['context', 'inspect', '--format', '{{ .Endpoints.docker.Host }}'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 2000,
+  })
+  if (result.error || result.status !== 0) {
+    return ''
+  }
+  return result.stdout
+}
+
+function dockerSocketCandidates(home: string, platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] {
+  if (platform === 'win32') {
+    return []
+  }
+  if (platform === 'darwin') {
+    return [
+      '/var/run/docker.sock',
+      join(home, '.orbstack', 'run', 'docker.sock'),
+      join(home, '.colima', 'default', 'docker.sock'),
+      join(home, '.docker', 'run', 'docker.sock'),
+    ]
+  }
+  const candidates = ['/var/run/docker.sock']
+  const runtimeDir = env.XDG_RUNTIME_DIR?.trim()
+  if (runtimeDir) {
+    candidates.push(join(runtimeDir, 'docker.sock'))
+  }
+  candidates.push(
+    join(home, '.docker', 'desktop', 'docker.sock'),
+    join(home, '.colima', 'default', 'docker.sock'),
+  )
+  return candidates
+}
+
+function readDockerTextFile(path: string, options: DockerHostDetectionOptions): string | undefined {
+  if (options.readTextFile) {
+    return options.readTextFile(path)
+  }
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return undefined
+  }
+}
+
+function readDockerDir(path: string, options: DockerHostDetectionOptions): string[] {
+  if (options.readDir) {
+    return options.readDir(path)
+  }
+  try {
+    return readdirSync(path)
+  } catch {
+    return []
+  }
+}
+
+function normalizeDockerContextName(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeDockerHost(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  const host = value.split(/\r?\n/).map(line => line.trim()).find(Boolean) ?? ''
+  if (!host || host === '<no value>' || host === '<nil>' || host === 'null') {
+    return ''
+  }
+  return host
+}

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -13,6 +13,7 @@ import {
   type ManagedPid,
 } from './daemon'
 import { bundledGStreamerEnv } from './gstreamer'
+import { detectDockerHost } from './docker-host'
 import { desktopResourcePath, desktopServerWorkDir, repoRoot } from './paths'
 
 export const LOCAL_SERVER_PORT = 18731
@@ -237,23 +238,6 @@ function toAbsoluteConfigPath(cwd: string, value: string): string {
     return value
   }
   return join(cwd, value)
-}
-
-function detectDockerHost(home: string): string {
-  const envHost = process.env.DOCKER_HOST?.trim()
-  if (envHost) {
-    return envHost
-  }
-  const candidates = [
-    join(home, '.docker', 'run', 'docker.sock'),
-    '/var/run/docker.sock',
-  ]
-  for (const socketPath of candidates) {
-    if (existsSync(socketPath)) {
-      return `unix://${socketPath}`
-    }
-  }
-  return ''
 }
 
 function setDockerHostIfEmpty(contents: string, dockerHost: string): string {


### PR DESCRIPTION
## Summary

- Honor `DOCKER_HOST`, Docker context metadata, and `DOCKER_CONFIG` before probing socket fallbacks.
- Prefer the active Docker context so OrbStack, Colima, Docker Desktop, and custom contexts route to the daemon the user selected.
- Update platform fallbacks for macOS and Linux, while leaving Windows on Docker SDK defaults unless env/context supplies a host such as a named pipe.
- Add regression coverage for OrbStack/Docker Desktop socket conflicts, Colima-style context paths, Linux rootless sockets, and Windows named pipes.

## Root Cause

The desktop local-server config writer probed `~/.docker/run/docker.sock` before Docker context data or `/var/run/docker.sock`. On macOS machines where OrbStack is the active context but Docker Desktop's user socket still exists, Memoh can select Docker Desktop or a stale socket instead of OrbStack.

## Validation

- `pnpm exec vitest run apps/desktop/src/main/local-server.test.ts`
- `pnpm --filter @memohai/desktop typecheck:node`
- `pnpm exec eslint apps/desktop/src/main/local-server.ts apps/desktop/src/main/local-server.test.ts`
- Commit hook Go test suite completed successfully.

Closes #486