### PR TITLE
fix(bots): preserve bot name when persisting workspace preferences

### DIFF
--- a/internal/workspace/image_preference.go
+++ b/internal/workspace/image_preference.go
@@ -322,6 +322,7 @@ func (m *Manager) updateBotWorkspaceImagePreference(ctx context.Context, botID, 
 	}
 	_, err = m.queries.UpdateBotProfile(ctx, dbsqlc.UpdateBotProfileParams{
 		ID:          botUUID,
+		Name:        row.Name,
 		DisplayName: row.DisplayName,
 		AvatarUrl:   row.AvatarUrl,
 		Timezone:    row.Timezone,
@@ -354,6 +355,7 @@ func (m *Manager) rememberWorkspaceBackend(ctx context.Context, botID, backend, 
 	}
 	_, err = m.queries.UpdateBotProfile(ctx, dbsqlc.UpdateBotProfileParams{
 		ID:          botUUID,
+		Name:        row.Name,
 		DisplayName: row.DisplayName,
 		AvatarUrl:   row.AvatarUrl,
 		Timezone:    row.Timezone,
@@ -444,6 +446,7 @@ func (m *Manager) updateBotWorkspaceGPUPreference(ctx context.Context, botID str
 	}
 	_, err = m.queries.UpdateBotProfile(ctx, dbsqlc.UpdateBotProfileParams{
 		ID:          botUUID,
+		Name:        row.Name,
 		DisplayName: row.DisplayName,
 		AvatarUrl:   row.AvatarUrl,
 		Timezone:    row.Timezone,


### PR DESCRIPTION
## Problem

Creating a bot with a container workspace fails — the create stream emits
`Bot create failed` ("准备工作区时出现问题"), even though the bot row and its
workspace container are actually created. Server logs:

    WARN setup bot container: remember workspace image failed
      error="new row for relation \"bots\" violates check constraint
      \"bots_name_format_check\" (SQLSTATE 23514)"

Reproduces on every container-backed bot creation.

## Root cause

`internal/workspace/image_preference.go` persists workspace preferences
(image / backend / GPU) through the general-purpose `UpdateBotProfile`
query, which SETs every profile column:

    UPDATE bots SET name = $2, display_name = $3, avatar_url = $4,
      timezone = $5, is_active = $6, metadata = $7, updated_at = now()
    WHERE id = $1

The three callers read the current row and pass the existing values back to
keep them unchanged — but they omit `Name`, so it defaults to `""` and the
query rewrites `bots.name` to an empty string. The empty value violates the
`bots_name_format_check` constraint (`name ~ '^[a-z0-9][a-z0-9-]{1,62}$'`,
SQLSTATE 23514), so the UPDATE fails.

(The failed UPDATE rolls back, so the name isn't actually corrupted — but
the workspace-preference write fails and creation is reported as failed.)

**Regression from #536**, which added `name = $2` to `UpdateBotProfile` and
the `bots_name_format_check` constraint without updating these three callers.

## Fix

Pass `Name: row.Name` in all three `UpdateBotProfile` calls
(`updateBotWorkspaceImagePreference`, `rememberWorkspaceBackend`,
`updateBotWorkspaceGPUPreference`), preserving the existing name.

## Testing

- `go build ./internal/workspace/` passes; `gofmt` clean.
- Built the server from this branch and created a container-backed bot:
  the bot reaches `status=ready`, the `bots_name_format_check` error is gone,
  and `bots.name` is unchanged.
