### PR TITLE
feat(desktop): dev slots for parallel multi-worktree development

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -453,7 +453,9 @@ currently-bound ports), persists them, and reuses the same pair forever.
 `slot list` shows all slots. Per-slot files under `userData`:
 `local-server.<slot>.pid.json`, `local-server.<slot>.log`,
 `local-server/config.<slot>.toml`, and data under
-`local-server/data/instances/<slot>/`.
+`local-server/data/instances/<slot>/` (including the dev server binary at
+`.../<slot>/bin/memoh-server`, so parallel worktrees on different branches
+don't build different binaries to the same shared path).
 
 Port semantics: different keywords -> different ports, can run side by side;
 the same keyword must run in only one place at a time (it is one database).

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -417,6 +417,61 @@ desktop via screenshots and pointer/keyboard input. Headless Playwright can
 still run as an ordinary workspace command, but it is separate from the
 headed display path.
 
+### Dev Slots (multi-worktree parallel dev)
+
+Dev-only. Lets a full-stack developer run several desktop dev instances in
+parallel (e.g. one per git worktree / feature branch) without sharing one
+SQLite database and being forced to migrate up/down on every branch switch.
+
+- No keyword (`mise run desktop:dev`): the **default slot**. Unchanged
+  historical behavior — `userData/local-server/data/local/memoh.db`, server
+  `:18731`, web `8082`, `config.toml` / `local-server.pid.json` /
+  `local-server.log`. Existing users and the packaged app are unaffected.
+- With a keyword (`mise run desktop:dev -- bind`): an **isolated slot**,
+  reused by that keyword. Each keyword gets its own SQLite DB, ports, pid,
+  log, and rendered config. Schema version follows the keyword, so switching
+  worktrees never requires a manual downgrade.
+
+How the keyword flows (argument outside, env var inside):
+
+```
+mise run desktop:dev -- bind
+  -> go run ./cmd/agent slot env bind   # resolve + persist ports (free-port scan)
+  -> export MEMOH_SLOT / MEMOH_SLOT_SERVER_PORT / MEMOH_WEB_PORT / MEMOH_WEB_PROXY_TARGET
+  -> pnpm dev (electron-vite)
+       - electron.vite.config.ts: MEMOH_WEB_PORT pins the Vite dev port
+       - src/main/local-server.ts: MEMOH_SLOT picks data dir / pid / log /
+         config name; MEMOH_SLOT_SERVER_PORT sets [server].addr and the
+         LOCAL_SERVER_BASE_URL the renderer reaches via desktop:api-base-url
+```
+
+Port registry: `cmd/agent slot` (Go, no external deps) owns
+`userData/dev-slots.json`. `slot resolve <name>` allocates the next free
+server/web ports from the 18731 / 8082 baselines (skipping registry-used and
+currently-bound ports), persists them, and reuses the same pair forever.
+`slot env <name>` prints `KEY=VALUE` lines for the mise task to `eval`;
+`slot list` shows all slots. Per-slot files under `userData`:
+`local-server.<slot>.pid.json`, `local-server.<slot>.log`,
+`local-server/config.<slot>.toml`, and data under
+`local-server/data/instances/<slot>/`.
+
+Port semantics: different keywords -> different ports, can run side by side;
+the same keyword must run in only one place at a time (it is one database).
+
+Known limitations (v1, dev-only):
+
+- Embedded Qdrant is shared across slots. It only cross-contaminates if you
+  duplicate a DB so two slots use identical bot ids and both write memory;
+  quitting one running instance stops the shared Qdrant for the others.
+- The provider OAuth callback proxy binds a single fixed port (1455); only
+  one running slot gets it.
+- The ACP tools proxy binds a single fixed port (18732), shared across slots.
+  The allocator reserves it so no slot's server is handed 18732, but the proxy
+  itself is not partitioned per slot.
+- The `memoh` CLI and the packaged app only target the default slot.
+- Renderer `localStorage` (token, selection) is not partitioned per slot, so
+  the first request after switching slots may 401 and require a re-login.
+
 ## Routing
 
 Both windows use `createMemoryHistory()` — the `file://` runtime makes

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -41,6 +41,14 @@ function resolveProxyTarget(command: 'build' | 'serve'): { port: number; host: s
     }
   }
 
+  // Dev slot override: when launched via `mise run desktop:dev -- <keyword>`,
+  // MEMOH_WEB_PORT pins the Vite dev server port for that slot so multiple
+  // worktrees/slots can run side by side without clashing on 8082.
+  const slotWebPort = Number.parseInt(process.env.MEMOH_WEB_PORT?.trim() ?? '', 10)
+  if (Number.isInteger(slotWebPort) && slotWebPort > 0) {
+    port = slotWebPort
+  }
+
   return { port, host, baseUrl }
 }
 

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -109,13 +109,23 @@ function serverBinaryName(): string {
   return process.platform === 'win32' ? 'memoh-server.exe' : 'memoh-server'
 }
 
+// devServerBinDir is the directory the dev server binary is built into. The
+// default slot keeps the historical shared local-server/bin. A named slot gets
+// its own bin under the slot tree so two worktrees on different branches do not
+// build different binaries to the same path (clobbering each other, or — on
+// Windows — failing `go build -o` because a running slot locks the .exe).
+function devServerBinDir(cwd: string): string {
+  const slot = activeSlot()
+  return slot ? join(cwd, 'data', 'instances', slot, 'bin') : join(cwd, 'bin')
+}
+
 function devServerBinaryPath(cwd: string): string {
-  return join(cwd, 'bin', serverBinaryName())
+  return join(devServerBinDir(cwd), serverBinaryName())
 }
 
 function buildDevServerBinary(root: string, cwd: string): string {
   const binary = devServerBinaryPath(cwd)
-  mkdirSync(join(cwd, 'bin'), { recursive: true })
+  mkdirSync(devServerBinDir(cwd), { recursive: true })
   const result = spawnSync('go', ['build', '-o', binary, './cmd/agent'], {
     cwd: root,
     stdio: 'inherit',

--- a/apps/desktop/src/main/local-server.ts
+++ b/apps/desktop/src/main/local-server.ts
@@ -15,7 +15,57 @@ import {
 import { bundledGStreamerEnv } from './gstreamer'
 import { desktopResourcePath, desktopServerWorkDir, repoRoot } from './paths'
 
-export const LOCAL_SERVER_PORT = 18731
+const DEFAULT_SERVER_PORT = 18731
+
+// activeSlot is the desktop dev slot keyword set by
+// `mise run desktop:dev -- <keyword>`. Empty (or "default") means the
+// historical single-instance layout with unchanged behavior.
+function activeSlot(): string {
+  const slot = process.env.MEMOH_SLOT?.trim() ?? ''
+  return slot === 'default' ? '' : slot
+}
+
+// slotServerPort returns the port this instance binds. The default slot
+// always uses 18731. A named slot MUST carry an explicit resolved port via
+// MEMOH_SLOT_SERVER_PORT; we never silently fall back to 18731 for a named
+// slot, since that would collide with the default instance.
+function slotServerPort(): number {
+  const slot = activeSlot()
+  if (!slot) {
+    return DEFAULT_SERVER_PORT
+  }
+  const raw = process.env.MEMOH_SLOT_SERVER_PORT?.trim() ?? ''
+  const port = Number.parseInt(raw, 10)
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(
+      `dev slot "${slot}" is active but MEMOH_SLOT_SERVER_PORT is missing or invalid (${JSON.stringify(raw)}); ` +
+        'launch via `mise run desktop:dev -- <keyword>` so the slot port is resolved.',
+    )
+  }
+  return port
+}
+
+// slotSuffix is appended to per-slot file names (pid/log/config) so
+// multiple slots can run in parallel without clobbering each other.
+function slotSuffix(): string {
+  const slot = activeSlot()
+  return slot ? `.${slot}` : ''
+}
+
+// slotDataDir is the per-slot data subdirectory relative to the server
+// work dir. Default keeps data/local; named slots get an isolated tree.
+function slotDataDir(): string {
+  const slot = activeSlot()
+  return slot ? `data/instances/${slot}` : 'data/local'
+}
+
+// slotRuntimeDir is the per-slot bridge runtime subdirectory.
+function slotRuntimeDir(): string {
+  const slot = activeSlot()
+  return slot ? `data/instances/${slot}/runtime` : 'data/runtime'
+}
+
+export const LOCAL_SERVER_PORT = slotServerPort()
 export const LOCAL_SERVER_BASE_URL = `http://127.0.0.1:${LOCAL_SERVER_PORT}`
 const PROVIDER_OAUTH_CALLBACK_PORT = 1455
 
@@ -116,11 +166,11 @@ function currentServerCommand(): ServerCommand {
 }
 
 function logPath(): string {
-  return join(app.getPath('userData'), 'local-server.log')
+  return join(app.getPath('userData'), `local-server${slotSuffix()}.log`)
 }
 
 function pidPath(): string {
-  return join(app.getPath('userData'), 'local-server.pid.json')
+  return join(app.getPath('userData'), `local-server${slotSuffix()}.pid.json`)
 }
 
 function appendLog(message: string): void {
@@ -208,7 +258,7 @@ function prepareConfig(cwd: string, sourcePath: string, qdrantGrpcBaseUrl: strin
   const home = app.getPath('home')
   const source = readFileSync(sourcePath, 'utf8')
   const contents = applyLocalConfigDefaults(source, cwd, home, providersDir, qdrantGrpcBaseUrl)
-  const targetPath = join(cwd, 'config.toml')
+  const targetPath = join(cwd, `config${slotSuffix()}.toml`)
   writeFileSync(targetPath, contents, { mode: 0o600 })
   return targetPath
 }
@@ -221,11 +271,19 @@ function applyLocalConfigDefaults(
   qdrantGrpcBaseUrl?: string,
 ): string {
   let next = contents.replaceAll('__HOME__', home)
-  next = setTomlString(next, 'container', 'data_root', toAbsoluteConfigPath(cwd, 'data/local'))
-  next = setTomlString(next, 'container', 'runtime_dir', toAbsoluteConfigPath(cwd, 'data/runtime'))
-  next = setTomlString(next, 'local', 'metadata_root', toAbsoluteConfigPath(cwd, 'data/local/containers'))
-  next = setTomlString(next, 'sqlite', 'path', toAbsoluteConfigPath(cwd, 'data/local/memoh.db'))
+  const dataDir = slotDataDir()
+  next = setTomlString(next, 'container', 'data_root', toAbsoluteConfigPath(cwd, dataDir))
+  next = setTomlString(next, 'container', 'runtime_dir', toAbsoluteConfigPath(cwd, slotRuntimeDir()))
+  next = setTomlString(next, 'local', 'metadata_root', toAbsoluteConfigPath(cwd, `${dataDir}/containers`))
+  next = setTomlString(next, 'sqlite', 'path', toAbsoluteConfigPath(cwd, `${dataDir}/memoh.db`))
   next = setTomlString(next, 'registry', 'providers_dir', providersDir)
+  if (activeSlot()) {
+    // Pin the slot's server port so this instance does not collide with the
+    // default slot (18731) or other slots. The Go server ignores [web], so the
+    // Vite dev port is handled separately via MEMOH_WEB_PORT in
+    // electron.vite.config.ts, not by rewriting config here.
+    next = setTomlString(next, 'server', 'addr', `:${slotServerPort()}`)
+  }
   if (qdrantGrpcBaseUrl) {
     next = setTomlString(next, 'qdrant', 'base_url', qdrantGrpcBaseUrl)
   }
@@ -335,9 +393,9 @@ export function tomlStringLiteral(value: string): string {
 }
 
 function prepareRuntime(command: ServerCommand): void {
-  mkdirSync(join(command.cwd, 'data', 'local'), { recursive: true })
+  mkdirSync(join(command.cwd, slotDataDir()), { recursive: true })
   prepareProviders(command.cwd)
-  const targetRuntime = join(command.cwd, 'data', 'runtime')
+  const targetRuntime = join(command.cwd, slotRuntimeDir())
   mkdirSync(targetRuntime, { recursive: true })
 
   if (!app.isPackaged) {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,8 +20,10 @@ func main() {
 		if err := runVersion(); err != nil {
 			os.Exit(1)
 		}
+	case "slot":
+		runSlot(os.Args[2:])
 	default:
-		fmt.Fprintf(os.Stderr, "Usage: memoh-server <command>\n\nCommands:\n  serve     Start the server (default)\n  migrate   Run database migrations (up|down|version|force)\n  version   Print version information\n")
+		fmt.Fprintf(os.Stderr, "Usage: memoh-server <command>\n\nCommands:\n  serve     Start the server (default)\n  migrate   Run database migrations (up|down|version|force)\n  version   Print version information\n  slot      Desktop dev slot helper (resolve|env|list)\n")
 		os.Exit(1)
 	}
 }

--- a/cmd/agent/slot.go
+++ b/cmd/agent/slot.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/memohai/memoh/internal/tui/local"
+)
+
+// runSlot implements the `memoh-server slot` dev-only command group used
+// by the desktop dev launcher to resolve per-keyword ports and data
+// directories. It is not part of the server runtime.
+func runSlot(args []string) {
+	if len(args) == 0 {
+		slotUsage()
+		os.Exit(1)
+	}
+	rest := args[1:]
+	switch args[0] {
+	case "resolve":
+		if err := slotResolve(rest, false); err != nil {
+			fmt.Fprintf(os.Stderr, "slot resolve: %v\n", err)
+			os.Exit(1)
+		}
+	case "env":
+		if err := slotResolve(rest, true); err != nil {
+			fmt.Fprintf(os.Stderr, "slot env: %v\n", err)
+			os.Exit(1)
+		}
+	case "list":
+		if err := slotList(); err != nil {
+			fmt.Fprintf(os.Stderr, "slot list: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		slotUsage()
+		os.Exit(1)
+	}
+}
+
+func slotUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: memoh-server slot <resolve|env|list> [name]\n\n"+
+		"  resolve <name>  Print slot ports + data dir as JSON (allocates on first use)\n"+
+		"  env <name>      Print shell KEY=VALUE lines for `eval` (desktop dev launch)\n"+
+		"  list            List registered dev slots\n")
+}
+
+func slotResolve(args []string, asEnv bool) error {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	slot, err := local.ResolveDevSlot(name)
+	if err != nil {
+		return err
+	}
+	if asEnv {
+		fmt.Printf("MEMOH_SLOT=%s\n", slot.Name)
+		fmt.Printf("MEMOH_SLOT_SERVER_PORT=%d\n", slot.ServerPort)
+		fmt.Printf("MEMOH_WEB_PORT=%d\n", slot.WebPort)
+		fmt.Printf("MEMOH_WEB_PROXY_TARGET=http://127.0.0.1:%d\n", slot.ServerPort)
+		return nil
+	}
+	encoded, err := json.MarshalIndent(slot, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(encoded))
+	return nil
+}
+
+func slotList() error {
+	slots, err := local.ListDevSlots()
+	if err != nil {
+		return err
+	}
+	for _, s := range slots {
+		fmt.Printf("%-20s server=:%d web=%d  %s\n", s.Name, s.ServerPort, s.WebPort, s.DataDir)
+	}
+	return nil
+}

--- a/internal/tui/local/devslot.go
+++ b/internal/tui/local/devslot.go
@@ -1,0 +1,276 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+)
+
+// DefaultSlotName is the implicit slot used when no keyword is given. It
+// maps to the historical default ports and data directory so that
+// `mise run desktop:dev` (without a keyword) behaves exactly as before.
+const DefaultSlotName = "default"
+
+const (
+	baseServerPort       = 18731
+	baseWebPort          = 8082
+	devSlotsRegistryFile = "dev-slots.json"
+)
+
+// reservedHostPorts are fixed ports the desktop/local runtime binds outside
+// the slot system. The allocator must never hand these to a slot's server,
+// otherwise the slot would clash with that service at runtime.
+//
+//	18732 — ACP tools proxy (internal/workspace/bridge.ACPToolsProxyAddr)
+var reservedHostPorts = map[int]struct{}{
+	18732: {},
+}
+
+// devSlotNamePattern restricts slot keywords to filesystem- and shell-safe
+// identifiers. The desktop dev launcher `eval`s the `slot env` output, so this
+// pattern is also a security invariant: it guarantees the emitted MEMOH_SLOT
+// value carries no whitespace, quotes, or shell metacharacters. Do not relax
+// it without re-checking the eval call site in mise.toml.
+var devSlotNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,47}$`)
+
+// devSlotPorts is the persisted unit in dev-slots.json.
+type devSlotPorts struct {
+	ServerPort int `json:"server_port"`
+	WebPort    int `json:"web_port"`
+}
+
+// DevSlot is the resolved view of a dev slot returned to callers.
+type DevSlot struct {
+	Name       string `json:"name"`
+	ServerPort int    `json:"server_port"`
+	WebPort    int    `json:"web_port"`
+	DataDir    string `json:"data_dir"`
+}
+
+// ValidateDevSlotName reports whether name is an acceptable slot keyword.
+func ValidateDevSlotName(name string) error {
+	if !devSlotNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid slot name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]{0,47}", name)
+	}
+	return nil
+}
+
+// DevSlotsRegistryPath returns the path to the per-user dev slot
+// registry (userData/dev-slots.json).
+func DevSlotsRegistryPath() (string, error) {
+	dir, err := UserDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, devSlotsRegistryFile), nil
+}
+
+// DevSlotDataDir returns the per-slot data directory under the desktop
+// dev server work dir (userData/local-server). The default slot keeps
+// the historical data/local layout; named slots live under
+// data/instances/<name>.
+func DevSlotDataDir(name string) (string, error) {
+	dir, err := UserDataDir()
+	if err != nil {
+		return "", err
+	}
+	workDir := filepath.Join(dir, "local-server")
+	if name == DefaultSlotName || name == "" {
+		return filepath.Join(workDir, "data", "local"), nil
+	}
+	return filepath.Join(workDir, "data", "instances", name), nil
+}
+
+func loadDevSlotRegistry(path string) (map[string]devSlotPorts, error) {
+	reg := map[string]devSlotPorts{}
+	raw, err := os.ReadFile(path) //nolint:gosec // path derived from UserDataDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return reg, nil
+		}
+		return nil, fmt.Errorf("read dev-slots registry: %w", err)
+	}
+	if err := json.Unmarshal(raw, &reg); err != nil {
+		return nil, fmt.Errorf("parse dev-slots registry: %w", err)
+	}
+	return reg, nil
+}
+
+func saveDevSlotRegistry(path string, reg map[string]devSlotPorts) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create userData dir: %w", err)
+	}
+	encoded, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode dev-slots registry: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(encoded, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write dev-slots registry: %w", err)
+	}
+	return os.Rename(tmp, path)
+}
+
+// portAvailable reports whether a TCP port can currently be bound on
+// loopback. Used to skip ports occupied by foreign processes when
+// allocating a new slot.
+func portAvailable(port int) bool {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func nextFreePort(start int, used map[int]struct{}) (int, error) {
+	for port := start; port <= 65535; port++ {
+		if _, taken := used[port]; taken {
+			continue
+		}
+		if portAvailable(port) {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no free port available at or above %d", start)
+}
+
+// withRegistryLock serializes the registry read-modify-write across processes
+// (parallel worktrees can call ResolveDevSlot at the same time). The atomic
+// rename in saveDevSlotRegistry only prevents a torn file, not a lost update,
+// so a simple O_EXCL lock file guards the whole load→allocate→save sequence.
+func withRegistryLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return fmt.Errorf("create userData dir: %w", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // path derived from UserDataDir
+		if err == nil {
+			_ = f.Close()
+			break
+		}
+		if !os.IsExist(err) {
+			return fmt.Errorf("acquire dev-slots lock: %w", err)
+		}
+		// Reap a lock left behind by a crashed process.
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > 30*time.Second {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for dev-slots lock (%s); remove it if it is stale", lockPath)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	defer func() { _ = os.Remove(lockPath) }()
+	return fn()
+}
+
+// ResolveDevSlot returns the ports and data directory for the named
+// slot, allocating and persisting a fresh, free port pair on first use.
+// The default slot always maps to the reserved {18731, 8082} pair and
+// is never written to the registry.
+func ResolveDevSlot(name string) (DevSlot, error) {
+	if name == "" {
+		name = DefaultSlotName
+	}
+	if err := ValidateDevSlotName(name); err != nil {
+		return DevSlot{}, err
+	}
+	dataDir, err := DevSlotDataDir(name)
+	if err != nil {
+		return DevSlot{}, err
+	}
+	if name == DefaultSlotName {
+		return DevSlot{Name: name, ServerPort: baseServerPort, WebPort: baseWebPort, DataDir: dataDir}, nil
+	}
+
+	path, err := DevSlotsRegistryPath()
+	if err != nil {
+		return DevSlot{}, err
+	}
+
+	var resolved DevSlot
+	lockErr := withRegistryLock(path, func() error {
+		reg, err := loadDevSlotRegistry(path)
+		if err != nil {
+			return err
+		}
+		if existing, ok := reg[name]; ok {
+			resolved = DevSlot{Name: name, ServerPort: existing.ServerPort, WebPort: existing.WebPort, DataDir: dataDir}
+			return nil
+		}
+
+		usedServer := map[int]struct{}{baseServerPort: {}}
+		for p := range reservedHostPorts {
+			usedServer[p] = struct{}{}
+		}
+		usedWeb := map[int]struct{}{baseWebPort: {}}
+		for _, p := range reg {
+			usedServer[p.ServerPort] = struct{}{}
+			usedWeb[p.WebPort] = struct{}{}
+		}
+		serverPort, err := nextFreePort(baseServerPort+1, usedServer)
+		if err != nil {
+			return err
+		}
+		webPort, err := nextFreePort(baseWebPort+1, usedWeb)
+		if err != nil {
+			return err
+		}
+
+		reg[name] = devSlotPorts{ServerPort: serverPort, WebPort: webPort}
+		if err := saveDevSlotRegistry(path, reg); err != nil {
+			return err
+		}
+		resolved = DevSlot{Name: name, ServerPort: serverPort, WebPort: webPort, DataDir: dataDir}
+		return nil
+	})
+	if lockErr != nil {
+		return DevSlot{}, lockErr
+	}
+	return resolved, nil
+}
+
+// ListDevSlots returns all known dev slots, always including the
+// reserved default slot.
+func ListDevSlots() ([]DevSlot, error) {
+	path, err := DevSlotsRegistryPath()
+	if err != nil {
+		return nil, err
+	}
+	reg, err := loadDevSlotRegistry(path)
+	if err != nil {
+		return nil, err
+	}
+	names := []string{DefaultSlotName}
+	for n := range reg {
+		if n != DefaultSlotName {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	slots := make([]DevSlot, 0, len(names))
+	for _, n := range names {
+		dataDir, dirErr := DevSlotDataDir(n)
+		if dirErr != nil {
+			return nil, dirErr
+		}
+		if n == DefaultSlotName {
+			slots = append(slots, DevSlot{Name: n, ServerPort: baseServerPort, WebPort: baseWebPort, DataDir: dataDir})
+			continue
+		}
+		p := reg[n]
+		slots = append(slots, DevSlot{Name: n, ServerPort: p.ServerPort, WebPort: p.WebPort, DataDir: dataDir})
+	}
+	return slots, nil
+}

--- a/mise.toml
+++ b/mise.toml
@@ -344,10 +344,35 @@ echo '  Dev web UI will be available at http://localhost:18082'
 """
 
 [tasks."desktop:dev"]
-description = "Start Electron desktop app in dev mode (renderer reuses @memohai/web)"
+description = "Start Electron desktop app in dev mode (optional dev slot: mise run desktop:dev -- <keyword>)"
 dir = "{{config_root}}/apps/desktop"
-env = { MEMOH_WEB_PROXY_TARGET = "http://localhost:18731", CONFIG_PATH = "../../conf/app.local.toml" }
-run = "pnpm dev"
+env = { CONFIG_PATH = "../../conf/app.local.toml" }
+run = """
+#!/bin/bash
+set -euo pipefail
+
+SLOT="${1:-}"
+if [ -n "$SLOT" ]; then
+  # Per-keyword dev slot: resolve (and persist on first use) an isolated
+  # set of ports + data dir, then export them so both Vite and the
+  # Electron main process target this slot instead of the default 18731.
+  # Assign first so a failed resolve (e.g. invalid keyword) aborts here with
+  # the real error, instead of leaking through as a `set -u` unbound-variable
+  # error on the line below.
+  if ! SLOT_ENV="$(cd '{{config_root}}' && go run ./cmd/agent slot env "$SLOT")"; then
+    echo "desktop:dev: failed to resolve dev slot '$SLOT' (see error above)" >&2
+    exit 1
+  fi
+  eval "$SLOT_ENV"
+  export MEMOH_SLOT MEMOH_SLOT_SERVER_PORT MEMOH_WEB_PORT MEMOH_WEB_PROXY_TARGET
+  echo "desktop dev slot=$MEMOH_SLOT api=$MEMOH_WEB_PROXY_TARGET web=http://127.0.0.1:$MEMOH_WEB_PORT"
+else
+  # Default slot: unchanged historical behavior.
+  export MEMOH_WEB_PROXY_TARGET="http://localhost:18731"
+fi
+
+pnpm dev
+"""
 
 [tasks."desktop:qdrant:prepare"]
 description = "Download the Qdrant binary used by the Electron desktop app"


### PR DESCRIPTION
## Summary

Dev-only. Running `mise run desktop:dev -- <keyword>` boots an **isolated desktop dev instance** — its own SQLite DB, ports, pid, log, and rendered config — so a full-stack dev can run several git worktrees / feature branches in parallel **without migrating the shared DB up/down on every branch switch**.

- **No keyword** (`mise run desktop:dev`): unchanged historical default — `data/local/memoh.db`, server `:18731`, web `8082`, `config.toml` / `local-server.pid.json` / `local-server.log`. Verified byte-for-byte equivalent; packaged app unaffected.
- **With a keyword** (`mise run desktop:dev -- bind`): a reusable isolated slot. Schema version follows the keyword, so switching worktrees never needs a manual downgrade.

## How it works

```
mise run desktop:dev -- bind
  -> go run ./cmd/agent slot env bind     # resolve + persist ports (free-port scan)
  -> export MEMOH_SLOT / MEMOH_SLOT_SERVER_PORT / MEMOH_WEB_PORT / MEMOH_WEB_PROXY_TARGET
  -> pnpm dev
       - electron.vite.config.ts: MEMOH_WEB_PORT pins the Vite dev port
       - src/main/local-server.ts: per-slot data dir / pid / log / config + [server].addr
```

- `internal/tui/local/devslot.go`: per-user `dev-slots.json` registry, free-port allocation (reserves `18731`/`8082` baselines + the fixed ACP proxy `18732`), name validation (also the `eval`-safety invariant for the mise launcher), bounded port scan, cross-process `O_EXCL` lock around the registry read-modify-write.
- `cmd/agent/slot.go` + `main.go`: `slot resolve|env|list` helper.
- `mise.toml`: `desktop:dev` resolves the slot and **fails fast with a clear error** on a bad keyword (no `set -u` cascade).
- `local-server.ts`: slot-aware ports/baseUrl, per-slot pid/log/config; a **named slot requires an explicit resolved port** (no silent fallback to `18731`).
- `apps/desktop/AGENTS.md`: Dev Slots section + known limitations.

## Known limitations (v1, dev-only)

- Embedded Qdrant is shared across slots; quitting one running instance stops it for the others.
- The provider OAuth callback proxy (`1455`) and the ACP tools proxy (`18732`) bind single fixed ports — only one running slot gets them (allocator reserves `18732` so no slot's server is handed it).
- The `memoh` CLI and the packaged app only target the default slot.
- Renderer `localStorage` is not partitioned per slot, so the first request after switching slots may 401 and require a re-login.

## Test plan

- [x] `go build ./...`, `golangci-lint`, `gofmt`, desktop `typecheck:node` — all green
- [x] pre-commit hook (full Go test suite) — green
- [x] Real smoke: `mise run desktop:dev -- smoke1` booted alongside an existing default instance — Vite on slot web port, local server bound the slot port, isolated `data/instances/smoke1/memoh.db` migrated cleanly, per-slot pid/log/config created
- [ ] Follow-up: unit tests for `ValidateDevSlotName` / `ResolveDevSlot` (reserved/reuse/default) / `nextFreePort` bound