### PR TITLE
fix(docker): passthrough host proxy env vars to server container

### DIFF
--- a/devenv/docker-compose.minify.yml
+++ b/devenv/docker-compose.minify.yml
@@ -81,9 +81,19 @@ services:
     privileged: true
     pid: host
     command: ["air", "-c", ".air.toml"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       CONFIG_PATH: /workspace/devenv/app.dev.toml
       GOFLAGS: -buildvcs=false
+      # Proxy: use host.docker.internal for localhost proxies, e.g.
+      #   HTTP_PROXY=http://host.docker.internal:7890 mise run dev
+      HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
+      HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,qdrant,sparse,server,web,migrate,deps,memoh-dev-postgres,memoh-dev-qdrant,memoh-dev-sparse,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps"
+      http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
+      https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,qdrant,sparse,server,web,migrate,deps,memoh-dev-postgres,memoh-dev-qdrant,memoh-dev-sparse,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MIN:-30000}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MAX:-30100}"
     volumes:

--- a/devenv/docker-compose.sqlite.minify.yml
+++ b/devenv/docker-compose.sqlite.minify.yml
@@ -61,9 +61,19 @@ services:
     privileged: true
     pid: host
     command: ["air", "-c", ".air.toml"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       CONFIG_PATH: /workspace/devenv/app.sqlite.dev.toml
       GOFLAGS: -buildvcs=false
+      # Proxy: use host.docker.internal for localhost proxies, e.g.
+      #   HTTP_PROXY=http://host.docker.internal:7890 mise run dev:sqlite:minify
+      HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
+      HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},qdrant,sparse,server,web,migrate,deps,memoh-dev-sqlite-qdrant,memoh-dev-sqlite-sparse,memoh-dev-sqlite-server,memoh-dev-sqlite-web,memoh-dev-sqlite-migrate,memoh-dev-sqlite-deps"
+      http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
+      https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},qdrant,sparse,server,web,migrate,deps,memoh-dev-sqlite-qdrant,memoh-dev-sqlite-sparse,memoh-dev-sqlite-server,memoh-dev-sqlite-web,memoh-dev-sqlite-migrate,memoh-dev-sqlite-deps"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_SQLITE_DEV_DISPLAY_WEBRTC_UDP_PORT_MIN:-30200}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_SQLITE_DEV_DISPLAY_WEBRTC_UDP_PORT_MAX:-30300}"
     volumes:

--- a/devenv/docker-compose.sqlite.yml
+++ b/devenv/docker-compose.sqlite.yml
@@ -61,9 +61,19 @@ services:
     privileged: true
     pid: host
     command: ["air", "-c", ".air.toml"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       CONFIG_PATH: /workspace/devenv/app.sqlite.dev.toml
       GOFLAGS: -buildvcs=false
+      # Proxy: use host.docker.internal for localhost proxies, e.g.
+      #   HTTP_PROXY=http://host.docker.internal:7890 mise run dev:sqlite
+      HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
+      HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},qdrant,sparse,server,web,migrate,deps,memoh-dev-sqlite-qdrant,memoh-dev-sqlite-sparse,memoh-dev-sqlite-server,memoh-dev-sqlite-web,memoh-dev-sqlite-migrate,memoh-dev-sqlite-deps"
+      http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
+      https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},qdrant,sparse,server,web,migrate,deps,memoh-dev-sqlite-qdrant,memoh-dev-sqlite-sparse,memoh-dev-sqlite-server,memoh-dev-sqlite-web,memoh-dev-sqlite-migrate,memoh-dev-sqlite-deps"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_SQLITE_DEV_DISPLAY_WEBRTC_UDP_PORT_MIN:-30200}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_SQLITE_DEV_DISPLAY_WEBRTC_UDP_PORT_MAX:-30300}"
     volumes:

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -81,9 +81,19 @@ services:
     privileged: true
     pid: host
     command: ["air", "-c", ".air.toml"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       CONFIG_PATH: /workspace/devenv/app.dev.toml
       GOFLAGS: -buildvcs=false
+      # Proxy: use host.docker.internal for localhost proxies, e.g.
+      #   HTTP_PROXY=http://host.docker.internal:7890 mise run dev
+      HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
+      HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,qdrant,sparse,server,web,migrate,deps,memoh-dev-postgres,memoh-dev-qdrant,memoh-dev-sparse,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps"
+      http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
+      https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,qdrant,sparse,server,web,migrate,deps,memoh-dev-postgres,memoh-dev-qdrant,memoh-dev-sparse,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MIN:-30000}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MAX:-30100}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,17 @@ services:
     container_name: memoh-server
     privileged: true
     pid: host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
+      # Proxy: use host.docker.internal for localhost proxies, e.g.
+      #   HTTP_PROXY=http://host.docker.internal:7890 docker compose up -d
+      HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
+      HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,qdrant,sparse,server,web,migrate,memoh-postgres,memoh-qdrant,memoh-sparse,memoh-server,memoh-web,memoh-migrate"
+      http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
+      https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,qdrant,sparse,server,web,migrate,memoh-postgres,memoh-qdrant,memoh-sparse,memoh-server,memoh-web,memoh-migrate"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN:-30000}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX:-30100}"
     volumes:


### PR DESCRIPTION
Closes #495

## Summary

- Passthrough `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and lowercase variants) from host to the server container across all 5 compose files (prod + 4 dev variants)
- Upper/lowercase env vars cross-fallback so either casing works on the host side
- Add `extra_hosts: ["host.docker.internal:host-gateway"]` for Linux native Docker compatibility (macOS/Windows Docker Desktop already has this built-in)
- `NO_PROXY` defaults to `127.0.0.1,localhost` and always appends all internal compose service/container names to prevent internal traffic from being routed through the proxy

## Usage

For localhost proxies, use `host.docker.internal` instead of `127.0.0.1`:

```bash
# macOS / Windows / Linux
HTTP_PROXY=http://host.docker.internal:7890 HTTPS_PROXY=http://host.docker.internal:7890 docker compose up -d

# Dev
HTTP_PROXY=http://host.docker.internal:7890 HTTPS_PROXY=http://host.docker.internal:7890 mise run dev
```

For LAN/remote proxies, use the actual IP directly.

## Test plan

- [x] Verified on macOS Docker Desktop with `HTTP_PROXY=http://host.docker.internal:19881`
- [x] Server container correctly receives proxy env vars
- [x] Health check (`wget` to `127.0.0.1:8080`) bypasses proxy via `NO_PROXY`
- [x] Internal service communication (postgres, qdrant, etc.) bypasses proxy