### PR TITLE
fix(web): prevent autofill in ACP settings

### DIFF
--- a/apps/web/src/pages/bots/components/settings-acp-card.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-card.vue
@@ -129,6 +129,11 @@
                 <Input
                   :model-value="agentForm(profile).managed[field.id || ''] || ''"
                   :type="inputType(field.type)"
+                  :name="managedFieldName(profile, field)"
+                  :autocomplete="managedFieldAutocomplete(field)"
+                  autocapitalize="off"
+                  autocorrect="off"
+                  spellcheck="false"
                   :placeholder="field.placeholder"
                   class="h-8 text-xs shadow-none"
                   @update:model-value="(val) => setManagedField(profile, field.id, String(val ?? ''))"
@@ -220,6 +225,14 @@ function inputType(type: string | undefined): string {
   if (type === 'password') return 'password'
   if (type === 'url') return 'url'
   return 'text'
+}
+
+function managedFieldName(profile: AcpprofilePublicProfile, field: AcpprofileManagedField): string {
+  return `acp-${normalizeACPAgentID(profile.id) || 'agent'}-${normalizeACPAgentID(field.id) || 'field'}`
+}
+
+function managedFieldAutocomplete(field: AcpprofileManagedField): string {
+  return field.type === 'password' ? 'new-password' : 'off'
 }
 
 function setManagedField(profile: AcpprofilePublicProfile, fieldID: string | undefined, value: string) {

--- a/apps/web/src/pages/bots/detail.vue
+++ b/apps/web/src/pages/bots/detail.vue
@@ -99,6 +99,11 @@
               <Input
                 v-model="searchQuery"
                 type="text"
+                name="bot-settings-search"
+                autocomplete="off"
+                autocapitalize="off"
+                autocorrect="off"
+                spellcheck="false"
                 class="pl-8 h-8 text-xs bg-transparent shadow-none focus-visible:ring-0"
                 :placeholder="$t('common.search')"
               />


### PR DESCRIPTION
## Summary
- add explicit autocomplete/name hints to the bot settings search input
- mark ACP managed password fields as new-password to avoid browser credential autofill
- disable input correction helpers for these non-prose fields

## Testing
- git diff --check

Note: pnpm eslint was not run because host node_modules are not installed in this workspace.