### PR TITLE
fix(docker): use HEAD request for web healthcheck to avoid 405

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -31,6 +31,6 @@ COPY docker/nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 8082
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/health || exit 1
+    CMD curl -f -I http://localhost:8082/health >/dev/null || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
wget --spider sends a GET, returning 405 and marking the container unhealthy. 
curl -I sends HEAD, matching what the route actually serves.
Closes #575 