### PR TITLE
fix(web): refresh sessions for external message events

### DIFF
--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import type { UIStreamEvent, UIStreamEventHandler } from '@/composables/api/useChat'
+import type { MessageStreamEvent, UIStreamEvent, UIStreamEventHandler } from '@/composables/api/useChat'
 import { REASONING_EFFORT_DISABLE } from '@/pages/bots/components/reasoning-effort'
 import { useChatStore } from './chat-list'
 
@@ -27,6 +27,7 @@ function flushPromises() {
 
 describe('chat-list store', () => {
   let streamHandler: UIStreamEventHandler | null
+  let messageEventsHandler: ((event: MessageStreamEvent) => void) | null
   let sendEvents: UIStreamEvent[]
   let lastStreamId = ''
   let lastSessionId = ''
@@ -34,6 +35,7 @@ describe('chat-list store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     streamHandler = null
+    messageEventsHandler = null
     lastStreamId = ''
     lastSessionId = ''
     sendEvents = [
@@ -79,7 +81,8 @@ describe('chat-list store', () => {
       },
     })
     api.fetchMessagesUI.mockResolvedValue([])
-    api.streamMessageEvents.mockImplementation((_botId: string, signal: AbortSignal) => new Promise<void>((resolve) => {
+    api.streamMessageEvents.mockImplementation((_botId: string, signal: AbortSignal, onEvent: (event: MessageStreamEvent) => void) => new Promise<void>((resolve) => {
+      messageEventsHandler = onEvent
       signal.addEventListener('abort', () => resolve(), { once: true })
     }))
     api.connectWebSocket.mockImplementation((_botId: string, onStreamEvent: UIStreamEventHandler) => {
@@ -216,6 +219,38 @@ describe('chat-list store', () => {
 
     expect(api.ensureACPRuntime).toHaveBeenCalledTimes(1)
     expect(store.acpRuntimeStatuses[store.acpRuntimeKey('bot-1', 'acp-session-1')]?.models?.available_models).toHaveLength(1)
+  })
+
+  it('refreshes the session list when message events arrive for an unknown session', async () => {
+    api.fetchSessions
+      .mockResolvedValueOnce([
+        { id: 'session-old', bot_id: 'bot-1', title: 'Old', type: 'chat' },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'session-new', bot_id: 'bot-1', title: 'New from channel', type: 'chat' },
+        { id: 'session-old', bot_id: 'bot-1', title: 'Old', type: 'chat' },
+      ])
+    const store = useChatStore()
+
+    await store.selectBot('bot-1')
+    expect(store.sessionId).toBe('session-old')
+
+    messageEventsHandler?.({
+      type: 'message_created',
+      bot_id: 'bot-1',
+      message: {
+        id: 'message-1',
+        bot_id: 'bot-1',
+        session_id: 'session-new',
+        role: 'user',
+        created_at: '2026-06-02T10:00:00.000Z',
+      },
+    })
+    await flushPromises()
+
+    expect(api.fetchSessions).toHaveBeenCalledTimes(2)
+    expect(store.sessions.map(session => session.id)).toEqual(['session-new', 'session-old'])
+    expect(store.sessionId).toBe('session-old')
   })
 
   it('renders stream errors in the chat transcript after assistant output starts', async () => {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -220,6 +220,7 @@ export const useChatStore = defineStore('chat', () => {
   let activeWs: ChatWebSocket | null = null
   let refreshTimer: ReturnType<typeof setTimeout> | null = null
   let refreshPromise: { key: string; promise: Promise<void> } | null = null
+  let sessionListRefreshPromise: { botId: string; promise: Promise<void> } | null = null
   const pendingBackgroundEvents = new Map<string, BackgroundTask[]>()
   const latestBackgroundTasks = new Map<string, BackgroundTask>()
   // Open chat tabs share this store, so keep a small per-session view cache.
@@ -1096,6 +1097,7 @@ export const useChatStore = defineStore('chat', () => {
       refreshTimer = null
     }
     refreshPromise = null
+    sessionListRefreshPromise = null
     messageEventsSince = ''
 
     sessions.value = []
@@ -1172,6 +1174,29 @@ export const useChatStore = defineStore('chat', () => {
     refreshPromise = { key, promise }
 
     await promise
+  }
+
+  function refreshSessionsList(targetBotId: string): Promise<void> {
+    const bid = targetBotId.trim()
+    if (!bid) return Promise.resolve()
+    if (sessionListRefreshPromise?.botId === bid) return sessionListRefreshPromise.promise
+
+    const promise = fetchSessions(bid)
+      .then((visible) => {
+        if ((currentBotId.value ?? '').trim() !== bid) return
+        sessions.value = visible
+      })
+      .catch((error) => {
+        console.error('Failed to refresh sessions:', error)
+      })
+      .finally(() => {
+        if (sessionListRefreshPromise?.promise === promise) {
+          sessionListRefreshPromise = null
+        }
+      })
+
+    sessionListRefreshPromise = { botId: bid, promise }
+    return promise
   }
 
   function scheduleRefreshCurrentSession(expectedSessionId?: string, delay = 100) {
@@ -1289,6 +1314,14 @@ export const useChatStore = defineStore('chat', () => {
       const raw = event.message
       if (!raw) return
       updateSince(raw.created_at)
+      const messageSessionId = String(raw.session_id ?? event.session_id ?? '').trim()
+      if (messageSessionId) {
+        if (sessions.value.some((session) => session.id === messageSessionId)) {
+          touchSession(messageSessionId)
+        } else {
+          void refreshSessionsList(targetBotId)
+        }
+      }
       if (shouldRefreshFromMessageCreated(targetBotId, sessionId.value, streamingSessionId.value, event)) {
         scheduleRefreshCurrentSession((raw.session_id ?? '').trim())
       }


### PR DESCRIPTION
## Summary
- Refresh the chat session list when a `message_created` event references an unknown session.
- Keep the current active session unchanged while updating the sidebar list.
- Add store coverage for external channel-created sessions.

## Root Cause
Desktop reuses the web chat store and already listens to `/messages/events`, but `message_created` only refreshed the current session. External channels can create sessions without a separate `session_created` event, so the sidebar list stayed stale until a full reload.

## Validation
- `pnpm exec vitest run apps/web/src/store/chat-list.test.ts`
- pre-commit: large file check, Go lint, Go test, lint-staged
