### PR TITLE
feat(web): add chat scroll navigation and quick “scroll to latest” button

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -247,6 +247,8 @@
     "readonlyPlaceholder": "This chat is read-only. Sending messages is disabled.",
     "send": "Send",
     "sendFailed": "Message failed to send",
+    "timelineAnswer": "Answer",
+    "timelineMessage": "Message",
     "startChat": "Start Chat",
     "noBot": "No bots available, please create a bot first",
     "newChat": "New Chat",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -243,6 +243,8 @@
     "readonlyPlaceholder": "该聊天为只读，无法发送消息",
     "send": "发送",
     "sendFailed": "消息发送失败",
+    "timelineAnswer": "回复",
+    "timelineMessage": "消息",
     "startChat": "开始聊天",
     "noBot": "暂无可用 Bot，请先创建 Bot",
     "newChat": "开启新对话",

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -18,11 +18,10 @@
       <section class="flex-1 relative w-full px-3 sm:px-5 lg:px-8">
         <section class="absolute inset-0">
           <ScrollArea
-          
             ref="scrollContainer"
             :class="`${transitionScroll?'opacity-100':'opacity-0'} h-full`"
           >
-            <div            
+            <div
               class="w-full max-w-4xl mx-auto px-10 pt-6 pb-6 space-y-6"
             >
               <div
@@ -62,12 +61,13 @@
               </div>
 
               <div
-                v-for="msg in messages"
+                v-for="(msg, msgIndex) in messages"
                 :key="msg.id"
                 :data-message-id="msg.id"
+                :data-scroll-segment-id="messageSegmentDomId(msg, msgIndex)"
                 :data-external-message-id="(msg.role === 'user' || msg.role === 'assistant') ? msg.externalMessageId : undefined"
                 class="rounded-2xl transition-[background-color,box-shadow] duration-500"
-                :class="highlightedMessageId === msg.id ? 'bg-primary/10 ring-2 ring-primary/25' : ''"
+                :class="highlightedMessageId === msg.id ? 'bg-muted/45 ring-1 ring-border shadow-sm' : ''"
                 :data-anchor="msg.id"
               >
                 <MessageItem
@@ -83,6 +83,70 @@
               </div>
             </div>
           </ScrollArea>
+
+          <div
+            v-if="showScrollRail"
+            class="group hidden md:flex absolute right-2 top-1/2 z-10 w-64 -translate-y-1/2 flex-col items-end pointer-events-none"
+            aria-label="Conversation navigation"
+          >
+            <div
+              v-if="hoveredScrollSegment"
+              class="absolute right-12 top-1/2 w-fit max-w-72 -translate-y-1/2 rounded-lg border bg-background/95 px-2.5 py-1.5 text-left font-mono shadow-md backdrop-blur transition-opacity duration-150"
+            >
+              <div
+                v-if="hoveredScrollSegment.role === 'assistant'"
+                class="mb-1 text-[10px] font-medium leading-none text-muted-foreground"
+              >
+                memoh
+              </div>
+              <div class="line-clamp-4 overflow-hidden text-ellipsis break-words text-[11px] leading-snug text-foreground">
+                {{ hoveredScrollSegment.preview }}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              class="absolute bottom-full mb-1 flex size-8 translate-y-1 items-center justify-center rounded-full border border-transparent text-muted-foreground opacity-0 transition-all duration-200 hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-0 disabled:hover:bg-transparent disabled:hover:text-muted-foreground group-hover:translate-y-0 group-hover:opacity-100 disabled:group-hover:opacity-40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring pointer-events-auto"
+              aria-label="Navigate to previous message"
+              :disabled="!previousScrollSegment"
+              @click="scrollToAdjacentSegment(-1)"
+            >
+              <ChevronUp class="size-4" />
+            </button>
+
+            <div class="flex flex-col items-end gap-0 pointer-events-auto">
+              <button
+                v-for="segment in scrollSegments"
+                :key="segment.id"
+                type="button"
+                class="group/timeline-tick relative flex h-3 w-8 cursor-pointer items-center justify-center rounded-full border border-transparent text-xs font-medium text-muted-foreground transition-colors duration-100 hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                :aria-label="segment.label"
+                @mouseenter="hoveredSegmentId = segment.id"
+                @mouseleave="hoveredSegmentId = ''"
+                @focus="hoveredSegmentId = segment.id"
+                @blur="hoveredSegmentId = ''"
+                @click="scrollToSegment(segment)"
+              >
+                <span
+                  class="h-px rounded-full bg-muted-foreground/70 opacity-50 transition-all duration-150 group-hover:opacity-100 group-hover/timeline-tick:w-4 group-hover/timeline-tick:bg-foreground/70"
+                  :class="[
+                    activeSegmentId === segment.id ? 'w-4 bg-foreground/80 opacity-100' : segment.index % 2 === 0 ? 'w-1.5' : 'w-3',
+                    hoveredSegmentId === segment.id ? '!w-4 !bg-foreground/80 opacity-100' : '',
+                  ]"
+                />
+              </button>
+            </div>
+
+            <button
+              type="button"
+              class="absolute top-full mt-1 flex size-8 -translate-y-1 items-center justify-center rounded-full border border-transparent text-muted-foreground opacity-0 transition-all duration-200 hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-0 disabled:hover:bg-transparent disabled:hover:text-muted-foreground group-hover:translate-y-0 group-hover:opacity-100 disabled:group-hover:opacity-40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring pointer-events-auto"
+              aria-label="Navigate to next message"
+              :disabled="!nextScrollSegment"
+              @click="scrollToAdjacentSegment(1)"
+            >
+              <ChevronDown class="size-4" />
+            </button>
+          </div>
         </section>
       </section>
 
@@ -96,7 +160,28 @@
         v-if="!activeChatReadOnly"
         class="px-3 sm:px-5 lg:px-8 py-2.5"
       >
-        <div class="w-full max-w-4xl mx-auto">
+        <div class="relative w-full max-w-4xl mx-auto">
+          <Transition
+            enter-active-class="transition-opacity duration-150 ease-out"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition-opacity duration-150 ease-in"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0"
+          >
+            <Button
+              v-if="showJumpToBottom"
+              type="button"
+              size="icon"
+              variant="secondary"
+              class="absolute left-1/2 bottom-full z-20 mb-2 size-8 -translate-x-1/2 rounded-full border bg-background/95 shadow-sm backdrop-blur hover:bg-accent"
+              aria-label="Scroll to latest message"
+              @click="scrollToBottom"
+            >
+              <ArrowDown class="size-4" />
+            </Button>
+          </Transition>
+
           <div
             v-if="pendingFiles.length"
             class="flex flex-wrap gap-2 mb-2"
@@ -258,7 +343,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onBeforeUnmount, useTemplateRef, watchEffect, watch, nextTick, onActivated, onDeactivated } from 'vue'
-import { LoaderCircle, Image as ImageIcon, File as FileIcon, X, Paperclip, Send, ChevronDown, Lightbulb, CircleAlert } from 'lucide-vue-next'
+import { LoaderCircle, Image as ImageIcon, File as FileIcon, X, Paperclip, Send, ChevronDown, ChevronUp, Lightbulb, CircleAlert, ArrowDown } from 'lucide-vue-next'
 import { ScrollArea, Button, InputGroup, InputGroupAddon, InputGroupTextarea, Popover, PopoverContent, PopoverTrigger } from '@memohai/ui'
 import { useChatStore } from '@/store/chat-list'
 import { storeToRefs } from 'pinia'
@@ -276,6 +361,24 @@ import { EFFORT_LABELS, EFFORT_OPACITY } from '@/pages/bots/components/reasoning
 import { useMediaGallery } from '../composables/useMediaGallery'
 import type { ChatAttachment } from '@/composables/api/useChat'
 import { onAuthSessionCleared } from '@/lib/auth-session'
+import type { ChatMessage } from '@/store/chat-list'
+
+interface ScrollSegment {
+  id: string
+  targetSegmentId: string
+  targetMessageId: string
+  role: 'user' | 'assistant'
+  label: string
+  preview: string
+  index: number
+  top: number
+  topPercent: number
+}
+
+interface ScrollSegmentSource {
+  message: ChatMessage
+  messageIndex: number
+}
 
 const props = withDefaults(defineProps<{
   tabId?: string
@@ -483,12 +586,252 @@ const isInstant = ref(false)
 const highlightedMessageId = ref('')
 const { y, directions, arrivedState, isScrolling } = useScroll(scrollEl, { behavior: computed(() => isAutoScroll.value && isInstant.value ? 'smooth' : 'instant') })
 const { height } = useElementBounding(descEl)
+const scrollSegments = ref<ScrollSegment[]>([])
+const activeSegmentId = ref('')
+const hoveredSegmentId = ref('')
+const scrollAnchorOffset = 8
+const scrollAnimationMaxDuration = 760
+const scrollAnimationMinDuration = 260
+const scrollNavigationLockMs = scrollAnimationMaxDuration + 80
 let highlightTimer: ReturnType<typeof setTimeout> | null = null
+let scrollNavigationLockTimer: ReturnType<typeof setTimeout> | null = null
+let scrollNavigationRaf = 0
+let scrollAnimationRaf = 0
 
 onBeforeUnmount(() => {
   stopAuthSessionCleanup()
   if (highlightTimer) clearTimeout(highlightTimer)
+  if (scrollNavigationLockTimer) clearTimeout(scrollNavigationLockTimer)
+  if (scrollNavigationRaf) cancelAnimationFrame(scrollNavigationRaf)
+  if (scrollAnimationRaf) cancelAnimationFrame(scrollAnimationRaf)
 })
+
+const showJumpToBottom = computed(() =>
+  isActive.value
+  && !loadingChats.value
+  && messages.value.length > 0
+  && !arrivedState.bottom,
+)
+
+const showScrollRail = computed(() =>
+  isActive.value
+  && !loadingChats.value
+  && scrollSegments.value.length > 1,
+)
+
+const hoveredScrollSegment = computed(() => {
+  const id = hoveredSegmentId.value
+  return scrollSegments.value.find(segment => segment.id === id)
+})
+
+const activeSegmentIndex = computed(() => {
+  if (!scrollSegments.value.length) return -1
+  const index = scrollSegments.value.findIndex(segment => segment.id === activeSegmentId.value)
+  return index >= 0 ? index : 0
+})
+
+const previousScrollSegment = computed(() => {
+  const index = activeSegmentIndex.value
+  return index > 0 ? scrollSegments.value[index - 1] : null
+})
+
+const nextScrollSegment = computed(() => {
+  const index = activeSegmentIndex.value
+  return index >= 0 && index < scrollSegments.value.length - 1 ? scrollSegments.value[index + 1] : null
+})
+
+function messageSegmentDomId(message: ChatMessage, index: number) {
+  return `${index}:${message.role}:${message.id}`
+}
+
+function findSegmentElement(segmentId: string): HTMLElement | null {
+  const root = scrollEl.value
+  if (!root) return null
+  for (const item of Array.from(root.querySelectorAll<HTMLElement>('[data-scroll-segment-id]'))) {
+    if (item.dataset.scrollSegmentId === segmentId) return item
+  }
+  return null
+}
+
+function getElementAbsoluteTop(target: HTMLElement, root: HTMLElement, rootRect = root.getBoundingClientRect()) {
+  const rect = target.getBoundingClientRect()
+  return root.scrollTop + rect.top - rootRect.top
+}
+
+function getSegmentAbsoluteTop(segment: ScrollSegment) {
+  const target = findSegmentElement(segment.targetSegmentId)
+  if (!target) return segment.top
+  const root = scrollEl.value
+  if (!root) return segment.top
+  return getElementAbsoluteTop(target, root)
+}
+
+function getSegmentText(message: ChatMessage) {
+  if (message.role === 'user') {
+    return message.text?.trim().replace(/\s+/g, ' ') || ''
+  }
+  if (message.role === 'assistant') {
+    const textBlock = message.messages.find(block => block.type === 'text')
+    return textBlock?.content?.trim().replace(/\s+/g, ' ') || ''
+  }
+  return ''
+}
+
+function getSegmentLabel(index: number, message: ChatMessage) {
+  const preview = getSegmentText(message)
+  const roleLabel = message.role === 'assistant'
+    ? t('chat.timelineAnswer')
+    : t('chat.timelineMessage')
+  return preview ? `${roleLabel} ${index + 1}. ${preview.slice(0, 48)}` : `${roleLabel} ${index + 1}`
+}
+
+function buildSegmentSources(): ScrollSegmentSource[] {
+  const sources: ScrollSegmentSource[] = []
+  messages.value.forEach((message, messageIndex) => {
+    if ((message.role === 'user' || message.role === 'assistant') && getSegmentText(message).length > 0) {
+      sources.push({ message, messageIndex })
+    }
+  })
+  return sources
+}
+
+const scrollSegmentStructureKey = computed(() =>
+  messages.value
+    .filter(message => message.role === 'user' || message.role === 'assistant')
+    .map(message => `${message.id}:${message.role}:${message.streaming ? '1' : '0'}:${getSegmentText(message).length > 0 ? 'text' : 'empty'}`)
+    .join('|'),
+)
+
+function measureScrollNavigation() {
+  scrollNavigationRaf = 0
+  const root = scrollEl.value
+  if (!root) return
+
+  const scrollHeight = Math.max(root.scrollHeight, 1)
+  const rootRect = root.getBoundingClientRect()
+  const segmentSources = buildSegmentSources()
+  const nextSegments: ScrollSegment[] = []
+
+  segmentSources.forEach(({ message, messageIndex }, index) => {
+    const targetSegmentId = messageSegmentDomId(message, messageIndex)
+    const target = findSegmentElement(targetSegmentId)
+    if (!target) return
+
+    const absoluteTop = getElementAbsoluteTop(target, root, rootRect)
+
+    nextSegments.push({
+      id: targetSegmentId,
+      targetSegmentId,
+      targetMessageId: message.id,
+      role: message.role,
+      label: getSegmentLabel(index, message),
+      preview: getSegmentText(message) || getSegmentLabel(index, message),
+      index,
+      top: absoluteTop,
+      topPercent: Math.min(100, Math.max(0, (absoluteTop / scrollHeight) * 100)),
+    })
+  })
+
+  scrollSegments.value = nextSegments
+
+  if (scrollNavigationLockTimer) return
+
+  const viewportAnchor = root.scrollTop + scrollAnchorOffset
+  let active = nextSegments[0]?.id ?? ''
+  let activeDistance = Number.POSITIVE_INFINITY
+  for (const segment of nextSegments) {
+    const distance = Math.abs(segment.top - viewportAnchor)
+    if (distance < activeDistance) {
+      active = segment.id
+      activeDistance = distance
+    }
+  }
+  activeSegmentId.value = active
+}
+
+function scheduleScrollNavigationMeasure() {
+  if (scrollNavigationRaf) return
+  scrollNavigationRaf = requestAnimationFrame(measureScrollNavigation)
+}
+
+function easeInOutCubic(progress: number) {
+  return progress < 0.5
+    ? 4 * progress * progress * progress
+    : 1 - ((-2 * progress + 2) ** 3) / 2
+}
+
+function scrollViewportTo(top: number, animated = true) {
+  const root = scrollEl.value
+  if (!root) return
+  const nextTop = Math.min(Math.max(top, 0), Math.max(root.scrollHeight - root.clientHeight, 0))
+  if (scrollAnimationRaf) cancelAnimationFrame(scrollAnimationRaf)
+
+  if (!animated) {
+    root.scrollTop = nextTop
+    y.value = nextTop
+    scheduleScrollNavigationMeasure()
+    return
+  }
+
+  const startTop = root.scrollTop
+  const distance = nextTop - startTop
+  if (Math.abs(distance) < 1) {
+    root.scrollTop = nextTop
+    y.value = nextTop
+    scheduleScrollNavigationMeasure()
+    return
+  }
+
+  const duration = Math.min(scrollAnimationMaxDuration, Math.max(scrollAnimationMinDuration, Math.abs(distance) * 0.45))
+  const startedAt = performance.now()
+
+  const step = (now: number) => {
+    const progress = Math.min(1, (now - startedAt) / duration)
+    root.scrollTop = startTop + distance * easeInOutCubic(progress)
+    if (progress < 1) {
+      scrollAnimationRaf = requestAnimationFrame(step)
+      return
+    }
+    root.scrollTop = nextTop
+    y.value = nextTop
+    scrollAnimationRaf = 0
+    scheduleScrollNavigationMeasure()
+  }
+
+  scrollAnimationRaf = requestAnimationFrame(step)
+}
+
+async function scrollToSegment(segment: ScrollSegment) {
+  activeSegmentId.value = segment.id
+  if (scrollNavigationLockTimer) clearTimeout(scrollNavigationLockTimer)
+  scrollNavigationLockTimer = setTimeout(() => {
+    scrollNavigationLockTimer = null
+    scheduleScrollNavigationMeasure()
+  }, scrollNavigationLockMs)
+  await scrollToMessage(segment)
+}
+
+async function scrollToAdjacentSegment(direction: -1 | 1) {
+  const target = resolveAdjacentSegment(direction)
+  if (!target) return
+  await scrollToSegment(target)
+}
+
+function resolveAdjacentSegment(direction: -1 | 1) {
+  const segments = scrollSegments.value
+  if (!segments.length) return null
+
+  const targetIndex = activeSegmentIndex.value + direction
+  return targetIndex >= 0 && targetIndex < segments.length ? segments[targetIndex] : null
+}
+
+function scrollToBottom() {
+  const root = scrollEl.value
+  if (!root) return
+  isAutoScroll.value = true
+  isInstant.value = true
+  scrollViewportTo(root.scrollHeight)
+}
 
 
 const elId: { id: string, top: number }[] = []
@@ -591,6 +934,14 @@ watch([isAutoScroll, height, isActive], async () => {
   deep: true
 })
 
+watch([scrollSegmentStructureKey, y, height, isActive], async () => {
+  if (!isActive.value) return
+  await nextTick()
+  scheduleScrollNavigationMeasure()
+}, {
+  flush: 'post',
+})
+
 // Sentinel-based infinite scroll for older history. The IntersectionObserver
 // fires reliably even when the user is pinned at scrollTop=0 (where scroll
 // events stop), and we restore the visual position via scrollHeight diff —
@@ -685,18 +1036,24 @@ function findMessageElement(messageId: string): HTMLElement | null {
   return null
 }
 
-async function scrollToMessage(messageId: string): Promise<boolean> {
+async function scrollToMessage(messageOrSegment: string | ScrollSegment): Promise<boolean> {
   await nextTick()
   const root = scrollEl.value
-  const target = findMessageElement(messageId)
+  const target = typeof messageOrSegment === 'string'
+    ? findMessageElement(messageOrSegment)
+    : findSegmentElement(messageOrSegment.targetSegmentId)
   if (!root || !target) return false
-  // isAutoScroll.value = false
-  // isInstant.value = true
-  const rootRect = root.getBoundingClientRect()
-  const targetRect = target.getBoundingClientRect()
-  const offset = targetRect.top - rootRect.top - Math.max(24, root.clientHeight * 0.22)
+  isAutoScroll.value = false
+  isInstant.value = false
+  const messageId = typeof messageOrSegment === 'string'
+    ? messageOrSegment
+    : messageOrSegment.targetMessageId
+  const absoluteTop = typeof messageOrSegment === 'string'
+    ? getElementAbsoluteTop(target, root)
+    : getSegmentAbsoluteTop(messageOrSegment)
+  const nextTop = absoluteTop - scrollAnchorOffset
 
-  root.scrollTo({ top: root.scrollTop + offset, behavior: 'smooth' })
+  scrollViewportTo(nextTop)
   highlightedMessageId.value = messageId
   if (highlightTimer) clearTimeout(highlightTimer)
   highlightTimer = setTimeout(() => {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -149,7 +149,7 @@
 @layer base {
   * {
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in oklch, var(--color-border) 70%, transparent) transparent;
+    scrollbar-color: color-mix(in oklch, var(--color-muted-foreground) 45%, transparent) transparent;
   }
 
   /* Webkit browsers (Chrome, Safari, Edge) */
@@ -163,22 +163,21 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background: color-mix(in oklch, var(--color-border) 40%, transparent);
+    background: color-mix(in oklch, var(--color-muted-foreground) 36%, transparent);
     border-radius: 10px;
     transition: background 0.2s ease;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in oklch, var(--color-border) 80%, transparent);
+    background: color-mix(in oklch, var(--color-muted-foreground) 55%, transparent);
   }
 
   /* Dark mode adjustments if needed */
   .dark ::-webkit-scrollbar-thumb {
-    background: color-mix(in oklch, var(--color-border) 30%, transparent);
+    background: color-mix(in oklch, var(--color-muted-foreground) 34%, transparent);
   }
 
   .dark ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in oklch, var(--color-border) 60%, transparent);
+    background: color-mix(in oklch, var(--color-muted-foreground) 52%, transparent);
   }
 }
-

--- a/packages/ui/src/components/scroll-area/ScrollBar.vue
+++ b/packages/ui/src/components/scroll-area/ScrollBar.vue
@@ -26,7 +26,7 @@ const delegatedProps = reactiveOmit(props, 'class')
   >
     <ScrollAreaThumb
       data-slot="scroll-area-thumb"
-      class="bg-border/40 hover:bg-border/80 transition-colors relative flex-1 rounded-full"
+      class="bg-muted-foreground/35 hover:bg-muted-foreground/55 transition-colors relative flex-1 rounded-full"
     />
   </ScrollAreaScrollbar>
 </template>


### PR DESCRIPTION
## Summary

- Add right-side scroll navigation for chat conversations.
- Add a centered quick “scroll to latest” button above the input box.
- Refine chat scrollbar styling with neutral Memoh/shadcn-style colors.

## What Changed

- Added a compact timeline rail that lets users jump between conversation segments.
- Added up/down controls for moving to the previous or next segment with eased scrolling.
- Added hover previews for timeline segments with bounded, truncated content.
- Added Memoh reply labeling in timeline previews.
- Updated native and shared ScrollArea scrollbar thumb colors to be slightly darker and neutral.

## Verification

- `git diff --check`
- `mise exec -- pnpm exec eslint apps/web/src/pages/home/components/chat-pane.vue packages/ui/src/components/scroll-area/ScrollBar.vue`
- `mise exec -- pnpm --filter @memohai/web build`

## Picture

<img width="1277" height="798" alt="图片" src="https://github.com/user-attachments/assets/8076f5e6-fd79-4033-a408-ca02607ed385" />
