### PR TITLE
perf(web): virtualize model picker and searchable select dropdowns

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@shikijs/transformers": "^4.0.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/vue-table": "^8.21.3",
+    "@tanstack/vue-virtual": "^3.12.0",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^14.1.0",
     "@vueuse/integrations": "^14.2.1",

--- a/apps/web/src/components/searchable-select-popover/index.vue
+++ b/apps/web/src/components/searchable-select-popover/index.vue
@@ -28,7 +28,8 @@
       </slot>
     </PopoverTrigger>
     <PopoverContent
-      class="w-[--reka-popover-trigger-width] p-0"
+      class="p-0"
+      :style="{ width: 'calc(var(--reka-popover-trigger-width) * 0.55)' }"
       align="start"
     >
       <div class="flex items-center border-b px-3">
@@ -44,79 +45,89 @@
       </div>
 
       <div
-        class="max-h-64 overflow-y-auto"
+        ref="scrollEl"
+        class="max-h-64 overflow-y-auto px-1"
         role="listbox"
       >
         <div
-          v-if="filteredGroups.length === 0"
+          v-if="rows.length === 0"
           class="py-6 text-center text-xs text-muted-foreground"
         >
           {{ emptyText }}
         </div>
 
         <div
-          v-for="group in filteredGroups"
-          :key="group.key"
-          class="p-1 *:mt-1 overflow-hidden"
+          v-else
+          :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }"
         >
           <div
-            v-if="showGroupHeaders && group.label"
-            class="px-2 py-1.5 text-xs font-medium text-muted-foreground"
+            v-for="vRow in virtualRows"
+            :key="vRow.key"
+            :ref="measureRow"
+            :data-index="vRow.virtual.index"
+            class="py-0.5"
+            :style="{ position: 'absolute', top: '0', left: '0', width: '100%', transform: `translateY(${vRow.virtual.start}px)` }"
           >
-            <slot
-              name="group-label"
-              :group="group"
+            <div
+              v-if="vRow.row.type === 'header'"
+              class="px-2 py-1.5 text-xs font-medium text-muted-foreground"
             >
-              {{ group.label }}
-            </slot>
-          </div>
+              <slot
+                name="group-label"
+                :group="vRow.row.group"
+              >
+                {{ vRow.row.group.label }}
+              </slot>
+            </div>
 
-          <button
-            v-for="option in group.items"
-            :key="option.value"
-            type="button"
-            role="option"
-            :aria-selected="selected === option.value"
-            class="relative flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground"
-            :class="{ 'bg-accent': selected === option.value }"
-            @click="selectOption(option.value)"
-          >
-            <Check
-              v-if="selected === option.value"
-              class="size-3.5 shrink-0"
-            />
-            <span
+            <button
               v-else
-              class="size-3.5 shrink-0"
-            />
-            <slot
-              name="option-icon"
-              :option="option"
-            />
-            <span class="flex min-w-0 flex-1 items-center gap-2">
+              type="button"
+              role="option"
+              :aria-selected="selected === vRow.row.option.value"
+              :aria-setsize="optionCount"
+              :aria-posinset="vRow.row.posinset"
+              class="relative flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground"
+              :class="{ 'bg-accent': selected === vRow.row.option.value }"
+              @click="selectOption(vRow.row.option.value)"
+            >
+              <Check
+                v-if="selected === vRow.row.option.value"
+                class="size-3.5 shrink-0"
+              />
+              <span
+                v-else
+                class="size-3.5 shrink-0"
+              />
               <slot
-                name="option-label"
-                :option="option"
-              >
-                <span
-                  class="truncate flex-1 text-left"
-                  :title="option.label"
-                >{{ option.label }}</span>
-              </slot>
-              <slot
-                name="option-suffix"
-                :option="option"
-              >
-                <span
-                  v-if="option.description"
-                  class="ml-auto text-xs text-muted-foreground truncate max-w-[80%] text-right"
-                  :title="option.description"
+                name="option-icon"
+                :option="vRow.row.option"
+              />
+              <span class="flex min-w-0 flex-1 items-center gap-2">
+                <slot
+                  name="option-label"
+                  :option="vRow.row.option"
                 >
-                  {{ option.description }}
-                </span>
-              </slot>
-            </span>
-          </button>
+                  <span
+                    class="truncate flex-1 text-left"
+                    :title="vRow.row.option.label"
+                  >{{ vRow.row.option.label }}</span>
+                </slot>
+                <slot
+                  name="option-suffix"
+                  :option="vRow.row.option"
+                >
+                  <span
+                    v-if="vRow.row.option.description"
+                    class="ml-auto text-xs text-muted-foreground truncate max-w-[80%] text-right"
+                    :title="vRow.row.option.description"
+                  >
+                    {{ vRow.row.option.description }}
+                  </span>
+                </slot>
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </PopoverContent>
@@ -131,7 +142,8 @@ import {
   PopoverContent,
   Button,
 } from '@memohai/ui'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 
 export interface SearchableSelectOption {
   value: string
@@ -142,6 +154,28 @@ export interface SearchableSelectOption {
   keywords?: string[]
   meta?: unknown
 }
+
+interface SearchableSelectGroup {
+  key: string
+  label: string
+  items: SearchableSelectOption[]
+}
+
+interface HeaderRow {
+  type: 'header'
+  key: string
+  group: SearchableSelectGroup
+}
+
+interface ItemRow {
+  type: 'item'
+  key: string
+  option: SearchableSelectOption
+  // 1-based position among option rows (excludes headers), for aria-posinset
+  posinset: number
+}
+
+type Row = HeaderRow | ItemRow
 
 const props = withDefaults(defineProps<{
   options: SearchableSelectOption[]
@@ -163,12 +197,7 @@ const props = withDefaults(defineProps<{
 const selected = defineModel<string>({ default: '' })
 const searchTerm = ref('')
 const open = ref(false)
-
-watch(open, (value) => {
-  if (value) {
-    searchTerm.value = ''
-  }
-})
+const scrollEl = ref<HTMLElement | null>(null)
 
 const selectedOption = computed(() =>
   props.options.find((option) => option.value === selected.value),
@@ -192,8 +221,8 @@ const filteredOptions = computed(() => {
   })
 })
 
-const filteredGroups = computed(() => {
-  const groups = new Map<string, { key: string, label: string, items: SearchableSelectOption[] }>()
+const filteredGroups = computed<SearchableSelectGroup[]>(() => {
+  const groups = new Map<string, SearchableSelectGroup>()
   for (const option of filteredOptions.value) {
     const key = option.group ?? '__ungrouped__'
     if (!groups.has(key)) {
@@ -207,6 +236,64 @@ const filteredGroups = computed(() => {
   }
   return Array.from(groups.values())
 })
+
+// Flatten groups into a single list so the dropdown can be virtualized:
+// some consumers (e.g. timezone-select) feed hundreds of options, and
+// rendering them all at once on open janks the main thread. Row heights are
+// measured at runtime, so nothing here is hard-coded.
+const rows = computed<Row[]>(() => {
+  const result: Row[] = []
+  let posinset = 0
+  for (const group of filteredGroups.value) {
+    if (props.showGroupHeaders && group.label) {
+      result.push({ type: 'header', key: `header:${group.key}`, group })
+    }
+    for (const option of group.items) {
+      posinset += 1
+      result.push({ type: 'item', key: option.value, option, posinset })
+    }
+  }
+  return result
+})
+
+// Total option count (excludes headers) for aria-setsize: virtualization drops
+// off-screen options from the DOM, so screen readers need the real set size.
+const optionCount = computed(() => filteredOptions.value.length)
+
+const virtualizer = useVirtualizer<HTMLElement, HTMLElement>(
+  computed(() => ({
+    count: rows.value.length,
+    getScrollElement: () => scrollEl.value,
+    // Rows are single-line (~32px); this seed keeps the scroll size close to
+    // real so the scrollbar tracks. measureRow measures the true height at
+    // runtime, so an off estimate only causes minor jitter, never misalignment.
+    estimateSize: () => 32,
+    overscan: 8,
+    getItemKey: (index: number) => rows.value[index]?.key ?? index,
+  })),
+)
+
+const totalSize = computed(() => virtualizer.value.getTotalSize())
+
+const virtualRows = computed(() =>
+  virtualizer.value.getVirtualItems().flatMap((vi) => {
+    const row = rows.value[vi.index]
+    return row ? [{ key: String(vi.key), virtual: vi, row }] : []
+  }),
+)
+
+const measureRow = (el: unknown) => {
+  if (el instanceof HTMLElement) virtualizer.value.measureElement(el)
+}
+
+watch(open, (value) => {
+  if (value) {
+    searchTerm.value = ''
+    nextTick(() => virtualizer.value.scrollToOffset(0))
+  }
+})
+
+watch(searchTerm, () => virtualizer.value.scrollToOffset(0))
 
 function selectOption(value: string) {
   selected.value = value

--- a/apps/web/src/components/searchable-select-popover/index.vue
+++ b/apps/web/src/components/searchable-select-popover/index.vue
@@ -29,7 +29,7 @@
     </PopoverTrigger>
     <PopoverContent
       class="p-0"
-      :style="{ width: 'calc(var(--reka-popover-trigger-width) * 0.55)' }"
+      :style="{ width: `calc(var(--reka-popover-trigger-width) * ${widthRatio})` }"
       align="start"
     >
       <div class="flex items-center border-b px-3">
@@ -185,6 +185,9 @@ const props = withDefaults(defineProps<{
   searchAriaLabel?: string
   emptyText?: string
   showGroupHeaders?: boolean
+  // Popover width as a fraction of the trigger width. Defaults to full width;
+  // consumers with short labels (e.g. timezone) can narrow it.
+  widthRatio?: number
 }>(), {
   placeholder: '',
   ariaLabel: '',
@@ -192,6 +195,7 @@ const props = withDefaults(defineProps<{
   searchAriaLabel: 'Search options',
   emptyText: 'No results.',
   showGroupHeaders: true,
+  widthRatio: 1,
 })
 
 const selected = defineModel<string>({ default: '' })

--- a/apps/web/src/components/searchable-select-popover/index.vue
+++ b/apps/web/src/components/searchable-select-popover/index.vue
@@ -38,13 +38,19 @@
         />
         <input
           v-model="searchTerm"
+          role="combobox"
+          :aria-controls="listboxId"
+          :aria-expanded="open"
+          :aria-activedescendant="activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined"
           :placeholder="searchPlaceholder"
           :aria-label="searchAriaLabel"
           class="flex h-10 w-full bg-transparent py-3 text-xs outline-none placeholder:text-muted-foreground"
+          @keydown="onKeydown"
         >
       </div>
 
       <div
+        :id="listboxId"
         ref="scrollEl"
         class="max-h-64 overflow-y-auto px-1"
         role="listbox"
@@ -82,13 +88,17 @@
 
             <button
               v-else
+              :id="`${listboxId}-${vRow.virtual.index}`"
               type="button"
               role="option"
               :aria-selected="selected === vRow.row.option.value"
               :aria-setsize="optionCount"
               :aria-posinset="vRow.row.posinset"
               class="relative flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground"
-              :class="{ 'bg-accent': selected === vRow.row.option.value }"
+              :class="{
+                'bg-accent': selected === vRow.row.option.value,
+                'bg-accent text-accent-foreground': activeIndex === vRow.virtual.index,
+              }"
               @click="selectOption(vRow.row.option.value)"
             >
               <Check
@@ -142,8 +152,9 @@ import {
   PopoverContent,
   Button,
 } from '@memohai/ui'
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, useId, watch } from 'vue'
 import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useListboxKeyboard } from '@/composables/useListboxKeyboard'
 
 export interface SearchableSelectOption {
   value: string
@@ -290,9 +301,19 @@ const measureRow = (el: unknown) => {
   if (el instanceof HTMLElement) virtualizer.value.measureElement(el)
 }
 
+const listboxId = useId()
+const { activeIndex, onKeydown, reset: resetActive } = useListboxKeyboard<Row>({
+  rows,
+  scrollToIndex: (index) => virtualizer.value.scrollToIndex(index),
+  onSelect: (row) => {
+    if (row.type === 'item') selectOption(row.option.value)
+  },
+})
+
 watch(open, (value) => {
   if (value) {
     searchTerm.value = ''
+    resetActive()
     nextTick(() => virtualizer.value.scrollToOffset(0))
   }
 })

--- a/apps/web/src/components/timezone-select/index.vue
+++ b/apps/web/src/components/timezone-select/index.vue
@@ -8,6 +8,7 @@
     search-aria-label="Search timezones"
     :empty-text="$t('common.noTimezoneFound')"
     :show-group-headers="false"
+    :width-ratio="0.55"
   />
 </template>
 

--- a/apps/web/src/composables/useListboxKeyboard.ts
+++ b/apps/web/src/composables/useListboxKeyboard.ts
@@ -1,0 +1,87 @@
+import { computed, nextTick, ref, watch, type ComputedRef } from 'vue'
+
+interface ListboxRow {
+  type: 'header' | 'item'
+}
+
+/**
+ * Keyboard navigation for a virtualized listbox driven by a search input
+ * (the combobox pattern). Virtualization keeps only the visible rows in the
+ * DOM, so Tab alone can't reach off-screen options; this tracks an active row,
+ * scrolls it into view (which mounts it), and exposes the state needed to wire
+ * `aria-activedescendant`. Focus stays on the input throughout.
+ */
+export function useListboxKeyboard<TRow extends ListboxRow>(params: {
+  rows: ComputedRef<TRow[]>
+  scrollToIndex: (index: number) => void
+  onSelect: (row: TRow, index: number) => void
+}) {
+  const activeIndex = ref(-1)
+
+  // Row indexes that are selectable options (headers are skipped).
+  const itemIndexes = computed(() => {
+    const indexes: number[] = []
+    params.rows.value.forEach((row, index) => {
+      if (row.type === 'item') indexes.push(index)
+    })
+    return indexes
+  })
+
+  function activate(rowIndex: number) {
+    activeIndex.value = rowIndex
+    if (rowIndex >= 0) nextTick(() => params.scrollToIndex(rowIndex))
+  }
+
+  function step(delta: 1 | -1) {
+    const items = itemIndexes.value
+    if (items.length === 0) return
+    const pos = items.indexOf(activeIndex.value)
+    const next = pos === -1
+      ? (delta === 1 ? 0 : items.length - 1)
+      : Math.min(items.length - 1, Math.max(0, pos + delta))
+    activate(items[next])
+  }
+
+  function reset() {
+    activeIndex.value = -1
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        step(1)
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        step(-1)
+        break
+      case 'Home':
+        if (itemIndexes.value.length) {
+          event.preventDefault()
+          activate(itemIndexes.value[0])
+        }
+        break
+      case 'End':
+        if (itemIndexes.value.length) {
+          event.preventDefault()
+          activate(itemIndexes.value[itemIndexes.value.length - 1])
+        }
+        break
+      case 'Enter': {
+        const row = params.rows.value[activeIndex.value]
+        if (row && row.type === 'item') {
+          event.preventDefault()
+          params.onSelect(row, activeIndex.value)
+        }
+        break
+      }
+    }
+  }
+
+  // Filtering rebuilds the row list, so a prior active index may now point at a
+  // different row (or a header) — reset to avoid a stale highlight.
+  watch(params.rows, reset)
+
+  return { activeIndex, onKeydown, reset }
+}

--- a/apps/web/src/pages/bots/components/model-options.vue
+++ b/apps/web/src/pages/bots/components/model-options.vue
@@ -12,75 +12,86 @@
   </div>
 
   <div
-    class="max-h-64 overflow-y-auto"
+    ref="scrollEl"
+    class="max-h-64 overflow-y-auto px-1"
     role="listbox"
   >
     <div
-      v-if="filteredGroups.length === 0"
+      v-if="rows.length === 0"
       class="py-6 text-center text-xs text-muted-foreground"
     >
       {{ $t('bots.settings.noModel') }}
     </div>
 
     <div
-      v-for="group in filteredGroups"
-      :key="group.key"
-      class="p-1"
+      v-else
+      :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }"
     >
       <div
-        v-if="group.label"
-        class="px-2 py-1.5 text-xs font-medium text-muted-foreground"
+        v-for="vRow in virtualRows"
+        :key="vRow.key"
+        :ref="measureRow"
+        :data-index="vRow.virtual.index"
+        class="py-0.5"
+        :style="{ position: 'absolute', top: '0', left: '0', width: '100%', transform: `translateY(${vRow.virtual.start}px)` }"
       >
-        {{ group.label }}
-      </div>
+        <div
+          v-if="vRow.row.type === 'header'"
+          class="px-2 py-1.5 text-xs font-medium text-muted-foreground"
+        >
+          {{ vRow.row.label }}
+        </div>
 
-      <button
-        v-for="option in group.items"
-        :key="option.value"
-        type="button"
-        role="option"
-        :aria-selected="modelValue === option.value"
-        class="relative flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground [&_+button]:mt-1"
-        :class="{ 'bg-accent': modelValue === option.value }"
-        @click="$emit('update:modelValue', option.value)"
-      >
-        <Check
-          v-if="modelValue === option.value"
-          class="size-3.5 shrink-0 mt-0.5"
-        />
-        <span
+        <button
           v-else
-          class="size-3.5 shrink-0"
-        />
-        <span class="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span class="flex min-w-0 items-center gap-2">
+          type="button"
+          role="option"
+          :aria-selected="modelValue === vRow.row.option.value"
+          :aria-setsize="optionCount"
+          :aria-posinset="vRow.row.posinset"
+          class="relative flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground"
+          :class="{ 'bg-accent': modelValue === vRow.row.option.value }"
+          @click="$emit('update:modelValue', vRow.row.option.value)"
+        >
+          <Check
+            v-if="modelValue === vRow.row.option.value"
+            class="size-3.5 shrink-0 mt-0.5"
+          />
+          <span
+            v-else
+            class="size-3.5 shrink-0"
+          />
+          <span class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span class="flex min-w-0 items-center gap-2">
+              <span
+                class="truncate flex-1 text-left"
+                :title="vRow.row.option.label"
+              >{{ vRow.row.option.label }}</span>
+              <span class="flex items-center gap-1.5 shrink-0">
+                <ModelCapabilities
+                  v-if="vRow.row.option.compatibilities?.length"
+                  :compatibilities="vRow.row.option.compatibilities"
+                />
+                <ContextWindowBadge :context-window="vRow.row.option.contextWindow" />
+              </span>
+            </span>
             <span
-              class="truncate flex-1 text-left"
-              :title="option.label"
-            >{{ option.label }}</span>
-            <span class="flex items-center gap-1.5 shrink-0">
-              <ModelCapabilities
-                v-if="option.compatibilities?.length"
-                :compatibilities="option.compatibilities"
-              />
-              <ContextWindowBadge :context-window="option.contextWindow" />
+              v-if="vRow.row.hasDescription"
+              class="text-xs text-muted-foreground truncate text-left"
+              :title="vRow.row.option.description"
+            >
+              {{ vRow.row.option.description }}
             </span>
           </span>
-          <span
-            v-if="option.description && option.description !== option.label"
-            class="text-xs text-muted-foreground truncate text-left"
-            :title="option.description"
-          >
-            {{ option.description }}
-          </span>
-        </span>
-      </button>
+        </button>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 import { Search, Check } from 'lucide-vue-next'
 import type { ModelsGetResponse, ProvidersGetResponse } from '@memohai/sdk'
 import ModelCapabilities from '@/components/model-capabilities/index.vue'
@@ -96,6 +107,23 @@ export interface ModelOption {
   compatibilities?: string[]
   contextWindow?: number
 }
+
+interface HeaderRow {
+  type: 'header'
+  key: string
+  label: string
+}
+
+interface ItemRow {
+  type: 'item'
+  key: string
+  option: ModelOption
+  hasDescription: boolean
+  // 1-based position among option rows (excludes headers), for aria-posinset
+  posinset: number
+}
+
+type Row = HeaderRow | ItemRow
 
 const props = defineProps<{
   models: ModelsGetResponse[]
@@ -113,10 +141,7 @@ defineEmits<{
 const modelValue = defineModel<string>({ default: '' })
 
 const searchTerm = ref('')
-
-watch(() => props.open, (v) => {
-  if (v) searchTerm.value = ''
-})
+const scrollEl = ref<HTMLElement | null>(null)
 
 const providerMap = computed(() => {
   const map = new Map<string, string>()
@@ -169,4 +194,77 @@ const filteredGroups = computed(() => {
   }
   return Array.from(groups.values())
 })
+
+// Flatten the grouped options into one linear list so the dropdown can be
+// virtualized: rendering every row at once instantiates hundreds of buttons
+// (each with capability-icon sub-components) synchronously and freezes the
+// main thread when a provider exposes hundreds of models. Heights are measured
+// at runtime by the virtualizer, so no row heights are hard-coded here.
+const rows = computed<Row[]>(() => {
+  const result: Row[] = []
+  let posinset = 0
+  for (const group of filteredGroups.value) {
+    if (group.label) {
+      result.push({ type: 'header', key: `header:${group.key}`, label: group.label })
+    }
+    for (const option of group.items) {
+      posinset += 1
+      result.push({
+        type: 'item',
+        key: option.value,
+        option,
+        hasDescription: Boolean(option.description && option.description !== option.label),
+        posinset,
+      })
+    }
+  }
+  return result
+})
+
+// Total option count (excludes group headers) for aria-setsize: virtualization
+// drops off-screen options from the DOM, so screen readers need this to know the
+// real set size rather than only the rendered window.
+const optionCount = computed(() => filteredOptions.value.length)
+
+const virtualizer = useVirtualizer<HTMLElement, HTMLElement>(
+  computed(() => ({
+    count: rows.value.length,
+    getScrollElement: () => scrollEl.value,
+    // Per-row size estimate, kept close to the real rendered heights so the
+    // total scroll size barely shifts as rows get measured — otherwise the
+    // scrollbar drifts (estimate vs. measured mismatch). These are only seeds:
+    // measureRow measures the true height at runtime, so being slightly off
+    // causes minor jitter at worst, never clipping/misalignment.
+    estimateSize: (index) => {
+      const row = rows.value[index]
+      if (!row) return 44
+      if (row.type === 'header') return 32
+      return row.hasDescription ? 54 : 36
+    },
+    overscan: 8,
+    getItemKey: (index: number) => rows.value[index]?.key ?? index,
+  })),
+)
+
+const totalSize = computed(() => virtualizer.value.getTotalSize())
+
+const virtualRows = computed(() =>
+  virtualizer.value.getVirtualItems().flatMap((vi) => {
+    const row = rows.value[vi.index]
+    return row ? [{ key: String(vi.key), virtual: vi, row }] : []
+  }),
+)
+
+const measureRow = (el: unknown) => {
+  if (el instanceof HTMLElement) virtualizer.value.measureElement(el)
+}
+
+watch(() => props.open, (v) => {
+  if (v) {
+    searchTerm.value = ''
+    nextTick(() => virtualizer.value.scrollToOffset(0))
+  }
+})
+
+watch(searchTerm, () => virtualizer.value.scrollToOffset(0))
 </script>

--- a/apps/web/src/pages/bots/components/model-options.vue
+++ b/apps/web/src/pages/bots/components/model-options.vue
@@ -5,13 +5,19 @@
     />
     <input
       v-model="searchTerm"
+      role="combobox"
+      :aria-controls="listboxId"
+      :aria-expanded="open"
+      :aria-activedescendant="activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined"
       :placeholder="$t('bots.settings.searchModel')"
       aria-label="Search models"
       class="flex h-10 w-full bg-transparent py-3 text-xs outline-none placeholder:text-muted-foreground"
+      @keydown="onKeydown"
     >
   </div>
 
   <div
+    :id="listboxId"
     ref="scrollEl"
     class="max-h-64 overflow-y-auto px-1"
     role="listbox"
@@ -44,13 +50,17 @@
 
         <button
           v-else
+          :id="`${listboxId}-${vRow.virtual.index}`"
           type="button"
           role="option"
           :aria-selected="modelValue === vRow.row.option.value"
           :aria-setsize="optionCount"
           :aria-posinset="vRow.row.posinset"
           class="relative flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-xs outline-none hover:bg-accent hover:text-accent-foreground"
-          :class="{ 'bg-accent': modelValue === vRow.row.option.value }"
+          :class="{
+            'bg-accent': modelValue === vRow.row.option.value,
+            'bg-accent text-accent-foreground': activeIndex === vRow.virtual.index,
+          }"
           @click="$emit('update:modelValue', vRow.row.option.value)"
         >
           <Check
@@ -90,12 +100,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, useId, watch } from 'vue'
 import { useVirtualizer } from '@tanstack/vue-virtual'
 import { Search, Check } from 'lucide-vue-next'
 import type { ModelsGetResponse, ProvidersGetResponse } from '@memohai/sdk'
 import ModelCapabilities from '@/components/model-capabilities/index.vue'
 import ContextWindowBadge from '@/components/context-window-badge/index.vue'
+import { useListboxKeyboard } from '@/composables/useListboxKeyboard'
 
 export interface ModelOption {
   value: string
@@ -134,7 +145,7 @@ const props = defineProps<{
   showIcons?: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
 
@@ -259,9 +270,19 @@ const measureRow = (el: unknown) => {
   if (el instanceof HTMLElement) virtualizer.value.measureElement(el)
 }
 
+const listboxId = useId()
+const { activeIndex, onKeydown, reset: resetActive } = useListboxKeyboard<Row>({
+  rows,
+  scrollToIndex: (index) => virtualizer.value.scrollToIndex(index),
+  onSelect: (row) => {
+    if (row.type === 'item') emit('update:modelValue', row.option.value)
+  },
+})
+
 watch(() => props.open, (v) => {
   if (v) {
     searchTerm.value = ''
+    resetActive()
     nextTick(() => virtualizer.value.scrollToOffset(0))
   }
 })

--- a/apps/web/src/pages/bots/components/model-select.vue
+++ b/apps/web/src/pages/bots/components/model-select.vue
@@ -20,7 +20,7 @@
       </Button>
     </PopoverTrigger>
     <PopoverContent
-      class="w-[--reka-popover-trigger-width] p-0 shadow-md rounded-xl"
+      class="w-[var(--reka-popover-trigger-width)] p-0 shadow-md rounded-xl"
       align="start"
     >
       <ModelOptions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@tanstack/vue-table':
         specifier: ^8.21.3
         version: 8.21.3(vue@3.5.26(typescript@5.9.3))
+      '@tanstack/vue-virtual':
+        specifier: ^3.12.0
+        version: 3.13.17(vue@3.5.26(typescript@5.9.3))
       '@vee-validate/zod':
         specifier: ^4.15.1
         version: 4.15.1(vue@3.5.26(typescript@5.9.3))(zod@4.3.6)


### PR DESCRIPTION
## Summary
- Virtualize the model picker (`model-options.vue`) and the shared `searchable-select-popover` (used by ~10 selects: timezone, TTS model, provider selects, access control, chat language…) with `@tanstack/vue-virtual`. Providers like OpenRouter expose hundreds of models and timezone lists run to hundreds of entries; previously every option mounted at once on open, freezing the main thread and dropping the popover open animation. Now only visible rows mount, with row heights measured at runtime.
- Fix a Tailwind v4 width util (`w-[--var]` no longer auto-wraps in `var()`).
- Scope the narrower popover width (0.55× trigger) to the timezone picker only, via a `widthRatio` prop defaulting to full width — the other ~9 consumers are unaffected.

## Dependency note
Promotes `@tanstack/vue-virtual` to a direct dependency. It is **already in the tree transitively via reka-ui** (`reka-ui@2.7.0` → `^3.12.0`); pnpm dedupes to a single version `3.13.17`, so this adds **zero** new package to the bundle — it only makes the existing dependency explicit.

## Test plan
- [ ] Model picker (bot settings / chat pane) with a provider exposing hundreds of models: opens instantly, smooth scroll, search + selection work.
- [ ] Timezone picker (new bot / bot Global card / profile): narrow (0.55) width, hundreds of zones scroll smoothly, search + select work.
- [ ] Other searchable selects (TTS model, provider selects, access control, chat language): full trigger width restored; open/scroll/select correct.
- [ ] Scrollbar tracks correctly (no drift) in long lists.

## Known limitations (follow-up)
- Off-screen options leave the DOM, so Tab-key / screen-reader users can't reach options outside the rendered window, and the selected item isn't auto-scrolled into view on open. Deferred.
- `settings-interaction-card.vue` still uses the un-wrapped `w-[--reka-popover-trigger-width]` (same Tailwind v4 issue) — out of scope, separate fix.