### PR TITLE
fix(web): remove dead container data import/export buttons

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1387,8 +1387,6 @@
       "deleteSuccess": "Container deleted",
       "deletePreserveSuccess": "Container deleted and data preserved",
       "snapshotSuccess": "Snapshot created",
-      "exportSuccess": "Data exported",
-      "importSuccess": "Data imported",
       "restoreSuccess": "Data restored",
       "rollbackSuccess": "Snapshot rolled back",
       "pullingImage": "Pulling image...",
@@ -1456,8 +1454,6 @@
         "delete": "Delete",
         "deletePreserve": "Preserve & Delete",
         "snapshot": "Create",
-        "exportData": "Export",
-        "importData": "Import",
         "restoreData": "Restore",
         "rollback": "Rollback"
       }

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1383,8 +1383,6 @@
       "deleteSuccess": "容器删除成功",
       "deletePreserveSuccess": "容器已删除，数据已保留",
       "snapshotSuccess": "快照创建成功",
-      "exportSuccess": "数据导出成功",
-      "importSuccess": "数据导入成功",
       "restoreSuccess": "数据恢复成功",
       "rollbackSuccess": "快照回滚成功",
       "pullingImage": "正在拉取镜像...",
@@ -1452,8 +1450,6 @@
         "delete": "删除",
         "deletePreserve": "保留并删除",
         "snapshot": "创建",
-        "exportData": "导出",
-        "importData": "导入",
         "restoreData": "恢复",
         "rollback": "回滚"
       }

--- a/apps/web/src/pages/bots/components/bot-container.vue
+++ b/apps/web/src/pages/bots/components/bot-container.vue
@@ -956,24 +956,6 @@ watch([activeTab, botId], ([tab]) => {
                 </div>
               </div>
               <div class="flex items-center gap-2 shrink-0 sm:justify-end">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  :disabled="containerBusy || botLifecyclePending"
-                  class="h-8 text-xs shadow-none font-medium border border-border"
-                  @click="handleExportData"
-                >
-                  {{ $t('bots.container.actions.exportData') }}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  :disabled="containerBusy || botLifecyclePending"
-                  class="h-8 text-xs shadow-none font-medium border border-border"
-                  @click="triggerImportData"
-                >
-                  {{ $t('bots.container.actions.importData') }}
-                </Button>
                 <ConfirmPopover
                   :message="$t('bots.container.restoreConfirm')"
                   :loading="containerAction === 'restore'"
@@ -1035,13 +1017,6 @@ watch([activeTab, botId], ([tab]) => {
             </div>
           </div>
         </div>
-        <input
-          ref="importInputRef"
-          type="file"
-          accept=".tar.gz,.tgz,application/gzip,application/x-gzip,application/x-tar"
-          class="hidden"
-          @change="handleImportData"
-        >
       </div>
 
       <!-- Danger Zone - Exact replica from ?tab=channels -->


### PR DESCRIPTION
## Summary

PR #467 consolidated the container `/data` import/export into the bot-level backup feature. It removed the script handlers, SDK calls, and backend endpoints from the Container page, **but left the Export/Import buttons in the template**. Those buttons referenced now-undefined handlers (`handleExportData` / `triggerImportData` / `handleImportData` / `importInputRef`), so on `main` they render but clicking them is a silent no-op.

It slipped through because Vue does not fail the build on undefined template identifiers and `vue-tsc` is not in the build pipeline — the broken UI shipped and a reviewer reported "Container 页面导入导出失效".

This finishes the consolidation:

- Remove the orphaned **Export Data** / **Import Data** buttons and the hidden `<input>` from `bot-container.vue`.
- Remove the now-dead i18n keys: `bots.container.actions.exportData` / `importData` and `bots.container.exportSuccess` / `importSuccess` (en + zh).
- **Restore preserved data** is unchanged; whole-bot backup on the Bots page remains the supported import/export path.

## Test plan

- [x] `eslint .` clean (full repo)
- [x] `pnpm --filter @memohai/web build` succeeds (validates locale JSON parses)
- [x] No remaining references to the removed handlers or i18n keys anywhere in the repo
- [ ] Manual: open a bot → Container tab → confirm only "Restore" remains in the data section and the page has no dead buttons