### PR TITLE
fix: show pending ask_user tool call

### DIFF
--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -482,9 +482,7 @@ const shouldRenderMessage = computed(() =>
 )
 
 function isVisibleAssistantBlock(block: ContentBlock): boolean {
-  if (block.type === 'tool') {
-    return !(block.toolName === 'ask_user' && block.userInput?.status === 'pending')
-  }
+  if (block.type === 'tool') return true
   if (block.type === 'text' || block.type === 'error') return Boolean(block.content)
   if (block.type === 'attachments') return block.attachments.length > 0
   return true


### PR DESCRIPTION
## 这次做了什么

- 修复待回答状态下 `ask_user` 工具调用行被隐藏的问题。
- 现在 pending `ask_user` 仍会在消息流中显示 `Ask user / 询问用户`，底部回答面板继续负责展示问题和选项。

## 这次没做什么

- 没有改后端状态机、数据库、接口或 store 状态。
- 没有改变用户输入提交/取消流程。

## 验证

- 已通过提交钩子里的 ESLint 自动修复/检查。
- 已通过提交钩子里的 Go 测试。
- 提交前已手动跑过 `pnpm --dir apps/web exec vue-tsc --noEmit`。
- 提交前已手动跑过 `pnpm --dir apps/web exec vitest run src/store/chat-list.test.ts`。