### PR TITLE
fix: close desktop tab with cmd+w

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,7 @@ import {
   writeCliPrefs,
   type CliStatus,
 } from './cli-integration'
+import { closeFocusedTabOrWindow } from './window-commands'
 
 type DesktopRuntimeMode = 'local' | 'remote'
 
@@ -788,6 +789,17 @@ function dispatchSettingsNavigate(window: BrowserWindow, target: string): void {
   window.webContents.send('settings:navigate', target)
 }
 
+function closeWindowMenuItem(): MenuItemConstructorOptions {
+  if (process.platform !== 'darwin') return { role: 'close' }
+  return {
+    label: 'Close',
+    accelerator: 'Command+W',
+    click: () => {
+      closeFocusedTabOrWindow(chatWindow, BrowserWindow.getFocusedWindow())
+    },
+  }
+}
+
 // CLI install / menu helpers — kept above the whenReady block so the
 // Promise chain can call them without forward-declaration noise.
 
@@ -913,7 +925,7 @@ async function rebuildAppMenu(): Promise<void> {
         label: 'Window',
         submenu: [
           { role: 'minimize' },
-          { role: 'close' },
+          closeWindowMenuItem(),
         ],
       },
     )
@@ -1016,7 +1028,7 @@ async function rebuildAppMenu(): Promise<void> {
       label: 'Window',
       submenu: [
         { role: 'minimize' },
-        { role: 'close' },
+        closeWindowMenuItem(),
       ],
     },
   )

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,7 +35,8 @@ import {
   writeCliPrefs,
   type CliStatus,
 } from './cli-integration'
-import { closeFocusedTabOrWindow } from './window-commands'
+import { desktopKeyboardCommands } from '../shared/keyboard-commands'
+import { dispatchFocusedWindowCommand } from './window-commands'
 
 type DesktopRuntimeMode = 'local' | 'remote'
 
@@ -795,7 +796,11 @@ function closeWindowMenuItem(): MenuItemConstructorOptions {
     label: 'Close',
     accelerator: 'Command+W',
     click: () => {
-      closeFocusedTabOrWindow(chatWindow, BrowserWindow.getFocusedWindow())
+      dispatchFocusedWindowCommand(
+        chatWindow,
+        BrowserWindow.getFocusedWindow(),
+        desktopKeyboardCommands.closeCurrentWorkspaceTab,
+      )
     },
   }
 }

--- a/apps/desktop/src/main/window-commands.test.ts
+++ b/apps/desktop/src/main/window-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { closeFocusedTabOrWindow, CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL } from './window-commands'
+import { DESKTOP_KEYBOARD_COMMAND_CHANNEL, desktopKeyboardCommands } from '../shared/keyboard-commands'
+import { dispatchFocusedWindowCommand } from './window-commands'
 
 function createWindow() {
   return {
@@ -11,22 +12,33 @@ function createWindow() {
   }
 }
 
-describe('closeFocusedTabOrWindow', () => {
-  it('asks the chat renderer to close the current workspace tab', () => {
+describe('dispatchFocusedWindowCommand', () => {
+  it('dispatches keyboard commands to the chat renderer', () => {
     const chatWindow = createWindow()
 
-    const handled = closeFocusedTabOrWindow(chatWindow, chatWindow)
+    const handled = dispatchFocusedWindowCommand(
+      chatWindow,
+      chatWindow,
+      desktopKeyboardCommands.closeCurrentWorkspaceTab,
+    )
 
     expect(handled).toBe(true)
-    expect(chatWindow.webContents.send).toHaveBeenCalledWith(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL)
+    expect(chatWindow.webContents.send).toHaveBeenCalledWith(
+      DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+      desktopKeyboardCommands.closeCurrentWorkspaceTab,
+    )
     expect(chatWindow.close).not.toHaveBeenCalled()
   })
 
-  it('closes the focused non-chat window', () => {
+  it('keeps the close-tab command mapped to native close for non-chat windows', () => {
     const chatWindow = createWindow()
     const settingsWindow = createWindow()
 
-    const handled = closeFocusedTabOrWindow(chatWindow, settingsWindow)
+    const handled = dispatchFocusedWindowCommand(
+      chatWindow,
+      settingsWindow,
+      desktopKeyboardCommands.closeCurrentWorkspaceTab,
+    )
 
     expect(handled).toBe(true)
     expect(settingsWindow.close).toHaveBeenCalledOnce()

--- a/apps/desktop/src/main/window-commands.test.ts
+++ b/apps/desktop/src/main/window-commands.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { closeFocusedTabOrWindow, CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL } from './window-commands'
+
+function createWindow() {
+  return {
+    close: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      send: vi.fn(),
+    },
+  }
+}
+
+describe('closeFocusedTabOrWindow', () => {
+  it('asks the chat renderer to close the current workspace tab', () => {
+    const chatWindow = createWindow()
+
+    const handled = closeFocusedTabOrWindow(chatWindow, chatWindow)
+
+    expect(handled).toBe(true)
+    expect(chatWindow.webContents.send).toHaveBeenCalledWith(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL)
+    expect(chatWindow.close).not.toHaveBeenCalled()
+  })
+
+  it('closes the focused non-chat window', () => {
+    const chatWindow = createWindow()
+    const settingsWindow = createWindow()
+
+    const handled = closeFocusedTabOrWindow(chatWindow, settingsWindow)
+
+    expect(handled).toBe(true)
+    expect(settingsWindow.close).toHaveBeenCalledOnce()
+    expect(settingsWindow.webContents.send).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/window-commands.ts
+++ b/apps/desktop/src/main/window-commands.ts
@@ -1,0 +1,24 @@
+export const CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL = 'workspace-tab:close-current'
+
+interface CommandWindow {
+  close(): void
+  isDestroyed(): boolean
+  webContents: {
+    send(channel: string): void
+  }
+}
+
+export function closeFocusedTabOrWindow(
+  chatWindow: CommandWindow | null,
+  focusedWindow: CommandWindow | null,
+): boolean {
+  if (!focusedWindow || focusedWindow.isDestroyed()) return false
+
+  if (chatWindow && !chatWindow.isDestroyed() && focusedWindow === chatWindow) {
+    focusedWindow.webContents.send(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL)
+    return true
+  }
+
+  focusedWindow.close()
+  return true
+}

--- a/apps/desktop/src/main/window-commands.ts
+++ b/apps/desktop/src/main/window-commands.ts
@@ -1,24 +1,33 @@
-export const CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL = 'workspace-tab:close-current'
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  desktopKeyboardCommands,
+  type DesktopKeyboardCommand,
+} from '../shared/keyboard-commands'
 
 interface CommandWindow {
   close(): void
   isDestroyed(): boolean
   webContents: {
-    send(channel: string): void
+    send(channel: string, command: DesktopKeyboardCommand): void
   }
 }
 
-export function closeFocusedTabOrWindow(
+export function dispatchFocusedWindowCommand(
   chatWindow: CommandWindow | null,
   focusedWindow: CommandWindow | null,
+  command: DesktopKeyboardCommand,
 ): boolean {
   if (!focusedWindow || focusedWindow.isDestroyed()) return false
 
   if (chatWindow && !chatWindow.isDestroyed() && focusedWindow === chatWindow) {
-    focusedWindow.webContents.send(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL)
+    focusedWindow.webContents.send(DESKTOP_KEYBOARD_COMMAND_CHANNEL, command)
     return true
   }
 
-  focusedWindow.close()
-  return true
+  if (command === desktopKeyboardCommands.closeCurrentWorkspaceTab) {
+    focusedWindow.close()
+    return true
+  }
+
+  return false
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
+const CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL = 'workspace-tab:close-current'
+
 // Cross-window query-cache invalidation payload. Mirrors the subset of
 // Pinia Colada's `UseQueryEntryFilter` that survives structured-clone
 // serialization across the IPC boundary (no functions / predicates).
@@ -86,6 +88,11 @@ const api = {
     onChatNavigate: (cb: (target: string) => void): void => {
       ipcRenderer.on('chat:navigate', (_event: IpcRendererEvent, target: string) => {
         cb(target)
+      })
+    },
+    onCloseCurrentWorkspaceTab: (cb: () => void): void => {
+      ipcRenderer.on(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL, () => {
+        cb()
       })
     },
   },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,7 +1,10 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-
-const CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL = 'workspace-tab:close-current'
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  isDesktopKeyboardCommand,
+  type DesktopKeyboardCommand,
+} from '../shared/keyboard-commands'
 
 // Cross-window query-cache invalidation payload. Mirrors the subset of
 // Pinia Colada's `UseQueryEntryFilter` that survives structured-clone
@@ -90,10 +93,14 @@ const api = {
         cb(target)
       })
     },
-    onCloseCurrentWorkspaceTab: (cb: () => void): void => {
-      ipcRenderer.on(CLOSE_CURRENT_WORKSPACE_TAB_CHANNEL, () => {
-        cb()
-      })
+    onKeyboardCommand: (cb: (command: DesktopKeyboardCommand) => void): (() => void) => {
+      const listener = (_event: IpcRendererEvent, command: unknown) => {
+        if (isDesktopKeyboardCommand(command)) cb(command)
+      }
+      ipcRenderer.on(DESKTOP_KEYBOARD_COMMAND_CHANNEL, listener)
+      return () => {
+        ipcRenderer.removeListener(DESKTOP_KEYBOARD_COMMAND_CHANNEL, listener)
+      }
     },
   },
 }

--- a/apps/desktop/src/renderer/src/chat/workspace-tab-commands.test.ts
+++ b/apps/desktop/src/renderer/src/chat/workspace-tab-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { closeCurrentWorkspaceTab, registerWorkspaceTabCommands } from './workspace-tab-commands'
+import { desktopKeyboardCommands } from '../../../shared/keyboard-commands'
+import { handleWorkspaceKeyboardCommand, registerWorkspaceTabCommands } from './workspace-tab-commands'
 
 describe('workspace tab commands', () => {
   it('closes the active workspace tab', () => {
@@ -8,7 +9,7 @@ describe('workspace tab commands', () => {
       closeTab: vi.fn(),
     }
 
-    expect(closeCurrentWorkspaceTab(store)).toBe(true)
+    expect(handleWorkspaceKeyboardCommand(desktopKeyboardCommands.closeCurrentWorkspaceTab, store)).toBe(true)
     expect(store.closeTab).toHaveBeenCalledWith('terminal:1')
   })
 
@@ -18,15 +19,17 @@ describe('workspace tab commands', () => {
       closeTab: vi.fn(),
     }
 
-    expect(closeCurrentWorkspaceTab(store)).toBe(false)
+    expect(handleWorkspaceKeyboardCommand(desktopKeyboardCommands.closeCurrentWorkspaceTab, store)).toBe(false)
     expect(store.closeTab).not.toHaveBeenCalled()
   })
 
-  it('registers the desktop close-tab command', () => {
-    const listeners: Array<() => void> = []
-    const api = {
-      onCloseCurrentWorkspaceTab: vi.fn((cb: () => void) => {
-        listeners.push(cb)
+  it('registers the close-tab command with a keyboard registry', () => {
+    const handlers = new Map<string, () => boolean>()
+    const unregister = vi.fn()
+    const registry = {
+      register: vi.fn((command: string, handler: () => boolean) => {
+        handlers.set(command, handler)
+        return unregister
       }),
     }
     const store = {
@@ -34,12 +37,14 @@ describe('workspace tab commands', () => {
       closeTab: vi.fn(),
     }
 
-    registerWorkspaceTabCommands(api, store)
-    const listener = listeners[0]
-    if (!listener) throw new Error('close-tab listener was not registered')
-    listener()
+    const cleanup = registerWorkspaceTabCommands(registry, store)
+    const handler = handlers.get(desktopKeyboardCommands.closeCurrentWorkspaceTab)
+    if (!handler) throw new Error('close-tab handler was not registered')
 
-    expect(api.onCloseCurrentWorkspaceTab).toHaveBeenCalledOnce()
+    expect(registry.register).toHaveBeenCalledWith(desktopKeyboardCommands.closeCurrentWorkspaceTab, expect.any(Function))
+    expect(handler()).toBe(true)
     expect(store.closeTab).toHaveBeenCalledWith('browser:1')
+    cleanup()
+    expect(unregister).toHaveBeenCalledOnce()
   })
 })

--- a/apps/desktop/src/renderer/src/chat/workspace-tab-commands.test.ts
+++ b/apps/desktop/src/renderer/src/chat/workspace-tab-commands.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { closeCurrentWorkspaceTab, registerWorkspaceTabCommands } from './workspace-tab-commands'
+
+describe('workspace tab commands', () => {
+  it('closes the active workspace tab', () => {
+    const store = {
+      activeId: 'terminal:1',
+      closeTab: vi.fn(),
+    }
+
+    expect(closeCurrentWorkspaceTab(store)).toBe(true)
+    expect(store.closeTab).toHaveBeenCalledWith('terminal:1')
+  })
+
+  it('leaves the workspace unchanged when there is no active tab', () => {
+    const store = {
+      activeId: null,
+      closeTab: vi.fn(),
+    }
+
+    expect(closeCurrentWorkspaceTab(store)).toBe(false)
+    expect(store.closeTab).not.toHaveBeenCalled()
+  })
+
+  it('registers the desktop close-tab command', () => {
+    const listeners: Array<() => void> = []
+    const api = {
+      onCloseCurrentWorkspaceTab: vi.fn((cb: () => void) => {
+        listeners.push(cb)
+      }),
+    }
+    const store = {
+      activeId: 'browser:1',
+      closeTab: vi.fn(),
+    }
+
+    registerWorkspaceTabCommands(api, store)
+    const listener = listeners[0]
+    if (!listener) throw new Error('close-tab listener was not registered')
+    listener()
+
+    expect(api.onCloseCurrentWorkspaceTab).toHaveBeenCalledOnce()
+    expect(store.closeTab).toHaveBeenCalledWith('browser:1')
+  })
+})

--- a/apps/desktop/src/renderer/src/chat/workspace-tab-commands.ts
+++ b/apps/desktop/src/renderer/src/chat/workspace-tab-commands.ts
@@ -1,13 +1,19 @@
-export interface WorkspaceTabCommandApi {
-  onCloseCurrentWorkspaceTab(cb: () => void): void
-}
+import {
+  desktopKeyboardCommands,
+  type DesktopKeyboardCommand,
+} from '../../../shared/keyboard-commands'
+import type { KeyboardCommandRegistry } from '../keyboard-command-registry'
 
 export interface WorkspaceTabCommandStore {
   activeId: string | null
   closeTab(id: string): void
 }
 
-export function closeCurrentWorkspaceTab(store: WorkspaceTabCommandStore): boolean {
+export function handleWorkspaceKeyboardCommand(
+  command: DesktopKeyboardCommand,
+  store: WorkspaceTabCommandStore,
+): boolean {
+  if (command !== desktopKeyboardCommands.closeCurrentWorkspaceTab) return false
   const activeId = store.activeId
   if (!activeId) return false
   store.closeTab(activeId)
@@ -15,10 +21,10 @@ export function closeCurrentWorkspaceTab(store: WorkspaceTabCommandStore): boole
 }
 
 export function registerWorkspaceTabCommands(
-  api: WorkspaceTabCommandApi,
+  registry: Pick<KeyboardCommandRegistry, 'register'>,
   store: WorkspaceTabCommandStore,
-): void {
-  api.onCloseCurrentWorkspaceTab(() => {
-    closeCurrentWorkspaceTab(store)
-  })
+): () => void {
+  return registry.register(desktopKeyboardCommands.closeCurrentWorkspaceTab, () =>
+    handleWorkspaceKeyboardCommand(desktopKeyboardCommands.closeCurrentWorkspaceTab, store),
+  )
 }

--- a/apps/desktop/src/renderer/src/chat/workspace-tab-commands.ts
+++ b/apps/desktop/src/renderer/src/chat/workspace-tab-commands.ts
@@ -1,0 +1,24 @@
+export interface WorkspaceTabCommandApi {
+  onCloseCurrentWorkspaceTab(cb: () => void): void
+}
+
+export interface WorkspaceTabCommandStore {
+  activeId: string | null
+  closeTab(id: string): void
+}
+
+export function closeCurrentWorkspaceTab(store: WorkspaceTabCommandStore): boolean {
+  const activeId = store.activeId
+  if (!activeId) return false
+  store.closeTab(activeId)
+  return true
+}
+
+export function registerWorkspaceTabCommands(
+  api: WorkspaceTabCommandApi,
+  store: WorkspaceTabCommandStore,
+): void {
+  api.onCloseCurrentWorkspaceTab(() => {
+    closeCurrentWorkspaceTab(store)
+  })
+}

--- a/apps/desktop/src/renderer/src/keyboard-command-registry.test.ts
+++ b/apps/desktop/src/renderer/src/keyboard-command-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { desktopKeyboardCommands } from '../../shared/keyboard-commands'
+import { createKeyboardCommandRegistry } from './keyboard-command-registry'
+
+describe('keyboard command registry', () => {
+  it('dispatches registered command handlers', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    registry.register(desktopKeyboardCommands.closeCurrentWorkspaceTab, handler)
+
+    expect(registry.dispatch(desktopKeyboardCommands.closeCurrentWorkspaceTab)).toBe(true)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('unregisters command handlers', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    const unregister = registry.register(desktopKeyboardCommands.closeCurrentWorkspaceTab, handler)
+    unregister()
+
+    expect(registry.dispatch(desktopKeyboardCommands.closeCurrentWorkspaceTab)).toBe(false)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('connects preload command events to the registry', () => {
+    const listeners: Array<(command: string) => void> = []
+    const unsubscribe = vi.fn()
+    const api = {
+      onKeyboardCommand: vi.fn((cb: (command: string) => void) => {
+        listeners.push(cb)
+        return unsubscribe
+      }),
+    }
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    registry.register(desktopKeyboardCommands.closeCurrentWorkspaceTab, handler)
+    const disconnect = registry.connect(api)
+    const listener = listeners[0]
+    if (!listener) throw new Error('keyboard command listener was not registered')
+    listener(desktopKeyboardCommands.closeCurrentWorkspaceTab)
+    disconnect()
+
+    expect(api.onKeyboardCommand).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledOnce()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/renderer/src/keyboard-command-registry.ts
+++ b/apps/desktop/src/renderer/src/keyboard-command-registry.ts
@@ -1,0 +1,46 @@
+import type { DesktopKeyboardCommand } from '../../shared/keyboard-commands'
+
+export type KeyboardCommandHandler = () => boolean | void
+
+export interface KeyboardCommandApi {
+  onKeyboardCommand(cb: (command: DesktopKeyboardCommand) => void): (() => void) | void
+}
+
+export interface KeyboardCommandRegistry {
+  register(command: DesktopKeyboardCommand, handler: KeyboardCommandHandler): () => void
+  dispatch(command: DesktopKeyboardCommand): boolean
+  connect(api: KeyboardCommandApi): () => void
+}
+
+export function createKeyboardCommandRegistry(): KeyboardCommandRegistry {
+  const handlers = new Map<DesktopKeyboardCommand, Set<KeyboardCommandHandler>>()
+
+  return {
+    register(command, handler) {
+      const commandHandlers = handlers.get(command) ?? new Set<KeyboardCommandHandler>()
+      commandHandlers.add(handler)
+      handlers.set(command, commandHandlers)
+      return () => {
+        commandHandlers.delete(handler)
+        if (commandHandlers.size === 0) handlers.delete(command)
+      }
+    },
+
+    dispatch(command) {
+      const commandHandlers = handlers.get(command)
+      if (!commandHandlers) return false
+      let handled = false
+      for (const handler of commandHandlers) {
+        handled = handler() === true || handled
+      }
+      return handled
+    },
+
+    connect(api) {
+      const unsubscribe = api.onKeyboardCommand((command) => {
+        this.dispatch(command)
+      })
+      return typeof unsubscribe === 'function' ? unsubscribe : () => {}
+    },
+  }
+}

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -9,6 +9,7 @@ import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import i18n from '@memohai/web/i18n'
 import { setupApiClient } from '@memohai/web/api-client'
+import { useWorkspaceTabsStore } from '@memohai/web/store/workspace-tabs'
 
 import 'markstream-vue/index.css'
 import '@memohai/web/style.css'
@@ -19,6 +20,7 @@ import 'katex/dist/katex.min.css'
 import App from './chat/App.vue'
 import router from './chat/router'
 import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
+import { registerWorkspaceTabCommands } from './chat/workspace-tab-commands'
 
 async function bootstrap() {
   const status = await window.api.desktop.getServerStatus()
@@ -36,8 +38,11 @@ async function bootstrap() {
     void router.push(target)
   })
 
+  const pinia = createPinia().use(piniaPluginPersistedstate)
+  registerWorkspaceTabCommands(window.api.window, useWorkspaceTabsStore(pinia))
+
   const app = createApp(App)
-    .use(createPinia().use(piniaPluginPersistedstate))
+    .use(pinia)
     .use(PiniaColada)
     .use(router)
     .use(i18n)

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -20,6 +20,7 @@ import 'katex/dist/katex.min.css'
 import App from './chat/App.vue'
 import router from './chat/router'
 import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
+import { createKeyboardCommandRegistry } from './keyboard-command-registry'
 import { registerWorkspaceTabCommands } from './chat/workspace-tab-commands'
 
 async function bootstrap() {
@@ -39,7 +40,9 @@ async function bootstrap() {
   })
 
   const pinia = createPinia().use(piniaPluginPersistedstate)
-  registerWorkspaceTabCommands(window.api.window, useWorkspaceTabsStore(pinia))
+  const keyboardCommands = createKeyboardCommandRegistry()
+  keyboardCommands.connect(window.api.window)
+  registerWorkspaceTabCommands(keyboardCommands, useWorkspaceTabsStore(pinia))
 
   const app = createApp(App)
     .use(pinia)

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -49,6 +49,13 @@ declare module '@memohai/web/store/settings' {
   export function useSettingsStore(): unknown
 }
 
+declare module '@memohai/web/store/workspace-tabs' {
+  export function useWorkspaceTabsStore(pinia?: unknown): {
+    activeId: string | null
+    closeTab: (id: string) => void
+  }
+}
+
 declare module '@memohai/web/store/user' {
   export function useUserStore(): {
     userInfo: {

--- a/apps/desktop/src/shared/keyboard-commands.test.ts
+++ b/apps/desktop/src/shared/keyboard-commands.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  desktopKeyboardCommands,
+  isDesktopKeyboardCommand,
+} from './keyboard-commands'
+
+describe('keyboard command protocol', () => {
+  it('defines a stable command channel and validates command ids', () => {
+    expect(DESKTOP_KEYBOARD_COMMAND_CHANNEL).toBe('desktop:keyboard-command')
+    expect(isDesktopKeyboardCommand(desktopKeyboardCommands.closeCurrentWorkspaceTab)).toBe(true)
+    expect(isDesktopKeyboardCommand('workspace-tab:close-current')).toBe(false)
+    expect(isDesktopKeyboardCommand(null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/shared/keyboard-commands.ts
+++ b/apps/desktop/src/shared/keyboard-commands.ts
@@ -1,0 +1,14 @@
+export const DESKTOP_KEYBOARD_COMMAND_CHANNEL = 'desktop:keyboard-command'
+
+export const desktopKeyboardCommands = {
+  closeCurrentWorkspaceTab: 'close-current-workspace-tab',
+} as const
+
+export type DesktopKeyboardCommand =
+  typeof desktopKeyboardCommands[keyof typeof desktopKeyboardCommands]
+
+const desktopKeyboardCommandValues = new Set<string>(Object.values(desktopKeyboardCommands))
+
+export function isDesktopKeyboardCommand(value: unknown): value is DesktopKeyboardCommand {
+  return typeof value === 'string' && desktopKeyboardCommandValues.has(value)
+}


### PR DESCRIPTION
## Summary

- Make macOS `Cmd+W` close the active desktop workspace tab instead of closing the chat window.
- Add a shared typed desktop keyboard command layer between main, preload, and renderer.
- Register workspace-tab closing through the renderer command registry while preserving native close behavior for non-chat windows.