### PR TITLE
fix: backport tabbar offset fix to v0.9

### DIFF
--- a/apps/web/src/pages/home/components/workspace-tab-bar.vue
+++ b/apps/web/src/pages/home/components/workspace-tab-bar.vue
@@ -14,6 +14,7 @@
           ? 'bg-sidebar-accent text-sidebar-accent-foreground'
           : 'text-muted-foreground hover:bg-sidebar-accent/40 hover:text-foreground'"
         :title="resolveTitle(tab)"
+        style="margin-top:var(--pos-tab-bar)"
         @click="store.setActive(tab.id)"
       >
         <component
@@ -44,6 +45,7 @@
         class="inline-flex items-center justify-center size-8 rounded-md text-muted-foreground hover:bg-sidebar-accent/40 hover:text-foreground transition-colors [-webkit-app-region:no-drag]"
         :title="t('chat.tabBarToolkit.newTerminal')"
         :aria-label="t('chat.tabBarToolkit.newTerminal')"
+        
         @click="store.openTerminal()"
       >
         <TerminalSquare class="size-4" />
@@ -114,19 +116,14 @@ const tabRefs = new Map<string, HTMLElement>()
 useResizeObserver(tabsContainerRef, () => {
   const offsetNum = tabsContainerRef.value?.offsetHeight
   const clientNum = tabsContainerRef.value?.clientHeight
-  if (typeof offsetNum !== 'number' || typeof clientNum !== 'number') {
+  if (typeof offsetNum !== 'number' || typeof clientNum !== 'number'|| !tabsContainerRef.value) {
     return
   }
   if (offsetNum === clientNum) {   
-    tabRefs.values().forEach(el => {
-      el.style.marginTop = '0px'
-    })
-   
+    tabsContainerRef.value.style.cssText = '--pos-tab-bar:0px'
   } else {
     const pos = offsetNum - clientNum
-    tabRefs.values().forEach(el => {
-      el.style.marginTop = `${pos}px` 
-    })   
+    tabsContainerRef.value.style.cssText = `--pos-tab-bar:${pos}px`
   }
 })
 

--- a/internal/workspace/bridgesvc/exit_code_test.go
+++ b/internal/workspace/bridgesvc/exit_code_test.go
@@ -25,7 +25,7 @@ func TestResolveExitCodeFromCommands(t *testing.T) {
 	}{
 		{"clean_exit", "true", 0},
 		{"explicit_exit_42", "exit 42", 42},
-		{"sh_handles_sigterm", "echo hi; kill -SIGTERM $$", 1}, // shell wraps it
+		{"shell_sigterm", "echo hi; kill -TERM $$", 128 + 15},
 		{"direct_sigkill", "exec sh -c 'echo hi; kill -KILL $$'", 128 + 9},
 		{"direct_sigterm", "exec sh -c 'kill -TERM $$'", 128 + 15},
 		{"direct_sigint", "exec sh -c 'kill -INT $$'", 128 + 2},


### PR DESCRIPTION
## Summary
- backport the tabbar initial offset fix onto a clean v0.9 branch
- avoid the old fix/web branch history that reintroduced already-backported commits
- make the bridgesvc SIGTERM test portable across Ubuntu /bin/sh implementations

## Verification
- go test -race -coverprofile=/tmp/memoh-coverage.txt -covermode=atomic ./...
