### PR TITLE
fix: pagination layout issue and missing skeleton in Bot Overview

### DIFF
--- a/apps/web/src/pages/bots/components/bot-compaction.vue
+++ b/apps/web/src/pages/bots/components/bot-compaction.vue
@@ -495,8 +495,8 @@ onMounted(() => {
               @update:page="currentPage = $event"
             >
               <PaginationContent v-slot="{ items }">
-                <PaginationFirst class="h-7 w-7" />
-                <PaginationPrevious class="h-7 w-7" />
+                <PaginationFirst class="h-7" />
+                <PaginationPrevious class="h-7" />
                 <template
                   v-for="(item, index) in items"
                   :key="index"
@@ -504,17 +504,17 @@ onMounted(() => {
                   <PaginationEllipsis
                     v-if="item.type === 'ellipsis'"
                     :index="index"
-                    class="h-7 w-7"
+                    class="h-7"
                   />
                   <PaginationItem
                     v-else
                     :value="item.value"
                     :is-active="item.value === currentPage"
-                    class="h-7 w-7 text-[11px]"
+                    class="h-7  text-[11px]"
                   />
                 </template>
-                <PaginationNext class="h-7 w-7" />
-                <PaginationLast class="h-7 w-7" />
+                <PaginationNext class="h-7" />
+                <PaginationLast class="h-7" />
               </PaginationContent>
             </Pagination>
           </div>

--- a/apps/web/src/pages/bots/components/bot-heartbeat.vue
+++ b/apps/web/src/pages/bots/components/bot-heartbeat.vue
@@ -209,7 +209,7 @@
 
           <!-- Card Body / Result Summary -->
           <div 
-            v-if="!expandedIds.has(log.id)"
+            v-if="!expandedIds.has(log.id!)"
             class="pl-4"
           >
             <p 
@@ -271,8 +271,8 @@
           @update:page="currentPage = $event"
         >
           <PaginationContent v-slot="{ items }">
-            <PaginationFirst class="h-8 w-8" />
-            <PaginationPrevious class="h-8 w-8" />
+            <PaginationFirst class="h-8 " />
+            <PaginationPrevious class="h-8" />
             <template
               v-for="(item, index) in items"
               :key="index"
@@ -285,11 +285,11 @@
                 v-else
                 :value="item.value"
                 :is-active="item.value === currentPage"
-                class="h-8 w-8 text-[11px]"
+                class="h-8 text-[11px]"
               />
             </template>
-            <PaginationNext class="h-8 w-8" />
-            <PaginationLast class="h-8 w-8" />
+            <PaginationNext class="h-8" />
+            <PaginationLast class="h-8" />
           </PaginationContent>
         </Pagination>
       </div>

--- a/apps/web/src/pages/bots/components/bot-mcp.vue
+++ b/apps/web/src/pages/bots/components/bot-mcp.vue
@@ -627,7 +627,7 @@
                   v-for="tool in displayTools.slice(0, 5)"
                   :key="tool.name"
                   variant="secondary"
-                  class="text-[10px] font-mono hover:bg-secondary/80 cursor-default shadow-none border border-border bg-muted max-w-[140px] truncate"
+                  class="text-[10px] font-mono hover:bg-secondary/80 cursor-default shadow-none border border-border bg-muted max-w-35 truncate"
                   :title="tool.description"
                 >
                   {{ tool.name }}

--- a/apps/web/src/pages/bots/components/bot-network.vue
+++ b/apps/web/src/pages/bots/components/bot-network.vue
@@ -224,7 +224,7 @@
             <div class="space-y-0.5 flex-1 pr-4">
               <Label class="text-[11px] font-medium text-foreground/70">{{ $t('bots.settings.overlayProviderFieldLabel') }}</Label>
             </div>
-            <div class="shrink-0 flex justify-end min-w-[160px] max-w-[320px] w-full">
+            <div class="shrink-0 flex justify-end min-w-40 max-w-[320px] w-full">
               <OverlayProviderSelect
                 v-model="form.overlay_provider"
                 :providers="overlayProviderMeta"
@@ -296,7 +296,7 @@
                   <!-- Standard Fields (Horizontal) -->
                   <div 
                     v-else
-                    class="flex items-center justify-between gap-6 py-4 border-b border-border/40 last:border-0 min-h-[64px]"
+                    class="flex items-center justify-between gap-6 py-4 border-b border-border/40 last:border-0 min-h-16"
                   >
                     <div class="space-y-0.5 flex-1 pr-4">
                       <Label
@@ -493,7 +493,7 @@
                           </p>
                         </div>
 
-                        <div class="shrink-0 flex justify-end min-w-[160px] max-w-[320px] w-full">
+                        <div class="shrink-0 flex justify-end min-w-40 max-w-[320px] w-full">
                           <!-- Switch for Bool -->
                           <Switch
                             v-if="field.type === 'bool'"

--- a/apps/web/src/pages/bots/components/bot-overview.vue
+++ b/apps/web/src/pages/bots/components/bot-overview.vue
@@ -86,7 +86,7 @@
           </div>
           
           <!-- Segmented Progress Bar -->
-          <div class="mt-3 min-h-[32px] flex items-center w-full">
+          <div class="mt-3 min-h-8 flex items-center w-full">
             <div class="flex gap-1 h-1.5 w-full">
               <div 
                 v-for="(check, index) in checks" 
@@ -153,29 +153,23 @@
           {{ $t('bots.checks.empty') }}
         </p>
       </div>
-
+    
       <!-- Loading State -->
       <div
-        v-else-if="checksLoading && checks.length === 0"
+        v-else-if="checksLoading && checks.length == 0"
         class="space-y-2"
       >
         <div
           v-for="i in 5"
           :key="i"
-          class="rounded-md border transition-opacity opacity-60"
+          class="rounded-md border transition-opacity opacity-60 px-3"
         >
-          <div class="flex w-full items-center justify-between gap-3 px-3 py-2">
-            <div class="flex items-center gap-3 min-w-0 w-full">
-              <div class="w-4 h-4 shrink-0 rounded-full bg-muted/40 animate-pulse" />
-              <div class="min-w-0 space-y-0.5 w-full">
-                <div class="h-3 w-32 rounded bg-muted/40 animate-pulse" />
-              </div>
-            </div>
-            <div class="size-4 shrink-0 rounded-sm bg-muted/40 animate-pulse" />
+          <div class="flex items-center justify-between gap-3  py-2 overflow-hidden rounded-sm">
+            <Skeleton class="h-4 w-full" />
+            <!-- <div class="size-4 shrink-0 rounded-sm bg-muted/40 animate-pulse" /> -->
           </div>
         </div>
       </div>
-
       <!-- Smart Collapsible List -->
       <div
         v-else
@@ -184,13 +178,13 @@
         <Collapsible
           v-for="item in checks"
           :key="item.id"
-          :open="expandedIds.has(item.id)"
+          :open="expandedIds.has(item.id!)"
           class="rounded-md border transition-opacity"
           :class="item.status === 'ok' ? 'opacity-60 hover:opacity-100' : 'opacity-100'"
         >
           <CollapsibleTrigger 
             class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-accent/40"
-            @click="toggleItem(item.id)"
+            @click="toggleItem(item.id!)"
           >
             <div class="flex items-center gap-3 min-w-0">
               <component 
@@ -211,7 +205,7 @@
             </div>
             <ChevronRight 
               class="size-4 shrink-0 text-muted-foreground transition-transform duration-200"
-              :class="{ 'rotate-90': expandedIds.has(item.id) }"
+              :class="{ 'rotate-90': expandedIds.has(item.id!) }"
             />
           </CollapsibleTrigger>
           
@@ -242,7 +236,7 @@
             </div>
           </CollapsibleContent>
         </Collapsible>
-      </div>
+      </div>     
     </div>
   </div>
 </template>
@@ -263,7 +257,8 @@ import {
   Spinner, 
   Collapsible, 
   CollapsibleTrigger, 
-  CollapsibleContent 
+  CollapsibleContent,
+  Skeleton
 } from '@memohai/ui'
 import { 
   CheckCircle2, 
@@ -279,7 +274,6 @@ import {
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { useBotStatusMeta } from '@/composables/useBotStatusMeta'
 import { useSyncedQueryParam } from '@/composables/useSyncedQueryParam'
-
 type BotCheck = BotsBotCheck
 
 const checksLoading = ref(false)

--- a/apps/web/src/pages/bots/components/bot-schedule.vue
+++ b/apps/web/src/pages/bots/components/bot-schedule.vue
@@ -170,7 +170,7 @@
                   <Textarea
                     id="schedule-command"
                     v-model="form.command"
-                    class="text-xs shadow-none border-border/60 min-h-[60px] bg-transparent font-mono pr-8"
+                    class="text-xs shadow-none border-border/60 min-h-15 bg-transparent font-mono pr-8"
                     :placeholder="$t('bots.schedule.form.commandPlaceholder')"
                     rows="2"
                   />
@@ -334,7 +334,7 @@
           class="bg-background border border-border/60 rounded-md shadow-none flex flex-col overflow-hidden"
         >
           <div class="overflow-x-auto">
-            <table class="w-full text-xs border-collapse min-w-[800px]">
+            <table class="w-full text-xs border-collapse min-w-200">
               <thead>
                 <tr class="border-b border-border/50 bg-muted/40">
                   <th class="px-4 py-2.5 text-left font-semibold text-foreground/80 whitespace-nowrap">
@@ -365,7 +365,7 @@
                   @click="handleEdit(item)"
                 >
                   <!-- Identity -->
-                  <td class="px-4 py-3 align-middle min-w-[200px]">
+                  <td class="px-4 py-3 align-middle min-w-50">
                     <div class="font-medium text-foreground">
                       {{ item.name }}
                     </div>

--- a/apps/web/src/pages/bots/components/model-select.vue
+++ b/apps/web/src/pages/bots/components/model-select.vue
@@ -20,7 +20,7 @@
       </Button>
     </PopoverTrigger>
     <PopoverContent
-      class="w-[--reka-popover-trigger-width] p-0 shadow-md rounded-[8px]"
+      class="w-[--reka-popover-trigger-width] p-0 shadow-md rounded-xl"
       align="start"
     >
       <ModelOptions


### PR DESCRIPTION
1. 分页器错乱
<img width="797" height="71" alt="image" src="https://github.com/user-attachments/assets/e9594b5e-733e-4cea-bf7d-737f0b2e5f78" />

2. Bot的Overview里面加载时候没有使用骨架屏，造成短暂白屏