### PR TITLE
feat(models): add MiniMax chat completions compat

### DIFF
--- a/conf/providers/minimax.yaml
+++ b/conf/providers/minimax.yaml
@@ -2,6 +2,8 @@ name: Minimax
 client_type: openai-completions
 icon: minimax-color
 base_url: https://api.minimaxi.com/v1
+config:
+  chat_completions_compat: minimax
 
 models:
   - model_id: MiniMax-M2.7

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/mailgun/mailgun-go/v5 v5.14.0
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
-	github.com/memohai/twilight-ai v0.4.1-0.20260530103538-1a82f3c3637c
+	github.com/memohai/twilight-ai v0.4.1-0.20260603074827-eedffe3595b4
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7 h1:beehwOQperqGWj4m4E
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7/go.mod h1:OvmxM7JmnXBmwJWWVqtreL3HSHSKuzPbtbhlg5MvBg0=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
-github.com/memohai/twilight-ai v0.4.1-0.20260530103538-1a82f3c3637c h1:DiRlE5227dVk9ZGgaznWK5N0mV/YMRZ5NIg/kpheuXA=
-github.com/memohai/twilight-ai v0.4.1-0.20260530103538-1a82f3c3637c/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
+github.com/memohai/twilight-ai v0.4.1-0.20260603074827-eedffe3595b4 h1:oCcd1UGw+grKPTQ7UUMeCt7PasApy0gdzGj8yCdBmfY=
+github.com/memohai/twilight-ai v0.4.1-0.20260603074827-eedffe3595b4/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/internal/models/chat_completions_compat.go
+++ b/internal/models/chat_completions_compat.go
@@ -6,7 +6,10 @@ import (
 
 // ChatCompletionsCompatDeepSeek enables DeepSeek request compatibility while
 // still using the generic OpenAI Chat Completions provider.
-const ChatCompletionsCompatDeepSeek = "deepseek"
+const (
+	ChatCompletionsCompatDeepSeek = "deepseek"
+	ChatCompletionsCompatMiniMax  = "minimax"
+)
 
 func normalizeChatCompletionsCompat(compat string) string {
 	return strings.ToLower(strings.TrimSpace(compat))
@@ -16,15 +19,23 @@ func isDeepSeekChatCompletionsCompat(compat string) bool {
 	return normalizeChatCompletionsCompat(compat) == ChatCompletionsCompatDeepSeek
 }
 
+func isMiniMaxChatCompletionsCompat(compat string) bool {
+	return normalizeChatCompletionsCompat(compat) == ChatCompletionsCompatMiniMax
+}
+
 // ResolveChatCompletionsCompat returns a normalized compatibility mode from
-// explicit config, with a fallback for the built-in DeepSeek endpoint.
+// explicit config, with fallbacks for built-in provider endpoints.
 func ResolveChatCompletionsCompat(baseURL, compat string) string {
 	compat = normalizeChatCompletionsCompat(compat)
 	if compat != "" {
 		return compat
 	}
-	if strings.Contains(strings.ToLower(strings.TrimSpace(baseURL)), "api.deepseek.com") {
+	base := strings.ToLower(strings.TrimSpace(baseURL))
+	if strings.Contains(base, "api.deepseek.com") {
 		return ChatCompletionsCompatDeepSeek
+	}
+	if strings.Contains(base, "api.minimax.io") || strings.Contains(base, "api.minimaxi.com") {
+		return ChatCompletionsCompatMiniMax
 	}
 	return ""
 }

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -60,6 +60,9 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 		if isDeepSeekChatCompletionsCompat(chatCompletionsCompat) {
 			opts = append(opts, openaicompletions.WithDeepSeekChatCompletionsCompat())
 		}
+		if isMiniMaxChatCompletionsCompat(chatCompletionsCompat) {
+			opts = append(opts, openaicompletions.WithMiniMaxChatCompletionsCompat())
+		}
 		p := openaicompletions.New(opts...)
 		return p.ChatModel(cfg.ModelID)
 
@@ -127,6 +130,9 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 		if isDeepSeekChatCompletionsCompat(chatCompletionsCompat) {
 			opts = append(opts, openaicompletions.WithDeepSeekChatCompletionsCompat())
 		}
+		if isMiniMaxChatCompletionsCompat(chatCompletionsCompat) {
+			opts = append(opts, openaicompletions.WithMiniMaxChatCompletionsCompat())
+		}
 		p := openaicompletions.New(opts...)
 		return p.ChatModel(cfg.ModelID)
 	}
@@ -138,7 +144,14 @@ func BuildReasoningOptions(cfg SDKModelConfig) []sdk.GenerateOption {
 		return nil
 	}
 
-	if ClientType(cfg.ClientType) == ClientTypeOpenAICompletions && isDeepSeekChatCompletionsCompat(cfg.ChatCompletionsCompat) {
+	// DeepSeek and MiniMax keep the generic Chat Completions transport but gate
+	// thinking via a toggle rather than reasoning_effort. Their SDK compat layer
+	// maps reasoning_effort "none" to thinking-off and any other effort to
+	// thinking-on, so we forward "none" to disable and an explicit effort to
+	// enable. Enabled-without-effort (adaptive) forwards nothing and lets the
+	// provider's default thinking behavior apply.
+	if ClientType(cfg.ClientType) == ClientTypeOpenAICompletions &&
+		(isDeepSeekChatCompletionsCompat(cfg.ChatCompletionsCompat) || isMiniMaxChatCompletionsCompat(cfg.ChatCompletionsCompat)) {
 		switch {
 		case cfg.ReasoningConfig.Disabled:
 			return []sdk.GenerateOption{sdk.WithReasoningEffort(ReasoningEffortNone)}

--- a/internal/models/sdk_test.go
+++ b/internal/models/sdk_test.go
@@ -55,6 +55,51 @@ func TestBuildReasoningOptionsDeepSeekChatCompletionsCompat(t *testing.T) {
 	}
 }
 
+func TestBuildReasoningOptionsMiniMaxChatCompletionsCompat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *ReasoningConfig
+		wantOpts int
+	}{
+		{
+			name:     "disabled sends explicit none effort",
+			config:   &ReasoningConfig{Disabled: true},
+			wantOpts: 1,
+		},
+		{
+			name:     "enabled without effort forwards nothing (provider default applies)",
+			config:   &ReasoningConfig{Enabled: true},
+			wantOpts: 0,
+		},
+		{
+			name:     "enabled with effort forwards effort",
+			config:   &ReasoningConfig{Enabled: true, Effort: "high"},
+			wantOpts: 1,
+		},
+		{
+			name:     "nil config produces no options",
+			config:   nil,
+			wantOpts: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := BuildReasoningOptions(SDKModelConfig{
+				ClientType:            string(ClientTypeOpenAICompletions),
+				ChatCompletionsCompat: ChatCompletionsCompatMiniMax,
+				ReasoningConfig:       tt.config,
+			})
+			if len(opts) != tt.wantOpts {
+				t.Fatalf("expected %d options, got %d", tt.wantOpts, len(opts))
+			}
+		})
+	}
+}
+
 func TestNewSDKChatModelDeepSeekChatCompletionsCompatDisablesThinking(t *testing.T) {
 	t.Parallel()
 
@@ -114,11 +159,159 @@ func TestNewSDKChatModelDeepSeekChatCompletionsCompatDisablesThinking(t *testing
 	}
 }
 
+func TestNewSDKChatModelMiniMaxChatCompletionsCompatDisablesThinking(t *testing.T) {
+	t.Parallel()
+
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		ReasoningSplit  bool    `json:"reasoning_split"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-minimax",
+			"model": "MiniMax-M3",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	compat := ResolveChatCompletionsCompat(srv.URL, ChatCompletionsCompatMiniMax)
+	model := NewSDKChatModel(SDKModelConfig{
+		ModelID:               "MiniMax-M3",
+		ClientType:            string(ClientTypeOpenAICompletions),
+		BaseURL:               srv.URL,
+		ChatCompletionsCompat: compat,
+		APIKey:                "test-key",
+	})
+	if model == nil {
+		t.Fatal("expected a model, got nil")
+	}
+
+	opts := []sdk.GenerateOption{
+		sdk.WithModel(model),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("hi")}),
+	}
+	opts = append(opts, BuildReasoningOptions(SDKModelConfig{
+		ClientType:            string(ClientTypeOpenAICompletions),
+		ChatCompletionsCompat: compat,
+		ReasoningConfig:       &ReasoningConfig{Disabled: true},
+	})...)
+	_, err := sdk.GenerateTextResult(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("generate text: %v", err)
+	}
+
+	if !body.ReasoningSplit {
+		t.Fatal("expected reasoning_split=true")
+	}
+	if body.ReasoningEffort != nil {
+		t.Fatalf("reasoning_effort should be omitted, got %q", *body.ReasoningEffort)
+	}
+	if body.Thinking == nil || body.Thinking.Type != "disabled" {
+		t.Fatalf("thinking: got %#v, want disabled", body.Thinking)
+	}
+}
+
+func TestNewSDKChatModelMiniMaxChatCompletionsCompatEnablesThinking(t *testing.T) {
+	t.Parallel()
+
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		ReasoningSplit  bool    `json:"reasoning_split"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-minimax",
+			"model": "MiniMax-M3",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	compat := ResolveChatCompletionsCompat(srv.URL, ChatCompletionsCompatMiniMax)
+	model := NewSDKChatModel(SDKModelConfig{
+		ModelID:               "MiniMax-M3",
+		ClientType:            string(ClientTypeOpenAICompletions),
+		BaseURL:               srv.URL,
+		ChatCompletionsCompat: compat,
+		APIKey:                "test-key",
+	})
+	if model == nil {
+		t.Fatal("expected a model, got nil")
+	}
+
+	opts := []sdk.GenerateOption{
+		sdk.WithModel(model),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("hi")}),
+	}
+	opts = append(opts, BuildReasoningOptions(SDKModelConfig{
+		ClientType:            string(ClientTypeOpenAICompletions),
+		ChatCompletionsCompat: compat,
+		ReasoningConfig:       &ReasoningConfig{Enabled: true, Effort: "high"},
+	})...)
+	_, err := sdk.GenerateTextResult(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("generate text: %v", err)
+	}
+
+	if !body.ReasoningSplit {
+		t.Fatal("expected reasoning_split=true")
+	}
+	if body.ReasoningEffort != nil {
+		t.Fatalf("reasoning_effort should be omitted, got %q", *body.ReasoningEffort)
+	}
+	if body.Thinking == nil || body.Thinking.Type != "adaptive" {
+		t.Fatalf("thinking: got %#v, want adaptive", body.Thinking)
+	}
+}
+
 func TestResolveChatCompletionsCompatInfersDeepSeekBaseURL(t *testing.T) {
 	t.Parallel()
 
 	got := ResolveChatCompletionsCompat("https://api.deepseek.com/v1", "")
 	if got != ChatCompletionsCompatDeepSeek {
 		t.Fatalf("expected deepseek compat, got %q", got)
+	}
+}
+
+func TestResolveChatCompletionsCompatInfersMiniMaxBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"https://api.minimax.io/v1",
+		"https://api.minimaxi.com/v1",
+	}
+	for _, baseURL := range tests {
+		t.Run(baseURL, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveChatCompletionsCompat(baseURL, "")
+			if got != ChatCompletionsCompatMiniMax {
+				t.Fatalf("expected minimax compat, got %q", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Enable MiniMax providers to use Twilight AI MiniMax Chat Completions compatibility mode.
- Add MiniMax compatibility resolution for both `api.minimax.io` and `api.minimaxi.com`.
- Forward Memoh reasoning settings through the compat path so disabled reasoning maps to `thinking: disabled` and explicit effort maps to MiniMax adaptive thinking.
- Mark the built-in MiniMax provider template with `chat_completions_compat: minimax`.

## Dependency
Twilight AI PR #16 has merged upstream, and this branch now depends on `github.com/memohai/twilight-ai v0.4.1-0.20260603074827-eedffe3595b4` directly. The temporary fork `replace` has been removed.

## Testing
- `go test ./internal/models`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check up/main..HEAD`
