### PR TITLE
fix(memory): prevent built-in compact from truncating memories without LLM

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -1181,7 +1181,7 @@ func (c *lazyLLMClient) Decide(ctx context.Context, req memprovider.DecideReques
 }
 
 func (c *lazyLLMClient) Compact(ctx context.Context, req memprovider.CompactRequest) (memprovider.CompactResponse, error) {
-	client, err := c.resolve(ctx, "")
+	client, err := c.resolve(ctx, req.BotID)
 	if err != nil {
 		return memprovider.CompactResponse{}, err
 	}

--- a/internal/handlers/memory.go
+++ b/internal/handlers/memory.go
@@ -851,41 +851,16 @@ func (r *fileMemoryRuntime) DeleteAll(ctx context.Context, req memprovider.Delet
 	return memprovider.DeleteResponse{Message: "All memories deleted successfully!"}, nil
 }
 
-func (r *fileMemoryRuntime) Compact(ctx context.Context, filters map[string]any, ratio float64, _ int) (memprovider.CompactResult, error) {
+func (r *fileMemoryRuntime) ReplaceAll(ctx context.Context, filters map[string]any, items []memprovider.MemoryItem) error {
 	botID, err := runtimeBotID("", filters)
 	if err != nil {
-		return memprovider.CompactResult{}, err
+		return err
 	}
-	if ratio <= 0 || ratio > 1 {
-		return memprovider.CompactResult{}, echo.NewHTTPError(http.StatusBadRequest, "ratio must be in range (0, 1]")
+	storeItems := make([]storefs.MemoryItem, 0, len(items))
+	for _, item := range items {
+		storeItems = append(storeItems, runtimeToStoreItem(item))
 	}
-	items, err := r.store.ReadAllMemoryFiles(ctx, botID)
-	if err != nil {
-		return memprovider.CompactResult{}, err
-	}
-	before := len(items)
-	if before == 0 {
-		return memprovider.CompactResult{BeforeCount: 0, AfterCount: 0, Ratio: ratio, Results: []memprovider.MemoryItem{}}, nil
-	}
-	sort.Slice(items, func(i, j int) bool { return items[i].UpdatedAt > items[j].UpdatedAt })
-	target := int(float64(before) * ratio)
-	if target < 1 {
-		target = 1
-	}
-	if target > before {
-		target = before
-	}
-	keptStore := append([]storefs.MemoryItem(nil), items[:target]...)
-	if err := r.store.RebuildFiles(ctx, botID, keptStore, filters); err != nil {
-		return memprovider.CompactResult{}, err
-	}
-	kept := runtimeFromStoreItems(keptStore)
-	return memprovider.CompactResult{
-		BeforeCount: before,
-		AfterCount:  len(kept),
-		Ratio:       ratio,
-		Results:     kept,
-	}, nil
+	return r.store.RebuildFiles(ctx, botID, storeItems, filters)
 }
 
 func (r *fileMemoryRuntime) Usage(ctx context.Context, filters map[string]any) (memprovider.UsageResponse, error) {

--- a/internal/memory/adapters/builtin/builtin.go
+++ b/internal/memory/adapters/builtin/builtin.go
@@ -3,9 +3,12 @@ package builtin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/memohai/memoh/internal/conversation"
 	"github.com/memohai/memoh/internal/mcp"
@@ -43,7 +46,7 @@ type memoryRuntime interface {
 	Delete(ctx context.Context, memoryID string) (adapters.DeleteResponse, error)
 	DeleteBatch(ctx context.Context, memoryIDs []string) (adapters.DeleteResponse, error)
 	DeleteAll(ctx context.Context, req adapters.DeleteAllRequest) (adapters.DeleteResponse, error)
-	Compact(ctx context.Context, filters map[string]any, ratio float64, decayDays int) (adapters.CompactResult, error)
+	ReplaceAll(ctx context.Context, filters map[string]any, items []adapters.MemoryItem) error
 	Usage(ctx context.Context, filters map[string]any) (adapters.UsageResponse, error)
 	Mode() string
 	Status(ctx context.Context, botID string) (adapters.MemoryStatusResponse, error)
@@ -445,7 +448,95 @@ func (p *BuiltinProvider) Compact(ctx context.Context, filters map[string]any, r
 	if p.service == nil {
 		return adapters.CompactResult{}, errors.New("memory runtime not configured")
 	}
-	return p.service.Compact(ctx, filters, ratio, decayDays)
+	if p.llm == nil {
+		return adapters.CompactResult{}, errors.New("memory llm not configured")
+	}
+	if ratio <= 0 || ratio > 1 {
+		return adapters.CompactResult{}, errors.New("ratio must be in range (0, 1]")
+	}
+	botID, err := runtimeBotID("", filters)
+	if err != nil {
+		return adapters.CompactResult{}, err
+	}
+	current, err := p.service.GetAll(ctx, adapters.GetAllRequest{BotID: botID, Filters: filters})
+	if err != nil {
+		return adapters.CompactResult{}, err
+	}
+	before := len(current.Results)
+	if before <= 1 {
+		return adapters.CompactResult{BeforeCount: before, AfterCount: before, Ratio: 1, Results: current.Results}, nil
+	}
+
+	candidates := make([]adapters.CandidateMemory, 0, before)
+	for _, item := range current.Results {
+		item.Memory = strings.TrimSpace(item.Memory)
+		if item.Memory == "" {
+			continue
+		}
+		candidates = append(candidates, adapters.CandidateMemory{
+			ID:        item.ID,
+			Memory:    item.Memory,
+			CreatedAt: item.CreatedAt,
+			Metadata:  item.Metadata,
+		})
+	}
+	if len(candidates) == 0 {
+		return adapters.CompactResult{}, errors.New("memory compact: no non-empty memories")
+	}
+	candidateCount := len(candidates)
+	targetCount := int(math.Round(float64(candidateCount) * ratio))
+	if targetCount < 1 {
+		targetCount = 1
+	}
+	if targetCount > candidateCount {
+		targetCount = candidateCount
+	}
+	resp, err := p.llm.Compact(ctx, adapters.CompactRequest{
+		BotID:       botID,
+		Memories:    candidates,
+		TargetCount: targetCount,
+		DecayDays:   decayDays,
+	})
+	if err != nil {
+		return adapters.CompactResult{}, fmt.Errorf("compact llm call failed: %w", err)
+	}
+
+	now := time.Now().UTC()
+	items := make([]adapters.MemoryItem, 0, len(resp.Facts))
+	seen := make(map[string]struct{}, len(resp.Facts))
+	for _, fact := range resp.Facts {
+		fact = strings.TrimSpace(fact)
+		if fact == "" {
+			continue
+		}
+		if _, ok := seen[fact]; ok {
+			continue
+		}
+		seen[fact] = struct{}{}
+		timestamp := now.Format(time.RFC3339)
+		items = append(items, adapters.MemoryItem{
+			ID:        runtimeMemoryID(botID, now),
+			Memory:    fact,
+			Hash:      runtimeHash(fact),
+			CreatedAt: timestamp,
+			UpdatedAt: timestamp,
+			BotID:     botID,
+		})
+		now = now.Add(time.Nanosecond)
+	}
+	if len(items) == 0 {
+		return adapters.CompactResult{}, errors.New("compact returned no facts")
+	}
+	if err := p.service.ReplaceAll(ctx, filters, items); err != nil {
+		return adapters.CompactResult{}, err
+	}
+	actualRatio := math.Round((float64(len(items))/float64(before))*100) / 100
+	return adapters.CompactResult{
+		BeforeCount: before,
+		AfterCount:  len(items),
+		Ratio:       actualRatio,
+		Results:     items,
+	}, nil
 }
 
 func (p *BuiltinProvider) Usage(ctx context.Context, filters map[string]any) (adapters.UsageResponse, error) {

--- a/internal/memory/adapters/builtin/builtin_test.go
+++ b/internal/memory/adapters/builtin/builtin_test.go
@@ -187,6 +187,113 @@ func TestBuiltinProviderCRUDErrorsWithNilService(t *testing.T) {
 	}
 }
 
+func TestBuiltinProviderCompactUsesLLMAndReplacesWithFacts(t *testing.T) {
+	t.Parallel()
+	runtime := newFakeCompactRuntime([]adapters.MemoryItem{
+		{ID: "bot-1:mem_old", Memory: "old unchanged memory", CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "bot-1:mem_new", Memory: "new unchanged memory", CreatedAt: "2026-01-02T00:00:00Z", UpdatedAt: "2026-01-02T00:00:00Z"},
+		{ID: "bot-1:mem_mid", Memory: "middle unchanged memory", CreatedAt: "2026-01-03T00:00:00Z", UpdatedAt: "2026-01-03T00:00:00Z"},
+	})
+	llm := &fakeLLM{compactFacts: []string{"User prefers tea", "User lives in Berlin"}}
+	p := NewBuiltinProvider(slog.Default(), runtime, nil, nil)
+	p.SetLLM(llm)
+
+	result, err := p.Compact(context.Background(), map[string]any{"bot_id": "bot-1"}, 0.5, 30)
+	if err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if llm.compactCalls != 1 {
+		t.Fatalf("expected one LLM compact call, got %d", llm.compactCalls)
+	}
+	if llm.compactReq.BotID != "bot-1" {
+		t.Fatalf("expected compact BotID bot-1, got %q", llm.compactReq.BotID)
+	}
+	if llm.compactReq.TargetCount != 2 {
+		t.Fatalf("expected target count 2, got %d", llm.compactReq.TargetCount)
+	}
+	if llm.compactReq.DecayDays != 30 {
+		t.Fatalf("expected decay days 30, got %d", llm.compactReq.DecayDays)
+	}
+	if len(llm.compactReq.Memories) != 3 {
+		t.Fatalf("expected 3 candidate memories, got %d", len(llm.compactReq.Memories))
+	}
+	if runtime.replaceCalls != 1 {
+		t.Fatalf("expected one replace call, got %d", runtime.replaceCalls)
+	}
+	if len(runtime.replaced) != 2 {
+		t.Fatalf("expected 2 replaced memories, got %d", len(runtime.replaced))
+	}
+	if runtime.replaced[0].Memory != "User prefers tea" || runtime.replaced[1].Memory != "User lives in Berlin" {
+		t.Fatalf("expected LLM facts to replace source, got %#v", runtime.replaced)
+	}
+	for _, item := range runtime.replaced {
+		if strings.Contains(item.Memory, "unchanged memory") {
+			t.Fatalf("provider compact kept original memory instead of LLM fact: %#v", runtime.replaced)
+		}
+	}
+	if result.BeforeCount != 3 || result.AfterCount != 2 {
+		t.Fatalf("unexpected compact counts: %#v", result)
+	}
+}
+
+func TestBuiltinProviderCompactTargetCountUsesNonEmptyCandidates(t *testing.T) {
+	t.Parallel()
+	runtime := newFakeCompactRuntime([]adapters.MemoryItem{
+		{ID: "bot-1:mem_1", Memory: "one"},
+		{ID: "bot-1:mem_blank", Memory: "   "},
+		{ID: "bot-1:mem_2", Memory: "two"},
+	})
+	llm := &fakeLLM{compactFacts: []string{"one and two"}}
+	p := NewBuiltinProvider(slog.Default(), runtime, nil, nil)
+	p.SetLLM(llm)
+
+	if _, err := p.Compact(context.Background(), map[string]any{"bot_id": "bot-1"}, 1, 0); err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+	if len(llm.compactReq.Memories) != 2 {
+		t.Fatalf("expected 2 candidate memories, got %d", len(llm.compactReq.Memories))
+	}
+	if llm.compactReq.TargetCount != 2 {
+		t.Fatalf("expected target count 2, got %d", llm.compactReq.TargetCount)
+	}
+}
+
+func TestBuiltinProviderCompactDoesNotReplaceWhenLLMFails(t *testing.T) {
+	t.Parallel()
+	runtime := newFakeCompactRuntime([]adapters.MemoryItem{
+		{ID: "bot-1:mem_1", Memory: "one"},
+		{ID: "bot-1:mem_2", Memory: "two"},
+	})
+	llm := &fakeLLM{compactErr: errFakeCompact}
+	p := NewBuiltinProvider(slog.Default(), runtime, nil, nil)
+	p.SetLLM(llm)
+
+	if _, err := p.Compact(context.Background(), map[string]any{"bot_id": "bot-1"}, 0.5, 0); err == nil {
+		t.Fatal("expected compact error")
+	}
+	if runtime.replaceCalls != 0 {
+		t.Fatalf("replace should not be called when LLM fails, got %d", runtime.replaceCalls)
+	}
+}
+
+func TestBuiltinProviderCompactDoesNotReplaceWhenLLMReturnsNoFacts(t *testing.T) {
+	t.Parallel()
+	runtime := newFakeCompactRuntime([]adapters.MemoryItem{
+		{ID: "bot-1:mem_1", Memory: "one"},
+		{ID: "bot-1:mem_2", Memory: "two"},
+	})
+	llm := &fakeLLM{compactFacts: []string{"", "  "}}
+	p := NewBuiltinProvider(slog.Default(), runtime, nil, nil)
+	p.SetLLM(llm)
+
+	if _, err := p.Compact(context.Background(), map[string]any{"bot_id": "bot-1"}, 0.5, 0); err == nil {
+		t.Fatal("expected compact error")
+	}
+	if runtime.replaceCalls != 0 {
+		t.Fatalf("replace should not be called when LLM returns no facts, got %d", runtime.replaceCalls)
+	}
+}
+
 func TestNewBuiltinRuntimeFromConfig_DefaultReturnsFileRuntime(t *testing.T) {
 	t.Parallel()
 	sentinel := "file-runtime-sentinel"
@@ -227,4 +334,62 @@ var _ sparseEncoder = (*fakeSparseEncoder)(nil)
 
 func init() {
 	_ = sparse.SparseVector{}
+}
+
+type fakeCompactRuntime struct {
+	items        []adapters.MemoryItem
+	replaced     []adapters.MemoryItem
+	replaceCalls int
+}
+
+func newFakeCompactRuntime(items []adapters.MemoryItem) *fakeCompactRuntime {
+	return &fakeCompactRuntime{items: items}
+}
+
+func (r *fakeCompactRuntime) Add(context.Context, adapters.AddRequest) (adapters.SearchResponse, error) {
+	return adapters.SearchResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) Search(context.Context, adapters.SearchRequest) (adapters.SearchResponse, error) {
+	return adapters.SearchResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) GetAll(context.Context, adapters.GetAllRequest) (adapters.SearchResponse, error) {
+	return adapters.SearchResponse{Results: append([]adapters.MemoryItem(nil), r.items...)}, nil
+}
+
+func (r *fakeCompactRuntime) Update(context.Context, adapters.UpdateRequest) (adapters.MemoryItem, error) {
+	return adapters.MemoryItem{}, nil
+}
+
+func (r *fakeCompactRuntime) Delete(context.Context, string) (adapters.DeleteResponse, error) {
+	return adapters.DeleteResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) DeleteBatch(context.Context, []string) (adapters.DeleteResponse, error) {
+	return adapters.DeleteResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) DeleteAll(context.Context, adapters.DeleteAllRequest) (adapters.DeleteResponse, error) {
+	return adapters.DeleteResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) ReplaceAll(_ context.Context, _ map[string]any, items []adapters.MemoryItem) error {
+	r.replaceCalls++
+	r.replaced = append([]adapters.MemoryItem(nil), items...)
+	return nil
+}
+
+func (r *fakeCompactRuntime) Usage(context.Context, map[string]any) (adapters.UsageResponse, error) {
+	return adapters.UsageResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) Mode() string { return string(ModeOff) }
+
+func (r *fakeCompactRuntime) Status(context.Context, string) (adapters.MemoryStatusResponse, error) {
+	return adapters.MemoryStatusResponse{}, nil
+}
+
+func (r *fakeCompactRuntime) Rebuild(context.Context, string) (adapters.RebuildResult, error) {
+	return adapters.RebuildResult{}, nil
 }

--- a/internal/memory/adapters/builtin/dense_runtime.go
+++ b/internal/memory/adapters/builtin/dense_runtime.go
@@ -295,47 +295,20 @@ func (r *denseRuntime) DeleteAll(ctx context.Context, req adapters.DeleteAllRequ
 	return adapters.DeleteResponse{Message: "All memories deleted successfully!"}, nil
 }
 
-func (r *denseRuntime) Compact(ctx context.Context, filters map[string]any, ratio float64, _ int) (adapters.CompactResult, error) {
+func (r *denseRuntime) ReplaceAll(ctx context.Context, filters map[string]any, items []adapters.MemoryItem) error {
 	botID, err := runtimeBotID("", filters)
 	if err != nil {
-		return adapters.CompactResult{}, err
+		return err
 	}
-	if ratio <= 0 || ratio > 1 {
-		return adapters.CompactResult{}, errors.New("ratio must be in range (0, 1]")
+	storeItems := make([]storefs.MemoryItem, 0, len(items))
+	for _, item := range items {
+		storeItems = append(storeItems, storeItemFromMemoryItem(item))
 	}
-	items, err := r.store.ReadAllMemoryFiles(ctx, botID)
-	if err != nil {
-		return adapters.CompactResult{}, err
+	if err := r.store.RebuildFiles(ctx, botID, storeItems, filters); err != nil {
+		return err
 	}
-	before := len(items)
-	if before == 0 {
-		return adapters.CompactResult{BeforeCount: 0, AfterCount: 0, Ratio: ratio, Results: []adapters.MemoryItem{}}, nil
-	}
-	sort.Slice(items, func(i, j int) bool { return items[i].UpdatedAt > items[j].UpdatedAt })
-	target := int(float64(before) * ratio)
-	if target < 1 {
-		target = 1
-	}
-	if target > before {
-		target = before
-	}
-	keptStore := append([]storefs.MemoryItem(nil), items[:target]...)
-	if err := r.store.RebuildFiles(ctx, botID, keptStore, filters); err != nil {
-		return adapters.CompactResult{}, err
-	}
-	if _, err := r.Rebuild(ctx, botID); err != nil {
-		return adapters.CompactResult{}, err
-	}
-	kept := make([]adapters.MemoryItem, 0, len(keptStore))
-	for _, item := range keptStore {
-		kept = append(kept, memoryItemFromStore(item))
-	}
-	return adapters.CompactResult{
-		BeforeCount: before,
-		AfterCount:  len(kept),
-		Ratio:       ratio,
-		Results:     kept,
-	}, nil
+	_, err = r.Rebuild(ctx, botID)
+	return err
 }
 
 func (r *denseRuntime) Usage(ctx context.Context, filters map[string]any) (adapters.UsageResponse, error) {

--- a/internal/memory/adapters/builtin/formation_test.go
+++ b/internal/memory/adapters/builtin/formation_test.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -15,8 +16,12 @@ type fakeLLM struct {
 	extractErr    error
 	decideActions []adapters.DecisionAction
 	decideErr     error
+	compactFacts  []string
+	compactErr    error
 	extractCalls  int
 	decideCalls   int
+	compactCalls  int
+	compactReq    adapters.CompactRequest
 }
 
 func (f *fakeLLM) Extract(_ context.Context, _ adapters.ExtractRequest) (adapters.ExtractResponse, error) {
@@ -29,13 +34,17 @@ func (f *fakeLLM) Decide(_ context.Context, _ adapters.DecideRequest) (adapters.
 	return adapters.DecideResponse{Actions: f.decideActions}, f.decideErr
 }
 
-func (*fakeLLM) Compact(context.Context, adapters.CompactRequest) (adapters.CompactResponse, error) {
-	return adapters.CompactResponse{}, nil
+func (f *fakeLLM) Compact(_ context.Context, req adapters.CompactRequest) (adapters.CompactResponse, error) {
+	f.compactCalls++
+	f.compactReq = req
+	return adapters.CompactResponse{Facts: f.compactFacts}, f.compactErr
 }
 
 func (*fakeLLM) DetectLanguage(context.Context, string) (string, error) {
 	return "", nil
 }
+
+var errFakeCompact = errors.New("fake compact error")
 
 func TestFormationExtractAndAdd(t *testing.T) {
 	t.Parallel()

--- a/internal/memory/adapters/builtin/sparse_runtime.go
+++ b/internal/memory/adapters/builtin/sparse_runtime.go
@@ -262,47 +262,20 @@ func (r *sparseRuntime) DeleteAll(ctx context.Context, req adapters.DeleteAllReq
 	return adapters.DeleteResponse{Message: "All memories deleted successfully!"}, nil
 }
 
-func (r *sparseRuntime) Compact(ctx context.Context, filters map[string]any, ratio float64, _ int) (adapters.CompactResult, error) {
+func (r *sparseRuntime) ReplaceAll(ctx context.Context, filters map[string]any, items []adapters.MemoryItem) error {
 	botID, err := runtimeBotID("", filters)
 	if err != nil {
-		return adapters.CompactResult{}, err
+		return err
 	}
-	all, err := r.store.ReadAllMemoryFiles(ctx, botID)
-	if err != nil {
-		return adapters.CompactResult{}, err
+	storeItems := make([]storefs.MemoryItem, 0, len(items))
+	for _, item := range items {
+		storeItems = append(storeItems, storeItemFromMemoryItem(item))
 	}
-	before := len(all)
-	if before == 0 {
-		return adapters.CompactResult{Ratio: ratio}, nil
+	if err := r.store.RebuildFiles(ctx, botID, storeItems, filters); err != nil {
+		return err
 	}
-
-	sort.Slice(all, func(i, j int) bool {
-		return all[i].UpdatedAt > all[j].UpdatedAt
-	})
-	target := int(float64(before) * ratio)
-	if target < 1 {
-		target = 1
-	}
-	if target > before {
-		target = before
-	}
-	keptStore := append([]storefs.MemoryItem(nil), all[:target]...)
-	if err := r.store.RebuildFiles(ctx, botID, keptStore, filters); err != nil {
-		return adapters.CompactResult{}, err
-	}
-	if _, err := r.Rebuild(ctx, botID); err != nil {
-		return adapters.CompactResult{}, err
-	}
-	kept := make([]adapters.MemoryItem, 0, len(keptStore))
-	for _, item := range keptStore {
-		kept = append(kept, memoryItemFromStore(item))
-	}
-	return adapters.CompactResult{
-		BeforeCount: before,
-		AfterCount:  len(kept),
-		Ratio:       ratio,
-		Results:     kept,
-	}, nil
+	_, err = r.Rebuild(ctx, botID)
+	return err
 }
 
 func (r *sparseRuntime) Usage(ctx context.Context, filters map[string]any) (adapters.UsageResponse, error) {

--- a/internal/memory/adapters/types.go
+++ b/internal/memory/adapters/types.go
@@ -187,6 +187,7 @@ type DecideResponse struct {
 }
 
 type CompactRequest struct {
+	BotID       string            `json:"bot_id,omitempty"`
 	Memories    []CandidateMemory `json:"memories"`
 	TargetCount int               `json:"target_count"`
 	DecayDays   int               `json:"decay_days,omitempty"`


### PR DESCRIPTION
Fixes #550

修复了在agent使用builtin memory时，手动点击`压缩记忆`，会导致部分记忆条目直接丢失且不产生任何“压缩后的记忆”的问题

## 背景
分析了 #550 所提到的bug，认为问题所在是：在`627b673a`这一次commit后，似乎把压缩记忆和调用LLM compact的逻辑链路断开了。
即，手动触发压缩记忆后，并没有调用LLM去对记忆进行压缩。反而是只是简单地删去部分较老的记忆条目。

## 修复
将压缩的逻辑修改为
```
BuiltinProvider.Compact
-> 读取当前 memory
-> 过滤空 memory
-> 计算 targetCount
-> 调用 LLM.Compact
-> 校验返回 facts 非空
-> 将 facts 转成新的 MemoryItem
-> 调用 runtime.ReplaceAll 替换旧 memory
```

把runtime的compact更改为ReplaceAll，
原本的compact函数存在着严重的漏洞，其根本不会触发任何“压缩”操作，只会将记忆条目按时间排序和按比例删除
ReplaceAll这个函数用于将原来的记忆条目替换为新的记忆条目，新的记忆条目则来自LLM.Compact


补充了相关的测试：
```
BuiltinProvider.Compact 会调用 fake LLM
LLM 能收到正确的 bot_id / memories / target_count / decay_days
LLM 调用失败时不会 ReplaceAll
LLM 返回空 facts 时不会 ReplaceAll
LLM 返回 facts 时，runtime 收到的是新 facts，而不是原 memory 子集
targetCount 基于非空 memory candidates 计算，避免空白 memory 导致 targetCount 超过实际候选数
```

## 可能仍存在的问题
由于此问题涉及到的代码过多，要彻底解决链路上的所有问题，可能需要对本项目在此链路上的相关设计架构进行一定的修改，
因此本PR只做了很小的修复。
仍然存在的限制：
```
LLM 调用失败：不会删除旧 memory，已修复
LLM 返回空 facts：不会删除旧 memory，已修复
ReplaceAll 写入阶段失败：可能仍需要依赖底层 RebuildFiles/Rebuild 的错误处理
sparse/dense：如果文件已替换但 Qdrant Rebuild 失败，文件和向量索引可能短暂不一致
compact 质量：仍依赖现有 LLM prompt 和模型输出，本 PR 不重写 prompt
Mem0 / OpenViking：仍保持 unsupported，本 PR 只修复 Built-in Memory
```

## 已进行的测试
- 本地运行了go test
- 部署后手动测试点击`压缩记忆`按钮，发现能够按照预期工作