### PR TITLE
fix: add json_valid guard for SearchMessages with XML/plaintext content

### DIFF
--- a/db/sqlite/queries/messages.sql
+++ b/db/sqlite/queries/messages.sql
@@ -333,6 +333,8 @@ WHERE m.bot_id = sqlc.arg(bot_id)
   AND (sqlc.narg(role) IS NULL OR m.role = sqlc.narg(role))
   AND (sqlc.narg(keyword) IS NULL OR (
     CASE
+      WHEN NOT json_valid(m.content)
+        THEN CASE WHEN m.content LIKE '%' || sqlc.narg(keyword) || '%' THEN m.content ELSE '' END
       WHEN json_type(json_extract(m.content, '$.content')) = 'text'
         THEN json_extract(m.content, '$.content')
       WHEN json_type(json_extract(m.content, '$.content')) = 'array'

--- a/internal/db/sqlite/sqlc/messages.sql.go
+++ b/internal/db/sqlite/sqlc/messages.sql.go
@@ -1391,6 +1391,8 @@ WHERE m.bot_id = ?1
   AND (?6 IS NULL OR m.role = ?6)
   AND (?7 IS NULL OR (
     CASE
+      WHEN NOT json_valid(m.content)
+        THEN CASE WHEN m.content LIKE '%' || ?7 || '%' THEN m.content ELSE '' END
       WHEN json_type(json_extract(m.content, '$.content')) = 'text'
         THEN json_extract(m.content, '$.content')
       WHEN json_type(json_extract(m.content, '$.content')) = 'array'


### PR DESCRIPTION
## Problem

SearchMessages SQL query crashes with malformed JSON error when keyword searching user role messages.

User role messages store content as XML plaintext instead of JSON. When search_messages(keyword) is called, the CASE expression evaluates both branches, and json_type(json_extract(m.content, "$.content")) on non-JSON text throws a SQL error.

## Solution

Added a NOT json_valid(m.content) guard at the start of the CASE expression:

```sql
WHEN NOT json_valid(m.content)
  THEN CASE WHEN m.content LIKE "%" || keyword || "%" THEN m.content ELSE "" END
WHEN json_type(json_extract(m.content, "$.content")) = "text"
  THEN json_extract(m.content, "$.content")
-- ...
```

- Plaintext/XML content: matched directly via LIKE on m.content
- Structured JSON content: falls through to existing json_extract logic for text/array types

## Testing

Verified against production database where user role messages contain XML plaintext.

Fixes: search_messages(keyword:) with user role XML content