### PR TITLE
fix(web): serve frontend as nginx default_server on :8082

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,8 +24,8 @@ server {
 }
 
 server {
-    listen 8082;
-    listen [::]:8082;
+    listen 8082 default_server;
+    listen [::]:8082 default_server;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Problem

Opening the Web UI at http://localhost:8082 returns 404 on `/` (and 401 on
assets and `/login`); the `web` container also reports `unhealthy`.

## Root cause

`docker/nginx.conf` has two `listen 8082` server blocks:

1. browser-workspace proxy — `server_name ~^.+\.browser\..+$` → `proxy_pass` to the API server
2. static SPA — `server_name _` → `root /usr/share/nginx/html`

The proxy block is declared first and neither is `default_server`, so nginx
treats the proxy block as the default server for `:8082`. Every request whose
`Host` does not match `*.browser.*` (localhost, IPs, real domains) is proxied to
the API instead of served the frontend, so the SPA is unreachable on all paths.
The healthcheck (`wget /health`) hits the API, gets 405, and the container is
marked `unhealthy`.

## Fix

Mark the SPA block (`server_name _`) as `default_server` on both `listen`
directives. `*.browser.*` subdomains still match the proxy block by name, so
browser-workspace routing is unchanged.

## Testing

- Rebuilt the web image from source (`docker build -f docker/Dockerfile.web -t memohai/web:latest .`) and recreated the container.
- `GET /` → 200, serves `index.html` (`<title>Memoh</title>`); `/login` renders.
- `GET /health` → 200 `ok`; `web` container now reports `healthy`.
- `Host: x.browser.localhost` on `/health` → still 405 (proxied to API) — browser vhost intact.
