### PR TITLE
fix(desktop): resolve bot detail settings routing

### DIFF
--- a/apps/desktop/src/renderer/src/chat/router.ts
+++ b/apps/desktop/src/renderer/src/chat/router.ts
@@ -4,7 +4,7 @@ import {
   type RouteLocationNormalized,
   type RouteRecordRaw,
 } from 'vue-router'
-import { SETTINGS_ROUTE_SPECS } from '../shared/settings-routes'
+import { SETTINGS_ROUTE_SPECS, type SettingsRouteSpec } from '../shared/settings-routes'
 import { ensureOnboarding } from '@memohai/web/router-guards/onboarding'
 
 // Chat-window router. Owns ONLY chat-related routes — visiting `/settings`
@@ -18,15 +18,20 @@ import { ensureOnboarding } from '@memohai/web/router-guards/onboarding'
 // Stub component used by the settings name placeholders below. The
 // `beforeEach` guard returns `false` before vue-router ever renders these,
 // so the placeholder never instantiates — it exists purely so that
-// `router.push({ name: 'bot-detail', params: { botId } })` resolves to a
+// `router.push({ name: 'bot-detail', params: { botName } })` resolves to a
 // concrete `/settings/...` path that we can hand off to the IPC bridge.
 const SettingsRouteStub = { render: () => null }
 
-const settingsStubs: RouteRecordRaw[] = SETTINGS_ROUTE_SPECS.map(({ name, path }) => ({
-  name,
-  path,
-  component: SettingsRouteStub,
-}))
+function mapSettingsStub(spec: SettingsRouteSpec): RouteRecordRaw {
+  return {
+    path: spec.path,
+    component: SettingsRouteStub,
+    ...(spec.name ? { name: spec.name } : {}),
+    ...(spec.children ? { children: spec.children.map(mapSettingsStub) } : {}),
+  }
+}
+
+const settingsStubs: RouteRecordRaw[] = SETTINGS_ROUTE_SPECS.map(mapSettingsStub)
 
 const routes: RouteRecordRaw[] = [
   {


### PR DESCRIPTION
## Summary
- Register nested settings route stubs in the desktop chat router.
- Allow reused web navigation such as `router.push({ name: 'bot-detail', params: { botName } })` to resolve before the IPC settings-window handoff.

## Root cause
The desktop chat router only registered top-level settings route placeholders. Named navigation to nested routes like `bot-detail` could not resolve to a concrete `/settings/...` path, so clicking the bot detail action did not open the matching settings page.

## Validation
- `pnpm --filter @memohai/desktop typecheck:web`
- `pnpm exec lint-staged` returned no staged files after commit.