### PR TITLE
fix(weixin): repair CDN file delivery

### DIFF
--- a/internal/channel/adapters/weixin/crypto.go
+++ b/internal/channel/adapters/weixin/crypto.go
@@ -4,6 +4,7 @@
 package weixin
 
 import (
+	"bytes"
 	"crypto/aes"
 	"encoding/base64"
 	"encoding/hex"
@@ -12,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -166,7 +166,7 @@ func uploadToCDN(cdnBaseURL, uploadParam, filekey string, plaintext, aesKey []by
 	}
 	u := buildCDNUploadURL(cdnBaseURL, uploadParam, filekey)
 
-	req, err := http.NewRequest(http.MethodPost, u, io.NopCloser(strings.NewReader(string(ciphertext)))) //nolint:noctx
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(ciphertext)) //nolint:noctx
 	if err != nil {
 		return "", err
 	}

--- a/internal/channel/adapters/weixin/crypto_test.go
+++ b/internal/channel/adapters/weixin/crypto_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -94,5 +97,40 @@ func TestParseAESKey_Invalid(t *testing.T) {
 	_, err := parseAESKey(b64)
 	if err == nil {
 		t.Error("expected error for invalid key length")
+	}
+}
+
+func TestUploadToCDNSendsContentLength(t *testing.T) {
+	plaintext := []byte("hello")
+	aesKey := []byte("0123456789abcdef")
+	wantCiphertext, err := encryptAESECB(plaintext, aesKey)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if !bytes.Equal(body, wantCiphertext) {
+			t.Errorf("body = %x, want %x", body, wantCiphertext)
+		}
+		if r.ContentLength != int64(len(wantCiphertext)) {
+			t.Errorf("content length = %d, want %d", r.ContentLength, len(wantCiphertext))
+		}
+		if len(r.TransferEncoding) > 0 {
+			t.Errorf("transfer encoding = %v, want none", r.TransferEncoding)
+		}
+		w.Header().Set("x-encrypted-param", "download-param")
+	}))
+	defer server.Close()
+
+	got, err := uploadToCDN(server.URL, "upload-param", "file-key", plaintext, aesKey)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if got != "download-param" {
+		t.Errorf("download param = %q, want %q", got, "download-param")
 	}
 }

--- a/internal/channel/adapters/weixin/outbound.go
+++ b/internal/channel/adapters/weixin/outbound.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -251,7 +252,7 @@ func sendMediaBytesAsFile(ctx context.Context, client *Client, cfg adapterConfig
 // encodeAESKeyForSend encodes a raw 16-byte AES key for the sendmessage protocol.
 func encodeAESKeyForSend(key []byte) string {
 	hexStr := hex.EncodeToString(key)
-	return strings.TrimSpace(hexStr)
+	return base64.StdEncoding.EncodeToString([]byte(hexStr))
 }
 
 func generateClientID() string {

--- a/internal/channel/adapters/weixin/outbound.go
+++ b/internal/channel/adapters/weixin/outbound.go
@@ -249,7 +249,8 @@ func sendMediaBytesAsFile(ctx context.Context, client *Client, cfg adapterConfig
 	return nil
 }
 
-// encodeAESKeyForSend encodes a raw 16-byte AES key for the sendmessage protocol.
+// encodeAESKeyForSend base64-encodes the hex representation of a raw AES key,
+// matching the sendmessage wire format used by the upstream Weixin plugin.
 func encodeAESKeyForSend(key []byte) string {
 	hexStr := hex.EncodeToString(key)
 	return base64.StdEncoding.EncodeToString([]byte(hexStr))

--- a/internal/channel/adapters/weixin/outbound_test.go
+++ b/internal/channel/adapters/weixin/outbound_test.go
@@ -1,0 +1,12 @@
+package weixin
+
+import "testing"
+
+func TestEncodeAESKeyForSend(t *testing.T) {
+	key := []byte("0123456789abcdef")
+	want := "MzAzMTMyMzMzNDM1MzYzNzM4Mzk2MTYyNjM2NDY1NjY="
+
+	if got := encodeAESKeyForSend(key); got != want {
+		t.Errorf("encodeAESKeyForSend() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- send encrypted Weixin CDN uploads with a known `Content-Length` instead of chunked transfer encoding
- encode media AES keys as base64-encoded hex strings before calling the Weixin `sendmessage` API
- add regression coverage for the CDN upload request body and headers

Fixes #544

Related upstream report: [Tencent/openclaw-weixin#172](https://github.com/Tencent/openclaw-weixin/issues/172)

## Validation

- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] Build and deploy the ARM64 server image on OrbStack
- [x] Manually send a TXT file through Weixin and confirm it is received