### PR TITLE
fix: guard login submission while routing

### DIFF
--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <main class="w-screen h-screen flex *:m-auto bg-background relative p-4">
+  <main
+    class="w-screen h-screen flex *:m-auto bg-background relative p-4"
+    :aria-busy="isSubmitting"
+  >
     <header class="absolute top-6 right-6 flex items-center gap-2">
       <Select
         :model-value="language"
@@ -48,7 +51,7 @@
         </h1>
       </section>
       <form
-        @submit="login"
+        @submit.prevent="login"
       >
         <Card class="py-14">
           <CardContent class="flex flex-col [&_input]:py-5 gap-4">
@@ -69,6 +72,7 @@
                     id="username"
                     type="text"
                     :placeholder="$t('auth.username')"
+                    :disabled="isSubmitting"
                     autocomplete="new-password"
                   />
                 </FormControl>
@@ -91,6 +95,7 @@
                     type="password"
                     :placeholder="$t('auth.password')"
                     autocomplete="new-password"
+                    :disabled="isSubmitting"
                     v-bind="componentField"
                   />
                 </FormControl>
@@ -99,14 +104,13 @@
           </CardContent>
 
           <CardFooter>
-            <Button
+            <LoadingButton
               class="w-full"
               type="submit"
-              @click="login"
+              :loading="isSubmitting"
             >
-              <Spinner v-if="loading" />
               {{ $t('auth.login') }}
-            </Button>
+            </LoadingButton>
           </CardFooter>
         </Card>
       </form>
@@ -125,7 +129,6 @@ import {
   FormField,
   FormItem,
   Label,
-  Spinner,
   Select,
   SelectContent,
   SelectGroup,
@@ -146,6 +149,8 @@ import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
 import { postAuthLogin } from '@memohai/sdk'
 import type { Locale } from '@/i18n'
+import LoadingButton from '@/components/loading-button/index.vue'
+import { submitLogin } from './login-submit'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -166,31 +171,18 @@ const form = useForm({
 })
 
 const { login: loginHandle } = useUserStore()
-const loading = ref(false)
+const isSubmitting = ref(false)
 
 const login = form.handleSubmit(async (values) => {
-  try {
-    loading.value = true
-    const { data } = await postAuthLogin({ body: values })
-    if (data?.access_token && data?.user_id) {
-      loginHandle({
-        id: data.user_id,
-        username: data.username,
-        displayName: data.display_name ?? '',
-        role: data.role ?? '',
-        avatarUrl: data.avatar_url ?? '',
-        timezone: data.timezone ?? 'UTC',
-      }, data.access_token)
-    } else {
-      throw new Error(t('auth.loginFailed'))
-    }
-    router.replace({ path: '/' })
-  } catch {
-    toast.error(t('auth.invalidCredentials'), {
-      description: t('auth.retryHint'),
-    })
-  } finally {
-    loading.value = false
-  }
+  await submitLogin(values, isSubmitting, {
+    authenticate: (body) => postAuthLogin({ body }),
+    applyLogin: loginHandle,
+    navigateHome: () => router.replace({ path: '/' }),
+    notifyInvalidCredentials: () => {
+      toast.error(t('auth.invalidCredentials'), {
+        description: t('auth.retryHint'),
+      })
+    },
+  })
 })
 </script>

--- a/apps/web/src/pages/login/login-submit.test.ts
+++ b/apps/web/src/pages/login/login-submit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { submitLogin, type SubmitLoginDependencies } from './login-submit'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function createDependencies(overrides: Partial<SubmitLoginDependencies> = {}): SubmitLoginDependencies {
+  return {
+    authenticate: vi.fn().mockResolvedValue({
+      data: {
+        access_token: 'token',
+        user_id: 'user-1',
+        username: 'alice',
+        display_name: 'Alice',
+        role: 'admin',
+        avatar_url: '',
+        timezone: 'UTC',
+      },
+    }),
+    applyLogin: vi.fn(),
+    navigateHome: vi.fn().mockResolvedValue(undefined),
+    notifyInvalidCredentials: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('submitLogin', () => {
+  it('ignores a submission while another login is already in progress', async () => {
+    const isSubmitting = ref(true)
+    const dependencies = createDependencies()
+
+    await expect(submitLogin({ username: 'alice', password: 'secret' }, isSubmitting, dependencies)).resolves.toBe(false)
+
+    expect(dependencies.authenticate).not.toHaveBeenCalled()
+    expect(dependencies.applyLogin).not.toHaveBeenCalled()
+    expect(isSubmitting.value).toBe(true)
+  })
+
+  it('keeps the form busy until the successful navigation settles', async () => {
+    const isSubmitting = ref(false)
+    const navigation = deferred<void>()
+    const dependencies = createDependencies({
+      navigateHome: vi.fn(() => navigation.promise),
+    })
+
+    const firstSubmission = submitLogin({ username: 'alice', password: 'secret' }, isSubmitting, dependencies)
+    await Promise.resolve()
+
+    expect(isSubmitting.value).toBe(true)
+    expect(dependencies.authenticate).toHaveBeenCalledTimes(1)
+    expect(dependencies.applyLogin).toHaveBeenCalledTimes(1)
+    expect(dependencies.navigateHome).toHaveBeenCalledTimes(1)
+
+    await expect(submitLogin({ username: 'alice', password: 'secret' }, isSubmitting, dependencies)).resolves.toBe(false)
+    expect(dependencies.authenticate).toHaveBeenCalledTimes(1)
+
+    navigation.resolve()
+    await expect(firstSubmission).resolves.toBe(true)
+    expect(isSubmitting.value).toBe(false)
+  })
+
+  it('notifies and releases the form when authentication fails', async () => {
+    const isSubmitting = ref(false)
+    const dependencies = createDependencies({
+      authenticate: vi.fn().mockResolvedValue({ data: null }),
+    })
+
+    await expect(submitLogin({ username: 'alice', password: 'bad' }, isSubmitting, dependencies)).resolves.toBe(false)
+
+    expect(dependencies.applyLogin).not.toHaveBeenCalled()
+    expect(dependencies.navigateHome).not.toHaveBeenCalled()
+    expect(dependencies.notifyInvalidCredentials).toHaveBeenCalledTimes(1)
+    expect(isSubmitting.value).toBe(false)
+  })
+})

--- a/apps/web/src/pages/login/login-submit.ts
+++ b/apps/web/src/pages/login/login-submit.ts
@@ -1,0 +1,63 @@
+import type { Ref } from 'vue'
+import type { UserInfo } from '@/store/user'
+
+export interface LoginCredentials {
+  username: string
+  password: string
+}
+
+interface LoginResponseData {
+  access_token?: string
+  user_id?: string
+  username?: string
+  display_name?: string | null
+  role?: string | null
+  avatar_url?: string | null
+  timezone?: string | null
+}
+
+export interface SubmitLoginDependencies {
+  authenticate: (values: LoginCredentials) => Promise<{ data?: LoginResponseData | null }>
+  applyLogin: (userData: UserInfo, token: string) => void
+  navigateHome: () => Promise<unknown> | unknown
+  notifyInvalidCredentials: () => void
+}
+
+export async function submitLogin(
+  values: LoginCredentials,
+  isSubmitting: Ref<boolean>,
+  dependencies: SubmitLoginDependencies,
+): Promise<boolean> {
+  if (isSubmitting.value) return false
+
+  isSubmitting.value = true
+  try {
+    let data: LoginResponseData | null | undefined
+    try {
+      const response = await dependencies.authenticate(values)
+      data = response.data
+    } catch {
+      dependencies.notifyInvalidCredentials()
+      return false
+    }
+
+    if (!data?.access_token || !data.user_id) {
+      dependencies.notifyInvalidCredentials()
+      return false
+    }
+
+    dependencies.applyLogin({
+      id: data.user_id,
+      username: data.username ?? '',
+      displayName: data.display_name ?? '',
+      role: data.role ?? '',
+      avatarUrl: data.avatar_url ?? '',
+      timezone: data.timezone ?? 'UTC',
+    }, data.access_token)
+
+    await dependencies.navigateHome()
+    return true
+  } finally {
+    isSubmitting.value = false
+  }
+}


### PR DESCRIPTION
## Summary

- Prevent duplicate login submissions while an existing login attempt is in progress.
- Keep the login form in a busy/disabled state until post-login navigation finishes.
- Remove the duplicate button click submission path and rely on the form submit handler.
- Add focused tests for login submission idempotency and busy-state behavior.

---

The login page previously showed a spinner during authentication, but the form remained interactive and the submit handler could be triggered again. On successful login, the UI could also become interactive before `router.replace('/')` and route guards completed, which made the several-second transition window race-prone.

This change extracts the login submission flow into a small tested helper, blocks concurrent submissions, disables the username/password inputs and submit button while busy, and awaits navigation before releasing the busy state.