### PR TITLE
fix: use printf to initialize ANSI color variables in installer (#571)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-PURPLE='\033[0;35m'
-RED='\033[0;31m'
-NC='\033[0m'
+GREEN=$(printf '\033[0;32m')
+YELLOW=$(printf '\033[1;33m')
+PURPLE=$(printf '\033[0;35m')
+RED=$(printf '\033[0;31m')
+NC=$(printf '\033[0m')
 
 GITHUB_REPO="memohai/Memoh"
 REPO="https://github.com/${GITHUB_REPO}.git"


### PR DESCRIPTION
Single-quoted assignments store literal \033 strings; bash's echo does not interpret them, causing raw escape sequences to be printed. Using printf at assignment time stores actual ESC bytes, making colored output work portably across bash, sh, and zsh.
Closes #571 