### PR TITLE
feat(agent): support run_in_background for spawn subagent batches

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -669,7 +669,7 @@ func provideToolProviders(log *slog.Logger, channelManager *channel.Manager, reg
 		agenttools.NewBrowserProvider(log, settingsService, manager, manager, config.DefaultDataMount),
 		agenttools.NewEmailProvider(log, emailService, emailManager),
 		agenttools.NewWebFetchProvider(log),
-		agenttools.NewSpawnProvider(log, settingsService, modelsService, queries, sessionService),
+		agenttools.NewSpawnProvider(log, settingsService, modelsService, queries, sessionService, bgManager),
 		agenttools.NewSkillProvider(log),
 		agenttools.NewTTSProvider(log, settingsService, audioService, channelManager, registry),
 		agenttools.NewTranscriptionProvider(log, settingsService, audioService, mediaService),

--- a/internal/agent/background/manager.go
+++ b/internal/agent/background/manager.go
@@ -131,6 +131,7 @@ func (m *Manager) emitTaskEvent(task *Task, event TaskEventType, stream, chunk s
 	payload := TaskEvent{
 		Event:      event,
 		TaskID:     task.ID,
+		Kind:       task.Kind,
 		BotID:      task.BotID,
 		SessionID:  task.SessionID,
 		Command:    task.Command,
@@ -169,6 +170,7 @@ func (m *Manager) Spawn(
 
 	task := &Task{
 		ID:          taskID,
+		Kind:        KindExec,
 		BotID:       botID,
 		SessionID:   sessionID,
 		Command:     command,
@@ -210,6 +212,7 @@ func (m *Manager) SpawnAdopt(
 
 	task := &Task{
 		ID:          taskID,
+		Kind:        KindExec,
 		BotID:       botID,
 		SessionID:   sessionID,
 		Command:     command,
@@ -677,11 +680,11 @@ func (m *Manager) RunningTasksSummary(botID, sessionID string) string {
 		if desc == "" {
 			desc = truncate(command, 80)
 		}
-		lines = append(lines, fmt.Sprintf("- [%s] %s (started %s ago, output: %s)",
-			id, desc,
-			time.Since(startedAt).Round(time.Second),
-			outputFile,
-		))
+		line := fmt.Sprintf("- [%s] %s (started %s ago", id, desc, time.Since(startedAt).Round(time.Second))
+		if outputFile != "" {
+			line += fmt.Sprintf(", output: %s", outputFile)
+		}
+		lines = append(lines, line+")")
 	}
 	if len(lines) == 0 {
 		return ""

--- a/internal/agent/background/spawn_task.go
+++ b/internal/agent/background/spawn_task.go
@@ -1,0 +1,204 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// TaskKind identifies what kind of work a background task tracks.
+type TaskKind string
+
+const (
+	// KindExec is a background container command execution.
+	KindExec TaskKind = "exec"
+	// KindSpawn is a background subagent batch run by the spawn tool.
+	KindSpawn TaskKind = "spawn"
+)
+
+// SpawnTaskTimeout is the safety ceiling for a background spawn task,
+// mirroring BackgroundExecTimeout for exec tasks.
+const SpawnTaskTimeout = 30 * time.Minute
+
+// MaxRunningSpawnTasks caps concurrently running background spawn tasks per
+// bot+session to prevent subagent storms across agent runs.
+const MaxRunningSpawnTasks = 3
+
+// spawnReportMaxBytes caps each branch report carried in join notifications,
+// mirroring maxTailBytes for exec output tails. Full transcripts stay in the
+// child session.
+const spawnReportMaxBytes = 2048
+
+// SpawnBranch is the join-record entry for one subagent in a spawn batch.
+// ChildSessionID points at the persisted subagent session so the parent
+// agent can read the full transcript via history tools.
+type SpawnBranch struct {
+	Task           string
+	ChildSessionID string
+	Status         TaskStatus
+	Report         string
+	Error          string
+}
+
+// CompleteSpawnTask finalises a spawn task with its branch outcomes and
+// enqueues the join notification. The task is completed when every branch
+// completed and failed when any branch failed. Branch outcomes are recorded
+// even for killed tasks, but killed tasks never notify.
+func (m *Manager) CompleteSpawnTask(taskID string, branches []SpawnBranch) {
+	m.mu.Lock()
+	task := m.tasks[taskID]
+	m.mu.Unlock()
+	if task == nil || task.Kind != KindSpawn {
+		return
+	}
+	defer task.Cancel() // release the safety-timeout context
+
+	branches = clampSpawnBranchReports(branches)
+
+	status := TaskCompleted
+	for _, b := range branches {
+		if b.Status != TaskCompleted {
+			status = TaskFailed
+			break
+		}
+	}
+
+	task.mu.Lock()
+	task.branches = branches
+	if task.Status == TaskKilled {
+		task.mu.Unlock()
+		return
+	}
+	task.CompletedAt = time.Now()
+	task.Status = status
+	duration := task.CompletedAt.Sub(task.StartedAt)
+	task.mu.Unlock()
+
+	m.logger.Info("background spawn task finished",
+		slog.String("task_id", task.ID),
+		slog.String("status", string(status)),
+		slog.Int("branches", len(branches)),
+		slog.Duration("duration", duration),
+	)
+
+	eventType := TaskEventCompleted
+	if status == TaskFailed {
+		eventType = TaskEventFailed
+	}
+	m.emitTaskEvent(task, eventType, "", "")
+
+	if !task.MarkNotified() {
+		return
+	}
+	m.enqueueNotification(Notification{
+		TaskID:      task.ID,
+		Kind:        KindSpawn,
+		BotID:       task.BotID,
+		SessionID:   task.SessionID,
+		Status:      status,
+		Description: task.Description,
+		Branches:    append([]SpawnBranch(nil), branches...),
+		Duration:    duration,
+	})
+}
+
+// clampSpawnBranchReports returns a copy of branches with each report capped
+// to its tail spawnReportMaxBytes, where the findings live per the subagent
+// response contract.
+func clampSpawnBranchReports(branches []SpawnBranch) []SpawnBranch {
+	out := append([]SpawnBranch(nil), branches...)
+	for i := range out {
+		if len(out[i].Report) > spawnReportMaxBytes {
+			out[i].Report = out[i].Report[len(out[i].Report)-spawnReportMaxBytes:]
+		}
+	}
+	return out
+}
+
+// formatSpawnForAgent renders the join record of a spawn task.
+func (n Notification) formatSpawnForAgent() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "<task-notification>\n")
+	fmt.Fprintf(&b, "  <task-id>%s</task-id>\n", n.TaskID)
+	fmt.Fprintf(&b, "  <kind>spawn</kind>\n")
+	fmt.Fprintf(&b, "  <status>%s</status>\n", n.Status)
+	if n.Description != "" {
+		fmt.Fprintf(&b, "  <description>%s</description>\n", n.Description)
+	}
+	fmt.Fprintf(&b, "  <duration>%s</duration>\n", n.Duration.Round(time.Millisecond))
+	fmt.Fprintf(&b, "  <branches>\n")
+	for _, br := range n.Branches {
+		fmt.Fprintf(&b, "    <branch status=%q", br.Status)
+		if br.ChildSessionID != "" {
+			fmt.Fprintf(&b, " session-id=%q", br.ChildSessionID)
+		}
+		fmt.Fprintf(&b, ">\n")
+		fmt.Fprintf(&b, "      <task>%s</task>\n", br.Task)
+		if br.Report != "" {
+			fmt.Fprintf(&b, "      <report>\n%s\n      </report>\n", strings.TrimRight(br.Report, "\n"))
+		}
+		if br.Error != "" {
+			fmt.Fprintf(&b, "      <error>%s</error>\n", br.Error)
+		}
+		fmt.Fprintf(&b, "    </branch>\n")
+	}
+	fmt.Fprintf(&b, "  </branches>\n")
+	fmt.Fprintf(&b, "  <suggestion>Read a branch's full transcript with search_messages using its session-id.</suggestion>\n")
+	fmt.Fprintf(&b, "</task-notification>")
+	return b.String()
+}
+
+// runningSpawnCountLocked counts running spawn tasks for a bot+session.
+// Caller must hold m.mu.
+func (m *Manager) runningSpawnCountLocked(botID, sessionID string) int {
+	count := 0
+	for _, t := range m.tasks {
+		if t.Kind != KindSpawn || t.BotID != botID || t.SessionID != sessionID {
+			continue
+		}
+		t.mu.Lock()
+		if t.Status == TaskRunning {
+			count++
+		}
+		t.mu.Unlock()
+	}
+	return count
+}
+
+// StartSpawnTask registers a background task for a spawn (subagent batch)
+// whose execution is driven by the spawn tool. It returns the task ID and a
+// detached, cancelable context that subagent branches must derive from so
+// Kill can stop in-flight work.
+func (m *Manager) StartSpawnTask(parentCtx context.Context, botID, sessionID, description string) (string, context.Context, error) {
+	ctx, cancel := detachedContextWithTimeout(parentCtx, SpawnTaskTimeout)
+
+	m.mu.Lock()
+	if m.runningSpawnCountLocked(botID, sessionID) >= MaxRunningSpawnTasks {
+		m.mu.Unlock()
+		cancel()
+		return "", nil, fmt.Errorf("spawn limit reached: max %d concurrently running background spawn tasks per session", MaxRunningSpawnTasks)
+	}
+	taskID := m.newTaskIDLocked(botID)
+	task := &Task{
+		ID:          taskID,
+		Kind:        KindSpawn,
+		BotID:       botID,
+		SessionID:   sessionID,
+		Description: description,
+		Status:      TaskRunning,
+		StartedAt:   time.Now(),
+		cancel:      cancel,
+	}
+	m.tasks[taskID] = task
+	m.mu.Unlock()
+
+	m.logger.Info("background spawn task started",
+		slog.String("task_id", taskID),
+		slog.String("bot_id", botID),
+		slog.String("description", truncate(description, 120)),
+	)
+	m.emitTaskEvent(task, TaskEventStarted, "", "")
+	return taskID, ctx, nil
+}

--- a/internal/agent/background/spawn_task.go
+++ b/internal/agent/background/spawn_task.go
@@ -31,6 +31,14 @@ const MaxRunningSpawnTasks = 3
 // child session.
 const spawnReportMaxBytes = 2048
 
+// spawnBranchTaskMaxBytes caps the per-branch task echo: identification only,
+// the full task text is persisted as the child session's user message.
+const spawnBranchTaskMaxBytes = 200
+
+// spawnBranchErrorMaxBytes caps per-branch error strings, whose summary sits
+// at the head.
+const spawnBranchErrorMaxBytes = 512
+
 // SpawnBranch is the join-record entry for one subagent in a spawn batch.
 // ChildSessionID points at the persisted subagent session so the parent
 // agent can read the full transcript via history tools.
@@ -55,7 +63,7 @@ func (m *Manager) CompleteSpawnTask(taskID string, branches []SpawnBranch) {
 	}
 	defer task.Cancel() // release the safety-timeout context
 
-	branches = clampSpawnBranchReports(branches)
+	branches = clampSpawnBranches(branches)
 
 	status := TaskCompleted
 	for _, b := range branches {
@@ -104,15 +112,18 @@ func (m *Manager) CompleteSpawnTask(taskID string, branches []SpawnBranch) {
 	})
 }
 
-// clampSpawnBranchReports returns a copy of branches with each report capped
-// to its tail spawnReportMaxBytes, where the findings live per the subagent
-// response contract.
-func clampSpawnBranchReports(branches []SpawnBranch) []SpawnBranch {
+// clampSpawnBranches returns a copy of branches with each text field bounded:
+// reports keep their tail (findings live at the end per the subagent response
+// contract), task echoes and errors keep their head (identification and
+// summary sit at the front).
+func clampSpawnBranches(branches []SpawnBranch) []SpawnBranch {
 	out := append([]SpawnBranch(nil), branches...)
 	for i := range out {
 		if len(out[i].Report) > spawnReportMaxBytes {
 			out[i].Report = out[i].Report[len(out[i].Report)-spawnReportMaxBytes:]
 		}
+		out[i].Task = truncate(out[i].Task, spawnBranchTaskMaxBytes)
+		out[i].Error = truncate(out[i].Error, spawnBranchErrorMaxBytes)
 	}
 	return out
 }

--- a/internal/agent/background/spawn_task_test.go
+++ b/internal/agent/background/spawn_task_test.go
@@ -1,0 +1,276 @@
+package background
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+func TestStartSpawnTaskRegistersRunningSpawnTask(t *testing.T) {
+	mgr := New(nil)
+	var events []TaskEvent
+	mgr.SetEventFunc(func(e TaskEvent) { events = append(events, e) })
+
+	taskID, taskCtx, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 2 tasks")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("expected non-empty task ID")
+	}
+	select {
+	case <-taskCtx.Done():
+		t.Fatal("expected task context to be alive")
+	default:
+	}
+
+	task := mgr.GetForSession("bot1", "sess1", taskID)
+	if task == nil {
+		t.Fatal("expected task to be registered for the owning session")
+	}
+	snap := task.Snapshot()
+	if snap.Kind != KindSpawn {
+		t.Errorf("expected kind %s, got %q", KindSpawn, snap.Kind)
+	}
+	if snap.Status != TaskRunning {
+		t.Errorf("expected status running, got %s", snap.Status)
+	}
+	if snap.Description != "spawn: 2 tasks" {
+		t.Errorf("unexpected description: %q", snap.Description)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 task event, got %d", len(events))
+	}
+	if events[0].Event != TaskEventStarted || events[0].Kind != KindSpawn || events[0].TaskID != taskID {
+		t.Errorf("unexpected started event: %+v", events[0])
+	}
+}
+
+func TestCompleteSpawnTaskNotifiesJoinRecord(t *testing.T) {
+	mgr := New(nil)
+	var events []TaskEvent
+	mgr.SetEventFunc(func(e TaskEvent) { events = append(events, e) })
+
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 2 tasks")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	mgr.CompleteSpawnTask(taskID, []SpawnBranch{
+		{Task: "research A", ChildSessionID: "child-a", Status: TaskCompleted, Report: "found A"},
+		{Task: "research B", ChildSessionID: "child-b", Status: TaskCompleted, Report: "found B"},
+	})
+
+	notifications := waitDrain(t, mgr, "bot1", "sess1", 1)
+	n := notifications[0]
+	if n.TaskID != taskID {
+		t.Errorf("expected task ID %s, got %s", taskID, n.TaskID)
+	}
+	if n.Kind != KindSpawn {
+		t.Errorf("expected kind spawn, got %q", n.Kind)
+	}
+	if n.Status != TaskCompleted {
+		t.Errorf("expected status completed, got %s", n.Status)
+	}
+	if len(n.Branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(n.Branches))
+	}
+	if n.Branches[0].ChildSessionID != "child-a" || n.Branches[0].Report != "found A" {
+		t.Errorf("unexpected first branch: %+v", n.Branches[0])
+	}
+
+	task := mgr.Get(taskID)
+	if task.Status != TaskCompleted {
+		t.Errorf("expected task status completed, got %s", task.Status)
+	}
+	last := events[len(events)-1]
+	if last.Event != TaskEventCompleted || last.Kind != KindSpawn {
+		t.Errorf("unexpected final event: %+v", last)
+	}
+}
+
+func TestCompleteSpawnTaskAnyBranchFailureMarksFailed(t *testing.T) {
+	mgr := New(nil)
+
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 2 tasks")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	mgr.CompleteSpawnTask(taskID, []SpawnBranch{
+		{Task: "ok", ChildSessionID: "child-a", Status: TaskCompleted, Report: "fine"},
+		{Task: "boom", Status: TaskFailed, Error: "all attempts failed"},
+	})
+
+	notifications := waitDrain(t, mgr, "bot1", "sess1", 1)
+	if notifications[0].Status != TaskFailed {
+		t.Errorf("expected status failed, got %s", notifications[0].Status)
+	}
+	if notifications[0].Branches[1].Error != "all attempts failed" {
+		t.Errorf("expected branch error to be preserved, got %+v", notifications[0].Branches[1])
+	}
+}
+
+func TestKillSpawnTaskCancelsContextAndSuppressesNotification(t *testing.T) {
+	mgr := New(nil)
+
+	taskID, taskCtx, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 1 task")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	if err := mgr.Kill(taskID); err != nil {
+		t.Fatalf("kill failed: %v", err)
+	}
+	select {
+	case <-taskCtx.Done():
+	default:
+		t.Fatal("expected task context to be canceled by Kill")
+	}
+
+	mgr.CompleteSpawnTask(taskID, []SpawnBranch{
+		{Task: "interrupted", Status: TaskFailed, Error: "parent cancelled"},
+	})
+
+	task := mgr.Get(taskID)
+	if task.Status != TaskKilled {
+		t.Errorf("expected status killed, got %s", task.Status)
+	}
+	if got := len(task.Snapshot().Branches); got != 1 {
+		t.Errorf("expected branch outcomes recorded on killed task, got %d", got)
+	}
+	if notifications := mgr.DrainNotifications("bot1", "sess1"); len(notifications) != 0 {
+		t.Errorf("expected no notifications for killed task, got %d", len(notifications))
+	}
+}
+
+func TestStartSpawnTaskEnforcesRunningCap(t *testing.T) {
+	mgr := New(nil)
+
+	ids := make([]string, 0, MaxRunningSpawnTasks)
+	for range MaxRunningSpawnTasks {
+		id, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn batch")
+		if err != nil {
+			t.Fatalf("StartSpawnTask under cap failed: %v", err)
+		}
+		ids = append(ids, id)
+	}
+
+	if _, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "over cap"); err == nil {
+		t.Fatal("expected error when running spawn cap is reached")
+	}
+	if _, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess2", "other session"); err != nil {
+		t.Fatalf("expected other session to be unaffected by cap: %v", err)
+	}
+
+	mgr.CompleteSpawnTask(ids[0], nil)
+	if _, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "after slot freed"); err != nil {
+		t.Fatalf("expected start to succeed after a slot freed: %v", err)
+	}
+}
+
+func TestSpawnNotificationFormat(t *testing.T) {
+	n := Notification{
+		TaskID:      "bg_test_3",
+		Kind:        KindSpawn,
+		Status:      TaskCompleted,
+		Description: "spawn: 2 tasks",
+		Branches: []SpawnBranch{
+			{Task: "research A", ChildSessionID: "child-a", Status: TaskCompleted, Report: "found A"},
+			{Task: "research B", ChildSessionID: "child-b", Status: TaskFailed, Error: "watchdog timed out"},
+		},
+		Duration: 90 * time.Second,
+	}
+
+	text := n.FormatForAgent()
+	for _, want := range []string{
+		"<task-notification>",
+		"<kind>spawn</kind>",
+		"bg_test_3",
+		"<status>completed</status>",
+		"spawn: 2 tasks",
+		"child-a",
+		"research A",
+		"found A",
+		"child-b",
+		"watchdog timed out",
+		"search_messages",
+		"</task-notification>",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("spawn notification missing %q:\n%s", want, text)
+		}
+	}
+	for _, reject := range []string{"exit-code", "output-file", "<command>"} {
+		if strings.Contains(text, reject) {
+			t.Errorf("spawn notification should not contain %q:\n%s", reject, text)
+		}
+	}
+	if !strings.HasPrefix(n.MessageText(), "A background task completed:") {
+		t.Errorf("unexpected message lead: %q", n.MessageText())
+	}
+
+	// Exec notifications keep their existing format, without a kind tag.
+	execN := Notification{TaskID: "bg_test_4", Kind: KindExec, Status: TaskCompleted, Command: "npm install"}
+	if strings.Contains(execN.FormatForAgent(), "<kind>") {
+		t.Errorf("exec notification format must stay unchanged:\n%s", execN.FormatForAgent())
+	}
+}
+
+func TestCompleteSpawnTaskClampsBranchReports(t *testing.T) {
+	mgr := New(nil)
+
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 1 task")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	long := strings.Repeat("x", spawnReportMaxBytes) + "FINDINGS-TAIL"
+	mgr.CompleteSpawnTask(taskID, []SpawnBranch{
+		{Task: "verbose", ChildSessionID: "child-a", Status: TaskCompleted, Report: long},
+	})
+
+	n := waitDrain(t, mgr, "bot1", "sess1", 1)[0]
+	if got := len(n.Branches[0].Report); got > spawnReportMaxBytes {
+		t.Errorf("expected report clamped to %d bytes, got %d", spawnReportMaxBytes, got)
+	}
+	if !strings.HasSuffix(n.Branches[0].Report, "FINDINGS-TAIL") {
+		t.Error("expected clamping to keep the report tail")
+	}
+	if snap := mgr.Get(taskID).Snapshot(); len(snap.Branches[0].Report) > spawnReportMaxBytes {
+		t.Error("expected recorded branch report to be clamped as well")
+	}
+}
+
+func TestRunningTasksSummaryIncludesSpawnTasksWithoutOutputFile(t *testing.T) {
+	mgr := New(nil)
+
+	if _, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn: 3 research tasks"); err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	summary := mgr.RunningTasksSummary("bot1", "sess1")
+	if !strings.Contains(summary, "spawn: 3 research tasks") {
+		t.Errorf("summary should mention spawn task description, got: %s", summary)
+	}
+	if strings.Contains(summary, "output:") {
+		t.Errorf("summary should omit output file for spawn tasks, got: %s", summary)
+	}
+}
+
+func TestExecTasksCarryExecKind(t *testing.T) {
+	mgr := New(nil)
+	execFn := func(_ context.Context, _, _ string, _ int32) (*bridge.ExecResult, error) {
+		return &bridge.ExecResult{Stdout: "ok\n", ExitCode: 0}, nil
+	}
+
+	taskID, _ := mgr.Spawn(context.Background(), "bot1", "sess1", "echo hi", "/data", "", execFn, nil, nil)
+	if snap := mgr.Get(taskID).Snapshot(); snap.Kind != KindExec {
+		t.Errorf("expected exec kind, got %q", snap.Kind)
+	}
+	_ = waitDrain(t, mgr, "bot1", "sess1", 1)
+}

--- a/internal/agent/background/spawn_task_test.go
+++ b/internal/agent/background/spawn_task_test.go
@@ -229,20 +229,37 @@ func TestCompleteSpawnTaskClampsBranchReports(t *testing.T) {
 		t.Fatalf("StartSpawnTask failed: %v", err)
 	}
 
-	long := strings.Repeat("x", spawnReportMaxBytes) + "FINDINGS-TAIL"
+	longReport := strings.Repeat("x", spawnReportMaxBytes) + "FINDINGS-TAIL"
+	longTask := "TASK-HEAD" + strings.Repeat("y", spawnBranchTaskMaxBytes)
+	longError := "ERROR-HEAD" + strings.Repeat("z", spawnBranchErrorMaxBytes)
 	mgr.CompleteSpawnTask(taskID, []SpawnBranch{
-		{Task: "verbose", ChildSessionID: "child-a", Status: TaskCompleted, Report: long},
+		{Task: longTask, ChildSessionID: "child-a", Status: TaskFailed, Report: longReport, Error: longError},
 	})
 
 	n := waitDrain(t, mgr, "bot1", "sess1", 1)[0]
-	if got := len(n.Branches[0].Report); got > spawnReportMaxBytes {
+	br := n.Branches[0]
+	if got := len(br.Report); got > spawnReportMaxBytes {
 		t.Errorf("expected report clamped to %d bytes, got %d", spawnReportMaxBytes, got)
 	}
-	if !strings.HasSuffix(n.Branches[0].Report, "FINDINGS-TAIL") {
+	if !strings.HasSuffix(br.Report, "FINDINGS-TAIL") {
 		t.Error("expected clamping to keep the report tail")
 	}
-	if snap := mgr.Get(taskID).Snapshot(); len(snap.Branches[0].Report) > spawnReportMaxBytes {
-		t.Error("expected recorded branch report to be clamped as well")
+	if got := len(br.Task); got > spawnBranchTaskMaxBytes+len("...") {
+		t.Errorf("expected task clamped to ~%d bytes, got %d", spawnBranchTaskMaxBytes, got)
+	}
+	if !strings.HasPrefix(br.Task, "TASK-HEAD") {
+		t.Error("expected clamping to keep the task head")
+	}
+	if got := len(br.Error); got > spawnBranchErrorMaxBytes+len("...") {
+		t.Errorf("expected error clamped to ~%d bytes, got %d", spawnBranchErrorMaxBytes, got)
+	}
+	if !strings.HasPrefix(br.Error, "ERROR-HEAD") {
+		t.Error("expected clamping to keep the error head")
+	}
+	if snap := mgr.Get(taskID).Snapshot(); len(snap.Branches[0].Report) > spawnReportMaxBytes ||
+		len(snap.Branches[0].Task) > spawnBranchTaskMaxBytes+len("...") ||
+		len(snap.Branches[0].Error) > spawnBranchErrorMaxBytes+len("...") {
+		t.Error("expected recorded branch fields to be clamped as well")
 	}
 }
 

--- a/internal/agent/background/types.go
+++ b/internal/agent/background/types.go
@@ -18,9 +18,11 @@ const (
 	TaskKilled    TaskStatus = "killed"
 )
 
-// Task represents a single background command execution.
+// Task represents a single background task (a container command execution
+// or a spawn subagent batch, per Kind).
 type Task struct {
 	ID          string
+	Kind        TaskKind
 	BotID       string
 	SessionID   string
 	Command     string
@@ -37,11 +39,13 @@ type Task struct {
 	notified        bool            // true once a terminal notification has been enqueued; prevents duplicates
 	stalledNotified bool            // true once a stalled notification has been enqueued
 	output          strings.Builder // buffered output tail
+	branches        []SpawnBranch   // spawn-kind branch outcomes, set at completion
 }
 
 // TaskSnapshot is a lock-safe, immutable view of a task for handler/UI code.
 type TaskSnapshot struct {
 	TaskID      string
+	Kind        TaskKind
 	BotID       string
 	SessionID   string
 	Command     string
@@ -51,6 +55,7 @@ type TaskSnapshot struct {
 	ExitCode    int32
 	OutputFile  string
 	OutputTail  string
+	Branches    []SpawnBranch
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Duration    time.Duration
@@ -71,6 +76,7 @@ func (t *Task) Snapshot() TaskSnapshot {
 	}
 	return TaskSnapshot{
 		TaskID:      t.ID,
+		Kind:        t.Kind,
 		BotID:       t.BotID,
 		SessionID:   t.SessionID,
 		Command:     t.Command,
@@ -80,6 +86,7 @@ func (t *Task) Snapshot() TaskSnapshot {
 		ExitCode:    t.ExitCode,
 		OutputFile:  t.OutputFile,
 		OutputTail:  t.outputTailLocked(),
+		Branches:    append([]SpawnBranch(nil), t.branches...),
 		StartedAt:   t.StartedAt,
 		CompletedAt: t.CompletedAt,
 		Duration:    duration,
@@ -176,6 +183,7 @@ type AdoptResult struct {
 // task reaches a terminal state or requires attention (e.g. stalled).
 type Notification struct {
 	TaskID      string
+	Kind        TaskKind
 	BotID       string
 	SessionID   string
 	Status      TaskStatus
@@ -184,6 +192,7 @@ type Notification struct {
 	ExitCode    int32
 	OutputFile  string
 	OutputTail  string // last N bytes of output for quick summary
+	Branches    []SpawnBranch
 	Duration    time.Duration
 	Stalled     bool // true when task appears stuck on interactive input
 }
@@ -205,6 +214,7 @@ const (
 type TaskEvent struct {
 	Event      TaskEventType `json:"event"`
 	TaskID     string        `json:"task_id"`
+	Kind       TaskKind      `json:"kind,omitempty"`
 	BotID      string        `json:"bot_id,omitempty"`
 	SessionID  string        `json:"session_id,omitempty"`
 	Command    string        `json:"command,omitempty"`
@@ -232,6 +242,9 @@ func (n Notification) MessageText() string {
 // FormatForAgent returns a human-readable task-notification block that can be
 // injected into the agent's message stream.
 func (n Notification) FormatForAgent() string {
+	if n.Kind == KindSpawn {
+		return n.formatSpawnForAgent()
+	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "<task-notification>\n")
 	fmt.Fprintf(&b, "  <task-id>%s</task-id>\n", n.TaskID)

--- a/internal/agent/prompts/_subagent.md
+++ b/internal/agent/prompts/_subagent.md
@@ -7,3 +7,5 @@ spawn({ tasks: ["task one", "task two"] })
 ```
 
 Use when you have independent subtasks that benefit from parallel execution. Don't use for simple single-step work — just do it directly.
+
+For long batches (extended research, builds), set `run_in_background: true`. The call returns a task ID immediately and you will be notified with each task's report when all tasks finish — do not poll or sleep while waiting. Manage running batches with `bg_status`; read a finished task's full transcript with `search_messages` using the session ID from the notification.

--- a/internal/agent/prompts/mode_subagent.md
+++ b/internal/agent/prompts/mode_subagent.md
@@ -5,6 +5,7 @@ You are a task-focused worker spawned by a parent agent.
 Response contract:
 - Complete the assigned task.
 - Report concise findings to the parent.
+- End your final message with a short findings summary — the tail of your report is what the parent sees first.
 - Do not send messages to users or channels.
 - Do not create schedules.
 - Do not manage memory.

--- a/internal/agent/tools/container.go
+++ b/internal/agent/tools/container.go
@@ -812,17 +812,21 @@ func (p *ContainerProvider) execBgStatus(_ context.Context, session SessionConte
 
 	switch action {
 	case "list":
-		tasks := p.bgManager.ListForSession(session.BotID, session.SessionID)
-		entries := make([]map[string]any, 0, len(tasks))
-		for _, t := range tasks {
-			entries = append(entries, map[string]any{
-				"task_id":     t.ID,
-				"command":     truncateStr(t.Command, 120),
-				"description": t.Description,
-				"status":      string(t.Status),
-				"output_file": t.OutputFile,
-				"started_at":  session.FormatTime(t.StartedAt),
-			})
+		snapshots := p.bgManager.ListSnapshotsForSession(session.BotID, session.SessionID)
+		entries := make([]map[string]any, 0, len(snapshots))
+		for _, s := range snapshots {
+			entry := map[string]any{
+				"task_id":     s.TaskID,
+				"kind":        string(s.Kind),
+				"description": s.Description,
+				"status":      string(s.Status),
+				"started_at":  session.FormatTime(s.StartedAt),
+			}
+			if s.Kind != background.KindSpawn {
+				entry["command"] = truncateStr(s.Command, 120)
+				entry["output_file"] = s.OutputFile
+			}
+			entries = append(entries, entry)
 		}
 		return map[string]any{"tasks": entries, "count": len(entries)}, nil
 
@@ -834,18 +838,42 @@ func (p *ContainerProvider) execBgStatus(_ context.Context, session SessionConte
 		if task == nil {
 			return nil, fmt.Errorf("task %s not found", taskID)
 		}
+		s := task.Snapshot()
 		result := map[string]any{
-			"task_id":     task.ID,
-			"command":     task.Command,
-			"description": task.Description,
-			"status":      string(task.Status),
-			"output_file": task.OutputFile,
-			"started_at":  session.FormatTime(task.StartedAt),
+			"task_id":     s.TaskID,
+			"kind":        string(s.Kind),
+			"description": s.Description,
+			"status":      string(s.Status),
+			"started_at":  session.FormatTime(s.StartedAt),
 		}
-		if task.Status != background.TaskRunning {
-			result["exit_code"] = task.ExitCode
-			result["completed_at"] = session.FormatTime(task.CompletedAt)
-			result["output_tail"] = task.OutputTail()
+		if s.Status != background.TaskRunning {
+			result["completed_at"] = session.FormatTime(s.CompletedAt)
+		}
+		if s.Kind == background.KindSpawn {
+			if len(s.Branches) > 0 {
+				branches := make([]map[string]any, 0, len(s.Branches))
+				for _, br := range s.Branches {
+					b := map[string]any{"task": br.Task, "status": string(br.Status)}
+					if br.ChildSessionID != "" {
+						b["session_id"] = br.ChildSessionID
+					}
+					if br.Report != "" {
+						b["report"] = br.Report
+					}
+					if br.Error != "" {
+						b["error"] = br.Error
+					}
+					branches = append(branches, b)
+				}
+				result["branches"] = branches
+			}
+			return result, nil
+		}
+		result["command"] = s.Command
+		result["output_file"] = s.OutputFile
+		if s.Status != background.TaskRunning {
+			result["exit_code"] = s.ExitCode
+			result["output_tail"] = s.OutputTail
 		}
 		return result, nil
 

--- a/internal/agent/tools/container_bgstatus_test.go
+++ b/internal/agent/tools/container_bgstatus_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/memohai/memoh/internal/agent/background"
+)
+
+func TestBgStatusListsAndInspectsSpawnTasks(t *testing.T) {
+	mgr := background.New(nil)
+	p := NewContainerProvider(nil, nil, mgr, "")
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn 2 task(s): alpha | beta")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	listRes, err := p.execBgStatus(context.Background(), session, map[string]any{"action": "list"})
+	if err != nil {
+		t.Fatalf("bg_status list failed: %v", err)
+	}
+	entries := listRes.(map[string]any)["tasks"].([]map[string]any)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 task entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry["kind"] != "spawn" {
+		t.Errorf("expected kind spawn in list entry, got %v", entry["kind"])
+	}
+	if entry["description"] != "spawn 2 task(s): alpha | beta" {
+		t.Errorf("unexpected description: %v", entry["description"])
+	}
+	if _, ok := entry["command"]; ok {
+		t.Error("spawn list entry should not carry an exec command field")
+	}
+	if _, ok := entry["output_file"]; ok {
+		t.Error("spawn list entry should not carry an exec output_file field")
+	}
+
+	mgr.CompleteSpawnTask(taskID, []background.SpawnBranch{
+		{Task: "alpha", ChildSessionID: "child-a", Status: background.TaskCompleted, Report: "found A"},
+		{Task: "beta", Status: background.TaskFailed, Error: "boom"},
+	})
+
+	statusRes, err := p.execBgStatus(context.Background(), session, map[string]any{"action": "status", "task_id": taskID})
+	if err != nil {
+		t.Fatalf("bg_status status failed: %v", err)
+	}
+	sm := statusRes.(map[string]any)
+	if sm["kind"] != "spawn" || sm["status"] != "failed" {
+		t.Errorf("unexpected spawn status payload: %v", sm)
+	}
+	if _, ok := sm["exit_code"]; ok {
+		t.Error("spawn status should not carry an exec exit_code field")
+	}
+	branches, ok := sm["branches"].([]map[string]any)
+	if !ok || len(branches) != 2 {
+		t.Fatalf("expected 2 branches in spawn status, got %v", sm["branches"])
+	}
+	if branches[0]["session_id"] != "child-a" || branches[0]["report"] != "found A" {
+		t.Errorf("unexpected first branch payload: %v", branches[0])
+	}
+	if branches[1]["error"] != "boom" {
+		t.Errorf("unexpected second branch payload: %v", branches[1])
+	}
+
+	mgr.DrainNotifications("bot1", "sess1")
+}

--- a/internal/agent/tools/subagent.go
+++ b/internal/agent/tools/subagent.go
@@ -16,6 +16,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/agent/background"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	messagepkg "github.com/memohai/memoh/internal/message"
 	"github.com/memohai/memoh/internal/models"
@@ -210,6 +211,8 @@ type SpawnProvider struct {
 	messageService messagepkg.Writer
 	systemPromptFn func(sessionType string) string
 	modelCreator   ModelCreator
+	bgManager      *background.Manager
+	modelResolver  func(ctx context.Context, botID string) (*sdk.Model, string, string, error)
 	logger         *slog.Logger
 }
 
@@ -221,17 +224,21 @@ func NewSpawnProvider(
 	modelsSvc *models.Service,
 	queries dbstore.Queries,
 	sessionService *sessionpkg.Service,
+	bgManager *background.Manager,
 ) *SpawnProvider {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &SpawnProvider{
+	p := &SpawnProvider{
 		settings:       settingsSvc,
 		models:         modelsSvc,
 		queries:        queries,
 		sessionService: sessionService,
+		bgManager:      bgManager,
 		logger:         log.With(slog.String("tool", "spawn")),
 	}
+	p.modelResolver = p.resolveModel
+	return p
 }
 
 // SetAgent injects the agent after construction (breaking the DI cycle).
@@ -268,6 +275,10 @@ func (p *SpawnProvider) Tools(_ context.Context, session SessionContext) ([]sdk.
 						"type":        "array",
 						"description": fmt.Sprintf("List of task instructions. Each string is a self-contained prompt for one subagent. Max %d tasks.", maxTasksPerSpawn),
 						"items":       map[string]any{"type": "string"},
+					},
+					"run_in_background": map[string]any{
+						"type":        "boolean",
+						"description": "If true, run the subagent batch in the background. Returns immediately with a task ID; you will be notified with each task's report when all tasks complete. Use for long research or build batches that should not block the conversation.",
 					},
 				},
 				"required": []string{"tasks"},
@@ -330,7 +341,7 @@ func (p *SpawnProvider) execSpawn(ctx context.Context, session SessionContext, a
 	// prevent the spawn from completing and returning its results.
 	sessionCtx := context.WithoutCancel(ctx)
 
-	sdkModel, modelID, promptCacheTTL, err := p.resolveModel(sessionCtx, botID)
+	sdkModel, modelID, promptCacheTTL, err := p.modelResolver(sessionCtx, botID)
 	if err != nil {
 		return nil, fmt.Errorf("resolve model: %w", err)
 	}
@@ -338,6 +349,10 @@ func (p *SpawnProvider) execSpawn(ctx context.Context, session SessionContext, a
 	systemPrompt := ""
 	if p.systemPromptFn != nil {
 		systemPrompt = p.systemPromptFn(sessionpkg.TypeSubagent)
+	}
+
+	if runInBg, _, _ := BoolArg(args, "run_in_background"); runInBg {
+		return p.execSpawnBackground(sessionCtx, session, sdkModel, modelID, promptCacheTTL, systemPrompt, tasks)
 	}
 
 	results := make([]spawnResult, len(tasks))
@@ -354,12 +369,76 @@ func (p *SpawnProvider) execSpawn(ctx context.Context, session SessionContext, a
 	for i, task := range tasks {
 		go func(idx int, query string) {
 			defer wg.Done()
-			results[idx] = p.runSubagentTask(sessionCtx, session, sdkModel, modelID, promptCacheTTL, systemPrompt, query)
+			results[idx] = p.runSubagentTask(sessionCtx, session, sdkModel, modelID, promptCacheTTL, systemPrompt, query, true)
 		}(i, task)
 	}
 	wg.Wait()
 
 	return map[string]any{"results": results}, nil
+}
+
+// execSpawnBackground registers the batch as a background spawn task and
+// returns immediately. Branches derive from the task context so bg_status
+// kill can cancel them; the join notification carries each branch's report.
+func (p *SpawnProvider) execSpawnBackground(
+	ctx context.Context,
+	session SessionContext,
+	model *sdk.Model,
+	modelID, promptCacheTTL, systemPrompt string,
+	tasks []string,
+) (any, error) {
+	if p.bgManager == nil {
+		return nil, errors.New("background task manager not available")
+	}
+
+	description := truncateTitle(fmt.Sprintf("spawn %d task(s): %s", len(tasks), strings.Join(tasks, " | ")), 120)
+	taskID, taskCtx, err := p.bgManager.StartSpawnTask(ctx, session.BotID, session.SessionID, description)
+	if err != nil {
+		return map[string]any{
+			"isError": true,
+			"content": []map[string]any{{
+				"type": "text",
+				"text": fmt.Sprintf("%s. Check running tasks with bg_status (and kill stale ones) before starting more.", err),
+			}},
+		}, nil
+	}
+
+	go func() {
+		results := make([]spawnResult, len(tasks))
+		var wg sync.WaitGroup
+		wg.Add(len(tasks))
+		for i, task := range tasks {
+			go func(idx int, query string) {
+				defer wg.Done()
+				results[idx] = p.runSubagentTask(taskCtx, session, model, modelID, promptCacheTTL, systemPrompt, query, false)
+			}(i, task)
+		}
+		wg.Wait()
+
+		branches := make([]background.SpawnBranch, len(results))
+		for i, r := range results {
+			status := background.TaskCompleted
+			if !r.Success {
+				status = background.TaskFailed
+			}
+			branches[i] = background.SpawnBranch{
+				Task:           r.Task,
+				ChildSessionID: r.SessionID,
+				Status:         status,
+				Report:         r.Text,
+				Error:          r.Error,
+			}
+		}
+		p.bgManager.CompleteSpawnTask(taskID, branches)
+	}()
+
+	return map[string]any{
+		"status":     "background_started",
+		"task_id":    taskID,
+		"kind":       "spawn",
+		"task_count": len(tasks),
+		"message":    fmt.Sprintf("%d subagent task(s) started in background with task ID: %s. You will be notified with each task's report when all complete. Do NOT poll or sleep — the notification arrives automatically.", len(tasks), taskID),
+	}, nil
 }
 
 // startSpawnHeartbeat emits periodic progress events into the parent agent
@@ -390,6 +469,9 @@ func (*SpawnProvider) startSpawnHeartbeat(ctx context.Context, session SessionCo
 	}()
 }
 
+// detachAttempts controls whether each attempt is detached from ctx
+// cancellation: foreground spawns detach so the batch survives parent stream
+// cancellation; background spawns inherit it so Kill stops in-flight work.
 func (p *SpawnProvider) runSubagentTask(
 	ctx context.Context,
 	parentSession SessionContext,
@@ -398,6 +480,7 @@ func (p *SpawnProvider) runSubagentTask(
 	promptCacheTTL string,
 	systemPrompt string,
 	query string,
+	detachAttempts bool,
 ) spawnResult {
 	res := spawnResult{Task: query}
 
@@ -462,9 +545,14 @@ func (p *SpawnProvider) runSubagentTask(
 		// 1. Safety net: wall-clock timeout (subagentTimeout) via context.WithTimeout.
 		// 2. Watchdog: activity-based timeout (subagentWatchdogTimeout) that fires
 		//    when no stream events (tokens, tool output) are received.
-		// Use context.WithoutCancel so retries get a fresh timeout even if
-		// the parent stream was cancelled (e.g. by idle timeout).
-		safetyCtx, safetyCancel := context.WithTimeout(context.WithoutCancel(ctx), subagentTimeout)
+		// When detachAttempts is set, use context.WithoutCancel so retries get
+		// a fresh timeout even if the parent stream was cancelled (e.g. by
+		// idle timeout).
+		attemptBase := ctx
+		if detachAttempts {
+			attemptBase = context.WithoutCancel(ctx)
+		}
+		safetyCtx, safetyCancel := context.WithTimeout(attemptBase, subagentTimeout)
 		wdCtx, wd := NewSubagentWatchdog(safetyCtx, subagentWatchdogTimeout, p.logger)
 
 		genResult, err := p.agent.GenerateWithWatchdog(wdCtx, cfg, wd.Touch)

--- a/internal/agent/tools/subagent.go
+++ b/internal/agent/tools/subagent.go
@@ -433,11 +433,12 @@ func (p *SpawnProvider) execSpawnBackground(
 	}()
 
 	return map[string]any{
-		"status":     "background_started",
-		"task_id":    taskID,
-		"kind":       "spawn",
-		"task_count": len(tasks),
-		"message":    fmt.Sprintf("%d subagent task(s) started in background with task ID: %s. You will be notified with each task's report when all complete. Do NOT poll or sleep — the notification arrives automatically.", len(tasks), taskID),
+		"status":      "background_started",
+		"task_id":     taskID,
+		"kind":        "spawn",
+		"task_count":  len(tasks),
+		"description": description,
+		"message":     fmt.Sprintf("%d subagent task(s) started in background with task ID: %s. You will be notified with each task's report when all complete. Do NOT poll or sleep — the notification arrives automatically.", len(tasks), taskID),
 	}, nil
 }
 

--- a/internal/agent/tools/subagent_bg_test.go
+++ b/internal/agent/tools/subagent_bg_test.go
@@ -120,6 +120,9 @@ func TestSpawnRunInBackgroundReturnsImmediatelyAndNotifiesJoinRecord(t *testing.
 	if taskID == "" {
 		t.Fatal("expected non-empty task_id")
 	}
+	if desc, _ := m["description"].(string); !strings.Contains(desc, "alpha") {
+		t.Errorf("expected description carrying the task list, got %q", desc)
+	}
 	if task := mgr.GetForSession("bot1", "sess1", taskID); task == nil || task.Status != background.TaskRunning {
 		t.Fatalf("expected running spawn task registered for session, got %+v", task)
 	}

--- a/internal/agent/tools/subagent_bg_test.go
+++ b/internal/agent/tools/subagent_bg_test.go
@@ -1,0 +1,284 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/agent/background"
+)
+
+// fakeSpawnAgent satisfies SpawnAgent. When block is non-nil it waits for the
+// channel to close or the context to cancel before returning.
+type fakeSpawnAgent struct {
+	block   chan struct{}
+	failFor map[string]string // query -> non-retryable error message
+}
+
+func (f *fakeSpawnAgent) Generate(ctx context.Context, cfg SpawnRunConfig) (*SpawnResult, error) {
+	return f.GenerateWithWatchdog(ctx, cfg, func() {})
+}
+
+func (f *fakeSpawnAgent) GenerateWithWatchdog(ctx context.Context, cfg SpawnRunConfig, _ func()) (*SpawnResult, error) {
+	if f.block != nil {
+		select {
+		case <-f.block:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if msg, ok := f.failFor[cfg.Query]; ok {
+		return nil, errors.New(msg)
+	}
+	return &SpawnResult{Text: "report for " + cfg.Query}, nil
+}
+
+func newBgSpawnProvider(t *testing.T, agent SpawnAgent) (*SpawnProvider, *background.Manager) {
+	t.Helper()
+	mgr := background.New(nil)
+	p := NewSpawnProvider(nil, nil, nil, nil, nil, mgr)
+	p.SetAgent(agent)
+	p.modelResolver = func(context.Context, string) (*sdk.Model, string, string, error) {
+		return &sdk.Model{}, "model-1", "", nil
+	}
+	return p, mgr
+}
+
+func spawnExecuteFn(t *testing.T, p *SpawnProvider, session SessionContext) func(args map[string]any) (any, error) {
+	t.Helper()
+	toolList, err := p.Tools(context.Background(), session)
+	if err != nil || len(toolList) != 1 {
+		t.Fatalf("expected one spawn tool, got %d (err=%v)", len(toolList), err)
+	}
+	return func(args map[string]any) (any, error) {
+		return toolList[0].Execute(&sdk.ToolExecContext{Context: context.Background()}, args)
+	}
+}
+
+func executeWithin(t *testing.T, fn func(args map[string]any) (any, error), args map[string]any, timeout time.Duration) (any, error) {
+	t.Helper()
+	type outcome struct {
+		result any
+		err    error
+	}
+	resCh := make(chan outcome, 1)
+	go func() {
+		r, err := fn(args)
+		resCh <- outcome{r, err}
+	}()
+	select {
+	case out := <-resCh:
+		return out.result, out.err
+	case <-time.After(timeout):
+		t.Fatalf("spawn execute did not return within %s", timeout)
+		return nil, nil
+	}
+}
+
+func drainSpawnNotifications(t *testing.T, mgr *background.Manager, botID, sessionID string, want int) []background.Notification {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	var all []background.Notification
+	for {
+		all = append(all, mgr.DrainNotifications(botID, sessionID)...)
+		if len(all) >= want {
+			return all
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d notifications, got %d", want, len(all))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestSpawnRunInBackgroundReturnsImmediatelyAndNotifiesJoinRecord(t *testing.T) {
+	fake := &fakeSpawnAgent{block: make(chan struct{})}
+	p, mgr := newBgSpawnProvider(t, fake)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+	execute := spawnExecuteFn(t, p, session)
+
+	result, err := executeWithin(t, execute, map[string]any{
+		"tasks":             []any{"alpha", "beta"},
+		"run_in_background": true,
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("background spawn failed: %v", err)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if m["status"] != "background_started" {
+		t.Fatalf("expected background_started, got %v", m["status"])
+	}
+	taskID, _ := m["task_id"].(string)
+	if taskID == "" {
+		t.Fatal("expected non-empty task_id")
+	}
+	if task := mgr.GetForSession("bot1", "sess1", taskID); task == nil || task.Status != background.TaskRunning {
+		t.Fatalf("expected running spawn task registered for session, got %+v", task)
+	}
+
+	close(fake.block)
+	n := drainSpawnNotifications(t, mgr, "bot1", "sess1", 1)[0]
+	if n.Kind != background.KindSpawn || n.TaskID != taskID {
+		t.Errorf("unexpected notification identity: %+v", n)
+	}
+	if n.Status != background.TaskCompleted {
+		t.Errorf("expected completed join, got %s", n.Status)
+	}
+	if len(n.Branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(n.Branches))
+	}
+	if n.Branches[0].Task != "alpha" || n.Branches[0].Report != "report for alpha" {
+		t.Errorf("unexpected first branch: %+v", n.Branches[0])
+	}
+	if n.Branches[1].Task != "beta" || n.Branches[1].Status != background.TaskCompleted {
+		t.Errorf("unexpected second branch: %+v", n.Branches[1])
+	}
+}
+
+func TestSpawnRunInBackgroundRecordsBranchFailure(t *testing.T) {
+	fake := &fakeSpawnAgent{failFor: map[string]string{"beta": "invalid task configuration"}}
+	p, mgr := newBgSpawnProvider(t, fake)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+	execute := spawnExecuteFn(t, p, session)
+
+	if _, err := executeWithin(t, execute, map[string]any{
+		"tasks":             []any{"alpha", "beta"},
+		"run_in_background": true,
+	}, 2*time.Second); err != nil {
+		t.Fatalf("background spawn failed: %v", err)
+	}
+
+	n := drainSpawnNotifications(t, mgr, "bot1", "sess1", 1)[0]
+	if n.Status != background.TaskFailed {
+		t.Errorf("expected failed join when a branch fails, got %s", n.Status)
+	}
+	if n.Branches[0].Status != background.TaskCompleted {
+		t.Errorf("expected alpha branch completed, got %+v", n.Branches[0])
+	}
+	if n.Branches[1].Status != background.TaskFailed || !strings.Contains(n.Branches[1].Error, "invalid task configuration") {
+		t.Errorf("expected beta branch failure preserved, got %+v", n.Branches[1])
+	}
+}
+
+func TestSpawnBackgroundKillCancelsBranchesAndSuppressesNotification(t *testing.T) {
+	fake := &fakeSpawnAgent{block: make(chan struct{})}
+	p, mgr := newBgSpawnProvider(t, fake)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+	execute := spawnExecuteFn(t, p, session)
+
+	result, err := executeWithin(t, execute, map[string]any{
+		"tasks":             []any{"alpha"},
+		"run_in_background": true,
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("background spawn failed: %v", err)
+	}
+	taskID, _ := result.(map[string]any)["task_id"].(string)
+	if taskID == "" {
+		t.Fatal("expected non-empty task_id")
+	}
+
+	if err := mgr.KillForSession("bot1", "sess1", taskID); err != nil {
+		t.Fatalf("kill failed: %v", err)
+	}
+
+	// The join still records branch outcomes once cancellation propagates.
+	deadline := time.After(5 * time.Second)
+	for len(mgr.Get(taskID).Snapshot().Branches) != 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for branch outcomes after kill")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	task := mgr.Get(taskID)
+	if task.Status != background.TaskKilled {
+		t.Errorf("expected killed status, got %s", task.Status)
+	}
+	if snap := task.Snapshot(); snap.Branches[0].Status != background.TaskFailed {
+		t.Errorf("expected killed branch recorded as failed, got %+v", snap.Branches[0])
+	}
+	if n := mgr.DrainNotifications("bot1", "sess1"); len(n) != 0 {
+		t.Errorf("expected no notifications for killed spawn task, got %d", len(n))
+	}
+}
+
+func TestSpawnBackgroundHonorsManagerRunningCapAcrossRuns(t *testing.T) {
+	fake := &fakeSpawnAgent{block: make(chan struct{})}
+	p, mgr := newBgSpawnProvider(t, fake)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	firstRun := spawnExecuteFn(t, p, session)
+	for range background.MaxRunningSpawnTasks {
+		result, err := executeWithin(t, firstRun, map[string]any{
+			"tasks":             []any{"task"},
+			"run_in_background": true,
+		}, 2*time.Second)
+		if err != nil {
+			t.Fatalf("background spawn under cap failed: %v", err)
+		}
+		if result.(map[string]any)["status"] != "background_started" {
+			t.Fatalf("expected background_started under cap, got %v", result)
+		}
+	}
+
+	// A fresh agent run gets a fresh per-run closure, but the manager cap
+	// still applies across runs.
+	secondRun := spawnExecuteFn(t, p, session)
+	result, err := executeWithin(t, secondRun, map[string]any{
+		"tasks":             []any{"over cap"},
+		"run_in_background": true,
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected structured limit result, got error: %v", err)
+	}
+	m := result.(map[string]any)
+	if m["isError"] != true {
+		t.Fatalf("expected isError result at cap, got %v", m)
+	}
+	text := m["content"].([]map[string]any)[0]["text"].(string)
+	if !strings.Contains(text, "spawn limit") {
+		t.Errorf("expected limit message, got %q", text)
+	}
+
+	close(fake.block)
+	drainSpawnNotifications(t, mgr, "bot1", "sess1", background.MaxRunningSpawnTasks)
+}
+
+func TestSpawnForegroundPathUnchangedAndSchemaExposesBackgroundFlag(t *testing.T) {
+	fake := &fakeSpawnAgent{}
+	p, _ := newBgSpawnProvider(t, fake)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	toolList, err := p.Tools(context.Background(), session)
+	if err != nil || len(toolList) != 1 {
+		t.Fatalf("expected one spawn tool, got %d (err=%v)", len(toolList), err)
+	}
+	props := toolList[0].Parameters.(map[string]any)["properties"].(map[string]any)
+	if _, ok := props["run_in_background"]; !ok {
+		t.Error("expected run_in_background in spawn tool schema")
+	}
+
+	result, err := toolList[0].Execute(&sdk.ToolExecContext{Context: context.Background()}, map[string]any{
+		"tasks": []any{"alpha"},
+	})
+	if err != nil {
+		t.Fatalf("foreground spawn failed: %v", err)
+	}
+	results, ok := result.(map[string]any)["results"].([]spawnResult)
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected one foreground result, got %v", result)
+	}
+	if !results[0].Success || results[0].Text != "report for alpha" {
+		t.Errorf("unexpected foreground result: %+v", results[0])
+	}
+}

--- a/internal/conversation/uimessage_convert.go
+++ b/internal/conversation/uimessage_convert.go
@@ -922,18 +922,16 @@ func applyToolResultToUIMessage(message *UIMessage, output any) {
 		return
 	}
 	message.Output = output
-	// Finalize before any early return below: a background exec result is
+	// Finalize before any early return below: a background handoff result is
 	// still a tool result, and replaying a pending user input would re-offer
 	// an already answered form.
 	finalizeInteractiveRequests(message, output)
-	if strings.EqualFold(strings.TrimSpace(message.Name), "exec") {
-		if task, ok := backgroundTaskFromExecToolResult(output); ok {
-			if task.Command == "" {
-				task.Command = stringFromMap(message.Input, "command")
-			}
-			mergeBackgroundTaskIntoTool(message, task)
-			return
+	if task, ok := backgroundTaskFromToolResult(output); ok {
+		if task.Command == "" {
+			task.Command = stringFromMap(message.Input, "command")
 		}
+		mergeBackgroundTaskIntoTool(message, task)
+		return
 	}
 	message.Running = uiBoolPtr(false)
 }
@@ -952,7 +950,11 @@ func finalizeInteractiveRequests(message *UIMessage, output any) {
 	}
 }
 
-func backgroundTaskFromExecToolResult(output any) (UIBackgroundTask, bool) {
+// backgroundTaskFromToolResult detects a background handoff in a tool result
+// by payload shape — a task_id plus a background-start status marker —
+// regardless of which tool produced it. Terminal statuses (e.g. bg_status
+// inspection results) intentionally do not match.
+func backgroundTaskFromToolResult(output any) (UIBackgroundTask, bool) {
 	payload, ok := toolResultMap(output)
 	if !ok {
 		return UIBackgroundTask{}, false
@@ -963,25 +965,18 @@ func backgroundTaskFromExecToolResult(output any) (UIBackgroundTask, bool) {
 		return UIBackgroundTask{}, false
 	}
 
-	statusToken := strings.ToLower(strings.TrimSpace(stringFromMap(payload, "status")))
-	status := normalizeBackgroundTaskStatus(statusToken)
-	switch statusToken {
+	switch strings.ToLower(strings.TrimSpace(stringFromMap(payload, "status"))) {
 	case "background_started", "auto_backgrounded", "started":
-		status = "running"
-	}
-	if status == "" {
+	default:
 		return UIBackgroundTask{}, false
 	}
 
 	task := UIBackgroundTask{
 		TaskID:     taskID,
-		Status:     status,
-		Command:    stringFromMap(payload, "command"),
+		Status:     "running",
+		Command:    firstNonEmptyString(stringFromMap(payload, "command"), stringFromMap(payload, "description")),
 		OutputFile: stringFromMap(payload, "output_file"),
-		ExitCode:   int32FromAny(payload["exit_code"]),
-		Duration:   stringFromMap(payload, "duration"),
 		OutputTail: firstNonEmptyString(stringFromMap(payload, "output_tail"), stringFromMap(payload, "tail")),
-		Stalled:    status == "stalled" || boolFromAny(payload["stalled"], false),
 	}
 	return task, true
 }
@@ -1058,9 +1053,12 @@ func parseBackgroundTaskNotification(text string) (UIBackgroundTask, bool) {
 		status = "completed"
 	}
 	task := UIBackgroundTask{
-		TaskID:     taskID,
-		Status:     status,
-		Command:    strings.TrimSpace(extractUITaskNotificationTag(body, "command")),
+		TaskID: taskID,
+		Status: status,
+		Command: firstNonEmptyString(
+			strings.TrimSpace(extractUITaskNotificationTag(body, "command")),
+			strings.TrimSpace(extractUITaskNotificationTag(body, "description")),
+		),
 		OutputFile: strings.TrimSpace(extractUITaskNotificationTag(body, "output-file")),
 		Duration:   strings.TrimSpace(extractUITaskNotificationTag(body, "duration")),
 		OutputTail: strings.TrimSpace(extractUITaskNotificationTag(body, "output-tail")),
@@ -1121,10 +1119,6 @@ func stringFromMap(value any, key string) string {
 		return ""
 	}
 	return stringFromAny(typed[key])
-}
-
-func int32FromAny(value any) int32 {
-	return int32(intFromAny(value)) //nolint:gosec // exit codes are small process statuses.
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/conversation/uimessage_convert_background_test.go
+++ b/internal/conversation/uimessage_convert_background_test.go
@@ -1,0 +1,95 @@
+package conversation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/agent/background"
+)
+
+func TestApplyToolResultRecognizesSpawnBackgroundStartByShape(t *testing.T) {
+	msg := &UIMessage{Type: UIMessageTool, Name: "spawn"}
+	applyToolResultToUIMessage(msg, map[string]any{
+		"status":      "background_started",
+		"task_id":     "bg_bot1_aaaa",
+		"kind":        "spawn",
+		"task_count":  2,
+		"description": "spawn 2 task(s): alpha | beta",
+		"message":     "2 subagent task(s) started in background",
+	})
+
+	if msg.Background == nil {
+		t.Fatal("expected background task recognized from spawn tool result")
+	}
+	if msg.Background.TaskID != "bg_bot1_aaaa" || msg.Background.Status != "running" {
+		t.Errorf("unexpected background state: %+v", msg.Background)
+	}
+	if msg.Background.Command != "spawn 2 task(s): alpha | beta" {
+		t.Errorf("expected description used as display label, got %q", msg.Background.Command)
+	}
+	if msg.Running == nil || !*msg.Running {
+		t.Error("expected tool to be marked running")
+	}
+}
+
+func TestApplyToolResultStillRecognizesExecBackgroundStart(t *testing.T) {
+	msg := &UIMessage{Type: UIMessageTool, Name: "exec"}
+	applyToolResultToUIMessage(msg, map[string]any{
+		"status":      "auto_backgrounded",
+		"task_id":     "bg_bot1_bbbb",
+		"output_file": "/tmp/memoh-bg/bg_bot1_bbbb.log",
+	})
+
+	if msg.Background == nil {
+		t.Fatal("expected background task recognized from exec tool result")
+	}
+	if msg.Background.Status != "running" || msg.Background.OutputFile != "/tmp/memoh-bg/bg_bot1_bbbb.log" {
+		t.Errorf("unexpected background state: %+v", msg.Background)
+	}
+}
+
+func TestApplyToolResultIgnoresTerminalTaskStatusPayloads(t *testing.T) {
+	// bg_status "status" results carry task_id with a terminal status; they
+	// must not turn the bg_status tool card into a running background task.
+	msg := &UIMessage{Type: UIMessageTool, Name: "bg_status"}
+	applyToolResultToUIMessage(msg, map[string]any{
+		"task_id": "bg_bot1_cccc",
+		"kind":    "exec",
+		"status":  "completed",
+	})
+
+	if msg.Background != nil {
+		t.Fatalf("expected no background task for terminal status payload, got %+v", msg.Background)
+	}
+	if msg.Running == nil || *msg.Running {
+		t.Error("expected tool to be marked not running")
+	}
+}
+
+func TestParseBackgroundTaskNotificationSpawnJoinUsesDescription(t *testing.T) {
+	n := background.Notification{
+		TaskID:      "bg_bot1_dddd",
+		Kind:        background.KindSpawn,
+		Status:      background.TaskFailed,
+		Description: "spawn 2 task(s): alpha | beta",
+		Branches: []background.SpawnBranch{
+			{Task: "alpha", ChildSessionID: "child-a", Status: background.TaskCompleted, Report: "found A"},
+			{Task: "beta", Status: background.TaskFailed, Error: "boom"},
+		},
+		Duration: 90 * time.Second,
+	}
+
+	task, ok := parseBackgroundTaskNotification(n.MessageText())
+	if !ok {
+		t.Fatal("expected spawn join notification to parse")
+	}
+	if task.TaskID != "bg_bot1_dddd" || task.Status != "failed" {
+		t.Errorf("unexpected parsed task: %+v", task)
+	}
+	if task.Command != "spawn 2 task(s): alpha | beta" {
+		t.Errorf("expected description used as display label, got %q", task.Command)
+	}
+	if task.ExitCode != 0 || task.OutputFile != "" {
+		t.Errorf("expected no exec fields for spawn notification, got %+v", task)
+	}
+}

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -338,10 +338,14 @@ func (h *MessageHandler) backgroundTaskSnapshots(botID, sessionID string) []conv
 		if stalled {
 			status = "stalled"
 		}
+		label := snapshot.Command
+		if label == "" {
+			label = snapshot.Description
+		}
 		tasks = append(tasks, conversation.UIBackgroundTask{
 			TaskID:     snapshot.TaskID,
 			Status:     status,
-			Command:    snapshot.Command,
+			Command:    label,
 			OutputFile: snapshot.OutputFile,
 			ExitCode:   snapshot.ExitCode,
 			Duration:   snapshot.Duration.Round(time.Millisecond).String(),

--- a/internal/handlers/message_background_test.go
+++ b/internal/handlers/message_background_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/memohai/memoh/internal/agent/background"
+)
+
+func TestBackgroundTaskSnapshotsUseDescriptionAsSpawnLabel(t *testing.T) {
+	mgr := background.New(nil)
+	h := &MessageHandler{bgManager: mgr}
+
+	if _, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "spawn 2 task(s): alpha | beta"); err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+
+	tasks := h.backgroundTaskSnapshots("bot1", "sess1")
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task snapshot, got %d", len(tasks))
+	}
+	if tasks[0].Command != "spawn 2 task(s): alpha | beta" {
+		t.Errorf("expected spawn description as display label, got %q", tasks[0].Command)
+	}
+	if tasks[0].Status != "running" {
+		t.Errorf("expected running status, got %q", tasks[0].Status)
+	}
+}


### PR DESCRIPTION
之前只有 exec 支持 run_in_background。此 PR 扩展 spawn 支持 run_in_background。
长子代理批处理（研究、构建）可以不再阻塞对话：调用会立即返回任务 ID，并且父代理会在所有任务完成后收到每个分支的报告通知。

- 非 bg spawn
<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/1c1b1a42-9435-418b-aeed-8f8ed75a6f20" />

- bg spawn
<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/7e3d9d7f-120b-4dc1-92b3-c38937fa7846" />

## design boundry

将 `spawn.run_in_background` 接到现有 `background.Manager`，复用 task_id、bg_status、session 通知池、SSE background_task、历史 UI replay。行为和 `exec.run_in_background` 保持一致。

spawn 本身行为未变动。内部 branches 依然同步全部完成或终止统一 join。

并行 spawn 之间异步，依然复用现有 notification pool 设计，由 main agent 主导 reduce：

- spawn 完成后入池，manager 调用 wake callback，**不会立即打断 main agent**
- main agent 不空闲时在池中持续等待
- main agent 一旦空闲且确有 pending notification **同时将池中所有上报**