### PR TITLE
fix: improve workspace desktop cursor handling

### DIFF
--- a/apps/web/src/pages/home/components/display-pane.vue
+++ b/apps/web/src/pages/home/components/display-pane.vue
@@ -13,6 +13,7 @@
     <video
       ref="videoRef"
       class="size-full min-h-0 flex-1 bg-foreground object-contain"
+      :style="{ cursor: displayCursor }"
       autoplay
       playsinline
       muted
@@ -339,9 +340,21 @@ interface BitrateSample {
 }
 
 type StatsRecord = Record<string, unknown>
+type DisplayCursor = string
 type VideoWithFrameCallback = HTMLVideoElement & {
   requestVideoFrameCallback?: (callback: (now: number, metadata: unknown) => void) => number
   cancelVideoFrameCallback?: (handle: number) => void
+}
+
+interface DisplayCursorMetadata {
+  type?: string
+  source?: string
+  cursor?: string
+  width?: number
+  height?: number
+  hot_x?: number
+  hot_y?: number
+  hidden?: boolean
 }
 
 const ACTIVE_SNAPSHOT_INTERVAL_MS = 10000
@@ -357,6 +370,25 @@ const FALLBACK_DISPLAY_WIDTH = 1280
 const FALLBACK_DISPLAY_HEIGHT = 960
 const CONNECT_TIMEOUT_MS = 15000
 const INACTIVE_RECONNECT_MS = 10000
+const DISPLAY_INPUT_CHANNEL = 'display-input'
+const DISPLAY_CURSOR_CHANNEL = 'display-cursor'
+const NATIVE_CURSOR_TYPES = new Set([
+  'default',
+  'text',
+  'pointer',
+  'move',
+  'grab',
+  'grabbing',
+  'ew-resize',
+  'ns-resize',
+  'nesw-resize',
+  'nwse-resize',
+  'col-resize',
+  'row-resize',
+  'not-allowed',
+  'wait',
+  'progress',
+])
 
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
@@ -374,6 +406,9 @@ const statsMenu = reactive({
   x: 0,
   y: 0,
 })
+const fallbackCursor = ref<DisplayCursor>('default')
+const remoteCursor = ref<DisplayCursor | null>(null)
+const displayCursor = computed<DisplayCursor>(() => remoteCursor.value ?? fallbackCursor.value)
 let peer: RTCPeerConnection | null = null
 let inputChannel: RTCDataChannel | null = null
 let pointerMask = 0
@@ -508,6 +543,8 @@ function cleanupLocal() {
   closeStatsMenu()
   pointerMask = 0
   lastPointerPoint = null
+  fallbackCursor.value = 'default'
+  remoteCursor.value = null
   if (inputChannel) {
     inputChannel.close()
     inputChannel = null
@@ -807,6 +844,61 @@ function inputReady() {
   return inputChannel?.readyState === 'open'
 }
 
+function handleDisplayDataChannel(event: RTCDataChannelEvent) {
+  const channel = event.channel
+  if (channel.label !== DISPLAY_CURSOR_CHANNEL) return
+  channel.addEventListener('message', (message) => {
+    handleCursorMetadata(message.data)
+  })
+  channel.addEventListener('close', () => {
+    remoteCursor.value = null
+  })
+}
+
+function handleCursorMetadata(data: unknown) {
+  if (typeof data !== 'string') return
+  let metadata: DisplayCursorMetadata
+  try {
+    metadata = JSON.parse(data) as DisplayCursorMetadata
+  } catch {
+    return
+  }
+  if (metadata.type !== 'cursor') return
+  remoteCursor.value = cursorMetadataToCSS(metadata)
+}
+
+function cursorMetadataToCSS(metadata: DisplayCursorMetadata): DisplayCursor | null {
+  if (metadata.hidden) return null
+  if (typeof metadata.cursor === 'string' && NATIVE_CURSOR_TYPES.has(metadata.cursor)) {
+    return metadata.cursor
+  }
+  return nativeCursorTypeFromGeometry(metadata)
+}
+
+function nativeCursorTypeFromGeometry(metadata: DisplayCursorMetadata): DisplayCursor | null {
+  const width = finiteNumber(metadata.width)
+  const height = finiteNumber(metadata.height)
+  const hotX = finiteNumber(metadata.hot_x)
+  const hotY = finiteNumber(metadata.hot_y)
+  if (!width || !height || hotX === null || hotY === null) return null
+  const centerX = Math.floor(width / 2)
+  const centerY = Math.floor(height / 2)
+  if (width <= 18 && height >= 18 && Math.abs(hotX - centerX) <= 3 && Math.abs(hotY - centerY) <= 4) {
+    return 'text'
+  }
+  if (width >= height * 2 && Math.abs(hotY - centerY) <= 4) return 'ew-resize'
+  if (height >= width * 2 && Math.abs(hotX - centerX) <= 4) return 'ns-resize'
+  if (width >= 18 && height >= 18 && Math.abs(hotX - centerX) <= 4 && Math.abs(hotY - centerY) <= 4) {
+    return 'move'
+  }
+  if (width >= 16 && height >= 16 && hotX > 3 && hotY <= 5) return 'pointer'
+  return 'default'
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null
+}
+
 function buttonBit(button: number): number {
   switch (button) {
     case 0: return 1
@@ -854,9 +946,26 @@ function sendPointer(event: MouseEvent | WheelEvent, mask = pointerMask) {
   })
 }
 
+function sendPointerAt(point: { x: number; y: number }, mask = pointerMask) {
+  sendInput({
+    type: 'pointer',
+    x: point.x,
+    y: point.y,
+    button_mask: mask,
+  })
+}
+
+function nudgeLastPointer(mask = pointerMask) {
+  if (!lastPointerPoint) return
+  const nudgeX = lastPointerPoint.x > 0 ? lastPointerPoint.x - 1 : lastPointerPoint.x + 1
+  sendPointerAt({ x: nudgeX, y: lastPointerPoint.y }, mask)
+  sendPointerAt(lastPointerPoint, mask)
+}
+
 function onPointerDown(event: MouseEvent) {
   videoRef.value?.focus()
   pointerMask |= buttonBit(event.button)
+  fallbackCursor.value = 'grabbing'
   sendPointer(event)
 }
 
@@ -866,11 +975,17 @@ function onPointerMove(event: MouseEvent) {
 
 function onPointerUp(event: MouseEvent) {
   pointerMask &= ~buttonBit(event.button)
+  if (pointerMask === 0 && fallbackCursor.value === 'grabbing') {
+    fallbackCursor.value = 'default'
+  }
   sendPointer(event)
 }
 
 function onPointerLeave(event: MouseEvent) {
   pointerMask = 0
+  if (fallbackCursor.value === 'grabbing') {
+    fallbackCursor.value = 'default'
+  }
   const point = resolveVideoPoint(event) ?? lastPointerPoint
   if (!point) return
   sendInput({
@@ -882,6 +997,9 @@ function onPointerLeave(event: MouseEvent) {
 }
 
 function onWheel(event: WheelEvent) {
+  if (fallbackCursor.value === 'grabbing') {
+    fallbackCursor.value = 'default'
+  }
   const bit = event.deltaY < 0 ? 8 : 16
   sendPointer(event, pointerMask | bit)
   sendPointer(event, pointerMask)
@@ -920,11 +1038,31 @@ function keysymForEvent(event: KeyboardEvent): number | null {
 function sendKey(event: KeyboardEvent, down: boolean) {
   const keysym = keysymForEvent(event)
   if (!keysym) return
+  if (down && isTextCursorKey(event)) {
+    fallbackCursor.value = 'text'
+  }
   sendInput({
     type: 'key',
     keysym,
     down,
   })
+  nudgeLastPointer()
+}
+
+function isTextCursorKey(event: KeyboardEvent): boolean {
+  if (event.key.length === 1) return true
+  return [
+    'Backspace',
+    'Delete',
+    'Enter',
+    'Tab',
+    'Home',
+    'End',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowUp',
+    'ArrowDown',
+  ].includes(event.key)
 }
 
 function onKeyDown(event: KeyboardEvent) {
@@ -1179,8 +1317,9 @@ async function connect() {
 
   const next = new RTCPeerConnection()
   peer = next
-  inputChannel = next.createDataChannel('display-input', { ordered: true })
+  inputChannel = next.createDataChannel(DISPLAY_INPUT_CHANNEL, { ordered: true })
   next.addTransceiver('video', { direction: 'recvonly' })
+  next.addEventListener('datachannel', handleDisplayDataChannel)
   next.addEventListener('connectionstatechange', () => setPeerStatus(next.connectionState))
   next.addEventListener('track', (event) => {
     const video = videoRef.value

--- a/cmd/bridge/display.go
+++ b/cmd/bridge/display.go
@@ -13,9 +13,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/memohai/memoh/internal/logger"
+	scriptassets "github.com/memohai/memoh/scripts"
 )
 
 const (
@@ -33,12 +35,16 @@ const (
 	systemXkbcompPath     = "/usr/bin/xkbcomp"
 	x11SocketDir          = "/tmp/.X11-unix"
 	xvncDisplay           = ":99"
+	xvncNoCursorArg       = "-nocursor"
 	defaultXvncGeometry   = "1280x960"
 	xvncSocketPath        = x11SocketDir + "/X99"
 	xvncLockPath          = "/tmp/.X99-lock"
+	desktopStylePath      = "/tmp/memoh-desktop-style.sh"
 	defaultRFBTCPAddr     = "127.0.0.1:5999"
 	displayReadyTimeout   = 30 * time.Second
 )
+
+var desktopSessionMonitorOnce sync.Once
 
 func startDisplaySupervisor(ctx context.Context) {
 	if !isTruthy(os.Getenv(displayEnabledEnv)) {
@@ -80,6 +86,12 @@ func superviseXvnc(ctx context.Context) {
 		geometry := displayGeometry()
 		prepareX11SocketDir(ctx)
 		if displayTCPReady(ctx, rfbTCPAddr) {
+			if xvncProcessMissingArg(xvncNoCursorArg) {
+				logger.FromContext(ctx).Info("restarting Xvnc to hide remote cursor", slog.String("display", xvncDisplay), slog.String("arg", xvncNoCursorArg))
+				stopXvncProcesses(ctx)
+				backoff = time.Second
+				continue
+			}
 			logger.FromContext(ctx).Info("Xvnc display already available", slog.String("display", xvncDisplay), slog.String("rfb_tcp_addr", rfbTCPAddr))
 			go startDisplaySession(ctx)
 			if waitExistingDisplay(ctx, rfbTCPAddr) {
@@ -97,6 +109,7 @@ func superviseXvnc(ctx context.Context) {
 			"-geometry", geometry,
 			"-depth", "24",
 			"-SecurityTypes", "None",
+			xvncNoCursorArg,
 			"-localhost",
 			"-rfbport", displayRFBTCPPort(rfbTCPAddr),
 		)
@@ -326,9 +339,14 @@ func startDisplaySession(ctx context.Context) {
 		return
 	}
 	if xsetroot := resolveDisplayCommand(toolkitXsetrootPath, "/usr/bin/xsetroot", "/usr/local/bin/xsetroot", "xsetroot"); xsetroot != "" {
-		runDisplayCommand(ctx, xsetroot, "-solid", "#315f7d")
+		runDisplayCommand(ctx, xsetroot, "-solid", desktopBackgroundColor())
+		runDisplayCommand(ctx, xsetroot, "-cursor_name", "left_ptr")
 	}
 	startDesktopSession(ctx)
+	desktopSessionMonitorOnce.Do(func() {
+		go superviseDesktopSession(ctx)
+	})
+	startDesktopStyle(ctx)
 	startDisplayTerminal(ctx)
 	startDisplayBrowser(ctx)
 }
@@ -380,19 +398,29 @@ func runDisplayCommand(ctx context.Context, path string, args ...string) {
 }
 
 func startDesktopSession(ctx context.Context) {
-	if displayProcessRunning(ctx, "xfce4-session", "xfwm4", "twm") {
+	if xfceSessionAvailable() {
+		if xfceSessionRunning(ctx) {
+			ensureXfceWindowManager(ctx)
+			return
+		}
+		if desktop := resolveDisplayCommand("startxfce4"); desktop != "" {
+			stopFallbackWindowManagers(ctx)
+			startDisplayCommand(ctx, "desktop", desktop)
+			return
+		}
+		if desktop := resolveDisplayCommand("xfce4-session"); desktop != "" {
+			stopFallbackWindowManagers(ctx)
+			startDisplayCommand(ctx, "desktop", desktop)
+			return
+		}
+	}
+	if xfceWindowManagerRunning(ctx) {
 		return
 	}
-	if desktop := resolveDisplayCommand("startxfce4"); desktop != "" {
-		startDisplayCommand(ctx, "desktop", desktop)
+	if ensureXfceWindowManager(ctx) {
 		return
 	}
-	if desktop := resolveDisplayCommand("xfce4-session"); desktop != "" {
-		startDisplayCommand(ctx, "desktop", desktop)
-		return
-	}
-	if windowManager := resolveDisplayCommand("xfwm4"); windowManager != "" {
-		startDisplayCommand(ctx, "window manager", windowManager)
+	if displayProcessRunning(ctx, "twm") {
 		return
 	}
 	if windowManager := resolveDisplayCommand(toolkitTwmPath); windowManager != "" {
@@ -400,6 +428,76 @@ func startDesktopSession(ctx context.Context) {
 		return
 	}
 	logger.FromContext(ctx).Warn("display desktop session unavailable")
+}
+
+func superviseDesktopSession(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	lastRestart := time.Time{}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !displayTCPReady(ctx, displayRFBTCPAddr()) {
+				continue
+			}
+			if desktopSessionHealthy(ctx) {
+				continue
+			}
+			if !lastRestart.IsZero() && time.Since(lastRestart) < 10*time.Second {
+				continue
+			}
+			lastRestart = time.Now()
+			logger.FromContext(ctx).Warn("display desktop session is not running; restarting")
+			startDesktopSession(ctx)
+			startDesktopStyle(ctx)
+		}
+	}
+}
+
+func desktopSessionHealthy(ctx context.Context) bool {
+	if xfceSessionAvailable() {
+		return xfceSessionRunning(ctx) && (!xfceWindowManagerAvailable() || xfceWindowManagerRunning(ctx))
+	}
+	if xfceWindowManagerAvailable() {
+		return xfceWindowManagerRunning(ctx)
+	}
+	return displayProcessRunning(ctx, "twm")
+}
+
+func xfceSessionAvailable() bool {
+	return resolveDisplayCommand("startxfce4") != "" ||
+		resolveDisplayCommand("xfce4-session") != ""
+}
+
+func xfceSessionRunning(ctx context.Context) bool {
+	return displayProcessRunning(ctx, "startxfce4", "xfce4-session", "xfdesktop")
+}
+
+func xfceWindowManagerAvailable() bool {
+	return resolveDisplayCommand("xfwm4") != ""
+}
+
+func xfceWindowManagerRunning(ctx context.Context) bool {
+	return displayProcessRunning(ctx, "xfwm4")
+}
+
+func ensureXfceWindowManager(ctx context.Context) bool {
+	windowManager := resolveDisplayCommand("xfwm4")
+	if windowManager == "" {
+		return false
+	}
+	if xfceWindowManagerRunning(ctx) {
+		return true
+	}
+	stopFallbackWindowManagers(ctx)
+	startDisplayCommand(ctx, "window manager", windowManager, "--replace")
+	return true
+}
+
+func stopFallbackWindowManagers(ctx context.Context) {
+	stopDisplayProcesses(ctx, "twm")
 }
 
 func startDisplayTerminal(ctx context.Context) {
@@ -447,18 +545,89 @@ func startDisplayBrowser(ctx context.Context) {
 	)
 }
 
-func displayProcessRunning(ctx context.Context, patterns ...string) bool {
-	pgrep := resolveDisplayCommand("pgrep")
-	if pgrep == "" {
-		return false
+func startDesktopStyle(ctx context.Context) {
+	script := strings.TrimSpace(desktopStyleScript())
+	if script == "" {
+		return
 	}
-	for _, pattern := range patterns {
-		cmd := exec.CommandContext(ctx, pgrep, "-f", pattern) //nolint:gosec // patterns are controlled by this package.
-		if cmd.Run() == nil {
-			return true
+	if err := os.WriteFile(desktopStylePath, []byte(script+"\n"), 0o755); err != nil { //nolint:gosec // G306: executable script is intentionally written for this container session.
+		logger.FromContext(ctx).Warn("failed to write display desktop style script", slog.String("path", desktopStylePath), slog.Any("error", err))
+		return
+	}
+	startDisplayCommand(ctx, "desktop style", "/bin/sh", desktopStylePath)
+}
+
+func desktopBackgroundColor() string {
+	color := strings.TrimSpace(os.Getenv("MEMOH_DISPLAY_DESKTOP_COLOR"))
+	if color == "" {
+		return "#1f2329"
+	}
+	return color
+}
+
+func desktopStyleScript() string {
+	if data, err := os.ReadFile("scripts/desktop-style.sh"); err == nil {
+		return string(data)
+	}
+	return scriptassets.DesktopStyle
+}
+
+func displayProcessRunning(_ context.Context, patterns ...string) bool {
+	return len(displayProcessIDsByName(patterns...)) > 0
+}
+
+func displayProcessIDsByName(names ...string) []int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			wanted[name] = struct{}{}
 		}
 	}
-	return false
+	if len(wanted) == 0 {
+		return nil
+	}
+	var pids []int
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == "" || name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", name, "cmdline")) //nolint:gosec // /proc entries are kernel-provided.
+		if err != nil || len(cmdline) == 0 {
+			continue
+		}
+		pid, err := strconv.Atoi(name)
+		if err != nil {
+			continue
+		}
+		parts := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
+		for _, arg := range parts {
+			if _, ok := wanted[filepath.Base(strings.TrimSpace(arg))]; ok {
+				pids = append(pids, pid)
+				break
+			}
+		}
+	}
+	return pids
+}
+
+func stopDisplayProcesses(ctx context.Context, names ...string) {
+	pids := displayProcessIDsByName(names...)
+	for _, pid := range pids {
+		process, err := os.FindProcess(pid)
+		if err == nil {
+			_ = process.Kill()
+		}
+	}
+	if len(pids) == 0 {
+		return
+	}
+	_ = sleepWithContext(ctx, 300*time.Millisecond)
 }
 
 func xvncProcessRunning() bool {
@@ -575,6 +744,46 @@ func xvncProcessIDs() []int {
 		}
 	}
 	return pids
+}
+
+func xvncProcessMissingArg(requiredArg string) bool {
+	requiredArg = strings.TrimSpace(requiredArg)
+	if requiredArg == "" {
+		return false
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == "" || name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", name, "cmdline")) //nolint:gosec // /proc entries are kernel-provided.
+		if err != nil || len(cmdline) == 0 {
+			continue
+		}
+		parts := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
+		hasXvnc := false
+		hasDisplay := false
+		hasRequiredArg := false
+		for _, arg := range parts {
+			if filepath.Base(arg) == "Xvnc" {
+				hasXvnc = true
+			}
+			if arg == xvncDisplay {
+				hasDisplay = true
+			}
+			if arg == requiredArg {
+				hasRequiredArg = true
+			}
+		}
+		if hasXvnc && hasDisplay && !hasRequiredArg {
+			return true
+		}
+	}
+	return false
 }
 
 func stopXvncProcesses(ctx context.Context) {

--- a/internal/display/service.go
+++ b/internal/display/service.go
@@ -51,6 +51,14 @@ const (
 	screenshotMaxBytes   = 512 * 1024
 	screenshotMIME       = "image/jpeg"
 	rfbTCPAddress        = "127.0.0.1:5999"
+	inputChannelLabel    = "display-input"
+	cursorChannelLabel   = "display-cursor"
+	rfbEncodingRaw       = 0
+	rfbEncodingCopyRect  = 1
+	rfbEncodingCursor    = -239
+	rfbEncodingXCursor   = -240
+	maxCursorDimension   = 512
+	maxRFBDiscardBytes   = 256 * 1024 * 1024
 )
 
 type screenshotJPEGCandidate struct {
@@ -323,7 +331,7 @@ func (s *Service) Screenshot(ctx context.Context, botID string) ([]byte, string,
 	defer cancel()
 	go proxyRFBListener(runCtx, proxy, func(ctx context.Context) (net.Conn, error) {
 		return s.dialRFB(ctx, botID)
-	}, s.logger, botID)
+	}, s.logger, botID, false)
 
 	proxyPort := proxy.Addr().(*net.TCPAddr).Port
 	cmd := exec.CommandContext(runCtx, gstLaunch, gstreamerScreenshotArgs(proxyPort, outputPath)...) //nolint:gosec // executable is resolved from PATH or explicit admin env.
@@ -491,6 +499,10 @@ type session struct {
 	tracks   map[string]*webrtc.TrackLocalStaticRTP
 	input    *rfbInputClient
 
+	cursorMu           sync.RWMutex
+	cursorPayload      []byte
+	cursorDataChannels map[string]*webrtc.DataChannel
+
 	peersMu sync.RWMutex
 	peers   map[string]*peerSession
 
@@ -513,14 +525,15 @@ type peerSession struct {
 func newSession(service *Service, botID, gstLaunch, codec string) *session {
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is stored on the session and called when the display session stops.
 	return &session{
-		service:   service,
-		botID:     botID,
-		gstLaunch: gstLaunch,
-		codec:     codec,
-		ctx:       ctx,
-		cancel:    cancel,
-		tracks:    make(map[string]*webrtc.TrackLocalStaticRTP),
-		peers:     make(map[string]*peerSession),
+		service:            service,
+		botID:              botID,
+		gstLaunch:          gstLaunch,
+		codec:              codec,
+		ctx:                ctx,
+		cancel:             cancel,
+		tracks:             make(map[string]*webrtc.TrackLocalStaticRTP),
+		peers:              make(map[string]*peerSession),
+		cursorDataChannels: make(map[string]*webrtc.DataChannel),
 	}
 }
 
@@ -605,6 +618,7 @@ func (s *session) start(ctx context.Context) error {
 
 	go s.acceptProxy()
 	go s.forwardRTP()
+	go s.watchCursor(runCtx)
 	gstreamerDone := make(chan error, 1)
 	go s.waitGStreamer(gstreamerDone)
 
@@ -673,8 +687,19 @@ func (s *session) answer(ctx context.Context, req OfferRequest) (OfferResponse, 
 	}
 	go drainRTCP(sender)
 
+	cursorChannel, err := pc.CreateDataChannel(cursorChannelLabel, nil)
+	if err != nil {
+		_ = pc.Close()
+		return OfferResponse{}, fmt.Errorf("create cursor metadata channel: %w", err)
+	}
+	cursorChannelID := uuid.NewString()
+	cursorChannel.OnOpen(func() {
+		s.sendLatestCursor(cursorChannel)
+	})
+	s.addCursorDataChannel(cursorChannelID, cursorChannel)
+
 	pc.OnDataChannel(func(dc *webrtc.DataChannel) {
-		if dc.Label() != "display-input" {
+		if dc.Label() != inputChannelLabel {
 			return
 		}
 		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
@@ -699,6 +724,7 @@ func (s *session) answer(ctx context.Context, req OfferRequest) (OfferResponse, 
 		cleanupOnce.Do(func() {
 			s.removePeer(peer)
 			s.removeTrack(trackID)
+			s.removeCursorDataChannel(cursorChannelID)
 			if closePeer {
 				_ = pc.Close()
 			}
@@ -777,6 +803,17 @@ type inputEvent struct {
 	Down       bool   `json:"down,omitempty"`
 }
 
+type cursorMetadata struct {
+	Type   string `json:"type"`
+	Source string `json:"source"`
+	Cursor string `json:"cursor,omitempty"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
+	HotX   int    `json:"hot_x,omitempty"`
+	HotY   int    `json:"hot_y,omitempty"`
+	Hidden bool   `json:"hidden,omitempty"`
+}
+
 func (s *session) handleInput(data []byte) error {
 	if s.input == nil {
 		return errors.New("display input is unavailable")
@@ -811,6 +848,119 @@ func (s *session) removeTrack(id string) {
 	s.tracksMu.Unlock()
 	if empty {
 		go s.stop()
+	}
+}
+
+func (s *session) addCursorDataChannel(id string, channel *webrtc.DataChannel) {
+	if channel == nil || strings.TrimSpace(id) == "" {
+		return
+	}
+	s.cursorMu.Lock()
+	s.cursorDataChannels[id] = channel
+	s.cursorMu.Unlock()
+}
+
+func (s *session) removeCursorDataChannel(id string) {
+	if strings.TrimSpace(id) == "" {
+		return
+	}
+	s.cursorMu.Lock()
+	delete(s.cursorDataChannels, id)
+	s.cursorMu.Unlock()
+}
+
+func (s *session) sendLatestCursor(channel *webrtc.DataChannel) {
+	if channel == nil {
+		return
+	}
+	s.cursorMu.RLock()
+	payload := append([]byte(nil), s.cursorPayload...)
+	s.cursorMu.RUnlock()
+	if len(payload) == 0 {
+		return
+	}
+	s.sendCursorPayload(channel, payload)
+}
+
+func (s *session) broadcastCursor(cursor cursorMetadata) {
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		s.service.logger.Debug("display cursor metadata dropped", slog.String("bot_id", s.botID), slog.Any("error", err))
+		return
+	}
+	s.cursorMu.Lock()
+	if bytes.Equal(s.cursorPayload, payload) {
+		s.cursorMu.Unlock()
+		return
+	}
+	s.cursorPayload = append(s.cursorPayload[:0], payload...)
+	channels := make([]*webrtc.DataChannel, 0, len(s.cursorDataChannels))
+	for _, channel := range s.cursorDataChannels {
+		channels = append(channels, channel)
+	}
+	s.cursorMu.Unlock()
+
+	for _, channel := range channels {
+		s.sendCursorPayload(channel, payload)
+	}
+}
+
+func (s *session) sendCursorPayload(channel *webrtc.DataChannel, payload []byte) {
+	if channel == nil || channel.ReadyState() != webrtc.DataChannelStateOpen {
+		return
+	}
+	if err := channel.SendText(string(payload)); err != nil {
+		s.service.logger.Debug("display cursor metadata send failed", slog.String("bot_id", s.botID), slog.Any("error", err))
+	}
+}
+
+func (s *session) watchCursor(ctx context.Context) {
+	backoff := 500 * time.Millisecond
+	for {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		conn, err := s.service.dialRFB(ctx, s.botID)
+		if err != nil {
+			s.service.logger.Debug("display cursor watcher unavailable", slog.String("bot_id", s.botID), slog.Any("error", err))
+			if waitContext(ctx, backoff) {
+				return
+			}
+			if backoff < 5*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		watcher := &rfbCursorWatcher{
+			conn: conn,
+			onCursor: func(cursor cursorMetadata) {
+				s.broadcastCursor(cursor)
+			},
+		}
+		err = watcher.Run(ctx)
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if err != nil {
+			s.service.logger.Debug("display cursor watcher stopped", slog.String("bot_id", s.botID), slog.Any("error", err))
+		}
+		if waitContext(ctx, backoff) {
+			return
+		}
+		if backoff < 5*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+func waitContext(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return true
+	case <-timer.C:
+		return false
 	}
 }
 
@@ -958,10 +1108,10 @@ func (s *session) acceptProxy() {
 func (s *session) proxyRFB(conn net.Conn) {
 	proxyRFBConnection(s.ctx, conn, func(ctx context.Context) (net.Conn, error) {
 		return s.service.dialRFB(ctx, s.botID)
-	}, s.service.logger, s.botID)
+	}, s.service.logger, s.botID, false)
 }
 
-func proxyRFBListener(ctx context.Context, listener net.Listener, dialRFB func(context.Context) (net.Conn, error), logger *slog.Logger, botID string) {
+func proxyRFBListener(ctx context.Context, listener net.Listener, dialRFB func(context.Context) (net.Conn, error), logger *slog.Logger, botID string, filterCursor bool) {
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -970,11 +1120,11 @@ func proxyRFBListener(ctx context.Context, listener net.Listener, dialRFB func(c
 			}
 			return
 		}
-		go proxyRFBConnection(ctx, conn, dialRFB, logger, botID)
+		go proxyRFBConnection(ctx, conn, dialRFB, logger, botID, filterCursor)
 	}
 }
 
-func proxyRFBConnection(ctx context.Context, conn net.Conn, dialRFB func(context.Context) (net.Conn, error), logger *slog.Logger, botID string) {
+func proxyRFBConnection(ctx context.Context, conn net.Conn, dialRFB func(context.Context) (net.Conn, error), logger *slog.Logger, botID string, filterCursor bool) {
 	defer func() { _ = conn.Close() }()
 
 	rfbConn, err := dialRFB(ctx)
@@ -983,6 +1133,13 @@ func proxyRFBConnection(ctx context.Context, conn net.Conn, dialRFB func(context
 		return
 	}
 	defer func() { _ = rfbConn.Close() }()
+
+	if filterCursor {
+		if err := proxyRFBWithoutCursor(ctx, conn, rfbConn); err != nil && ctx.Err() == nil && !errors.Is(err, net.ErrClosed) {
+			logger.Debug("display RFB cursor-filter proxy stopped", slog.String("bot_id", botID), slog.Any("error", err))
+		}
+		return
+	}
 
 	done := make(chan struct{}, 2)
 	go func() {
@@ -994,6 +1151,374 @@ func proxyRFBConnection(ctx context.Context, conn net.Conn, dialRFB func(context
 		done <- struct{}{}
 	}()
 	<-done
+}
+
+func proxyRFBWithoutCursor(ctx context.Context, client, server net.Conn) error {
+	format, err := proxyRFBHandshake(client, server)
+	if err != nil {
+		return err
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- proxyRFBClientMessages(ctx, client, server, &format)
+	}()
+	go func() {
+		errCh <- proxyRFBServerMessages(ctx, client, server, &format)
+	}()
+	return <-errCh
+}
+
+func proxyRFBHandshake(client, server net.Conn) (rfbPixelFormat, error) {
+	version := make([]byte, 12)
+	if _, err := io.ReadFull(server, version); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB version: %w", err)
+	}
+	if _, err := client.Write(version); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB version: %w", err)
+	}
+	if _, err := io.ReadFull(client, version); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB client version: %w", err)
+	}
+	if _, err := server.Write(version); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB client version: %w", err)
+	}
+
+	securityCount := []byte{0}
+	if _, err := io.ReadFull(server, securityCount); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB security count: %w", err)
+	}
+	if _, err := client.Write(securityCount); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB security count: %w", err)
+	}
+	if securityCount[0] == 0 {
+		if err := proxyRFBLengthPrefixedBytes(server, client); err != nil {
+			return rfbPixelFormat{}, err
+		}
+		return rfbPixelFormat{}, errors.New("RFB security negotiation failed")
+	}
+	securityTypes := make([]byte, int(securityCount[0]))
+	if _, err := io.ReadFull(server, securityTypes); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB security types: %w", err)
+	}
+	if _, err := client.Write(securityTypes); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB security types: %w", err)
+	}
+	securityType := []byte{0}
+	if _, err := io.ReadFull(client, securityType); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB selected security type: %w", err)
+	}
+	if _, err := server.Write(securityType); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB selected security type: %w", err)
+	}
+	securityResult := make([]byte, 4)
+	if _, err := io.ReadFull(server, securityResult); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB security result: %w", err)
+	}
+	if _, err := client.Write(securityResult); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB security result: %w", err)
+	}
+	if binary.BigEndian.Uint32(securityResult) != 0 {
+		if err := proxyRFBLengthPrefixedBytes(server, client); err != nil {
+			return rfbPixelFormat{}, err
+		}
+		return rfbPixelFormat{}, errors.New("RFB security rejected")
+	}
+
+	clientInit := []byte{0}
+	if _, err := io.ReadFull(client, clientInit); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB client init: %w", err)
+	}
+	if _, err := server.Write(clientInit); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB client init: %w", err)
+	}
+	serverInit := make([]byte, 24)
+	if _, err := io.ReadFull(server, serverInit); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy read RFB server init: %w", err)
+	}
+	if _, err := client.Write(serverInit); err != nil {
+		return rfbPixelFormat{}, fmt.Errorf("proxy write RFB server init: %w", err)
+	}
+	nameLen := binary.BigEndian.Uint32(serverInit[20:24])
+	if nameLen > maxRFBDiscardBytes {
+		return rfbPixelFormat{}, fmt.Errorf("RFB desktop name too large: %d", nameLen)
+	}
+	if nameLen > 0 {
+		name := make([]byte, nameLen)
+		if _, err := io.ReadFull(server, name); err != nil {
+			return rfbPixelFormat{}, fmt.Errorf("proxy read RFB desktop name: %w", err)
+		}
+		if _, err := client.Write(name); err != nil {
+			return rfbPixelFormat{}, fmt.Errorf("proxy write RFB desktop name: %w", err)
+		}
+	}
+	return parseRFBPixelFormat(serverInit[4:20]), nil
+}
+
+func proxyRFBLengthPrefixedBytes(src, dst net.Conn) error {
+	lengthBuf := make([]byte, 4)
+	if _, err := io.ReadFull(src, lengthBuf); err != nil {
+		return fmt.Errorf("proxy read RFB length: %w", err)
+	}
+	if _, err := dst.Write(lengthBuf); err != nil {
+		return fmt.Errorf("proxy write RFB length: %w", err)
+	}
+	length := binary.BigEndian.Uint32(lengthBuf)
+	if length > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB length-prefixed payload too large: %d", length)
+	}
+	if _, err := io.CopyN(dst, src, int64(length)); err != nil {
+		return fmt.Errorf("proxy copy RFB length-prefixed payload: %w", err)
+	}
+	return nil
+}
+
+func proxyRFBClientMessages(ctx context.Context, client, server net.Conn, format *rfbPixelFormat) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		msgType := []byte{0}
+		if _, err := io.ReadFull(client, msgType); err != nil {
+			return fmt.Errorf("proxy read RFB client message type: %w", err)
+		}
+		switch msgType[0] {
+		case 0:
+			payload := make([]byte, 19)
+			if _, err := io.ReadFull(client, payload); err != nil {
+				return fmt.Errorf("proxy read RFB set pixel format: %w", err)
+			}
+			*format = parseRFBPixelFormat(payload[3:19])
+			if _, err := server.Write(append(msgType, payload...)); err != nil {
+				return fmt.Errorf("proxy write RFB set pixel format: %w", err)
+			}
+		case 2:
+			if err := proxyRFBSetEncodingsWithCursor(client, server); err != nil {
+				return err
+			}
+		case 3:
+			if err := proxyFixedRFBClientMessage(client, server, msgType, 9, "framebuffer update request"); err != nil {
+				return err
+			}
+		case 4:
+			if err := proxyFixedRFBClientMessage(client, server, msgType, 7, "key event"); err != nil {
+				return err
+			}
+		case 5:
+			if err := proxyFixedRFBClientMessage(client, server, msgType, 5, "pointer event"); err != nil {
+				return err
+			}
+		case 6:
+			if err := proxyRFBClientCutText(client, server, msgType); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported RFB client message type %d", msgType[0])
+		}
+	}
+}
+
+func proxyFixedRFBClientMessage(client io.Reader, server io.Writer, msgType []byte, payloadSize int, name string) error {
+	payload := make([]byte, payloadSize)
+	if _, err := io.ReadFull(client, payload); err != nil {
+		return fmt.Errorf("proxy read RFB %s: %w", name, err)
+	}
+	if _, err := server.Write(append(msgType, payload...)); err != nil {
+		return fmt.Errorf("proxy write RFB %s: %w", name, err)
+	}
+	return nil
+}
+
+func proxyRFBClientCutText(client io.Reader, server io.Writer, msgType []byte) error {
+	header := make([]byte, 7)
+	if _, err := io.ReadFull(client, header); err != nil {
+		return fmt.Errorf("proxy read RFB client cut text header: %w", err)
+	}
+	length := binary.BigEndian.Uint32(header[3:7])
+	if length > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB client cut text too large: %d", length)
+	}
+	if _, err := server.Write(append(msgType, header...)); err != nil {
+		return fmt.Errorf("proxy write RFB client cut text header: %w", err)
+	}
+	if _, err := io.CopyN(server, client, int64(length)); err != nil {
+		return fmt.Errorf("proxy copy RFB client cut text: %w", err)
+	}
+	return nil
+}
+
+func proxyRFBSetEncodingsWithCursor(client io.Reader, server io.Writer) error {
+	header := make([]byte, 3)
+	if _, err := io.ReadFull(client, header); err != nil {
+		return fmt.Errorf("proxy read RFB set encodings header: %w", err)
+	}
+	count := int(binary.BigEndian.Uint16(header[1:3]))
+	buf := make([]byte, count*4)
+	if _, err := io.ReadFull(client, buf); err != nil {
+		return fmt.Errorf("proxy read RFB set encodings payload: %w", err)
+	}
+	seen := map[int32]bool{}
+	encodings := []int32{rfbEncodingCursor, rfbEncodingXCursor}
+	seen[rfbEncodingCursor] = true
+	seen[rfbEncodingXCursor] = true
+	for i := 0; i < count; i++ {
+		encoding := int32(binary.BigEndian.Uint32(buf[i*4 : i*4+4])) //nolint:gosec // RFB encodings are signed 32-bit values on the wire.
+		if encoding != rfbEncodingRaw && encoding != rfbEncodingCopyRect {
+			continue
+		}
+		if seen[encoding] {
+			continue
+		}
+		encodings = append(encodings, encoding)
+		seen[encoding] = true
+	}
+	if !seen[rfbEncodingRaw] {
+		encodings = append(encodings, rfbEncodingRaw)
+	}
+	return writeRFBSetEncodings(server, encodings)
+}
+
+func proxyRFBServerMessages(ctx context.Context, client, server net.Conn, format *rfbPixelFormat) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		msgType := []byte{0}
+		if _, err := io.ReadFull(server, msgType); err != nil {
+			return fmt.Errorf("proxy read RFB server message type: %w", err)
+		}
+		switch msgType[0] {
+		case 0:
+			if err := proxyRFBFramebufferUpdateWithoutCursor(client, server, *format); err != nil {
+				return err
+			}
+		case 2:
+			if _, err := client.Write(msgType); err != nil {
+				return fmt.Errorf("proxy write RFB bell: %w", err)
+			}
+		case 3:
+			if err := proxyRFBServerCutText(client, server, msgType); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported RFB server message type %d", msgType[0])
+		}
+	}
+}
+
+func proxyRFBServerCutText(client io.Writer, server io.Reader, msgType []byte) error {
+	header := make([]byte, 7)
+	if _, err := io.ReadFull(server, header); err != nil {
+		return fmt.Errorf("proxy read RFB server cut text header: %w", err)
+	}
+	length := binary.BigEndian.Uint32(header[3:7])
+	if length > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB server cut text too large: %d", length)
+	}
+	if _, err := client.Write(append(msgType, header...)); err != nil {
+		return fmt.Errorf("proxy write RFB server cut text header: %w", err)
+	}
+	if _, err := io.CopyN(client, server, int64(length)); err != nil {
+		return fmt.Errorf("proxy copy RFB server cut text: %w", err)
+	}
+	return nil
+}
+
+func proxyRFBFramebufferUpdateWithoutCursor(client io.Writer, server io.Reader, format rfbPixelFormat) error {
+	header := make([]byte, 3)
+	if _, err := io.ReadFull(server, header); err != nil {
+		return fmt.Errorf("proxy read RFB framebuffer update header: %w", err)
+	}
+	count := int(binary.BigEndian.Uint16(header[1:3]))
+	var payload bytes.Buffer
+	outCount := 0
+	for i := 0; i < count; i++ {
+		rect, rectHeader, err := readRFBRectHeaderBytes(server)
+		if err != nil {
+			return err
+		}
+		switch rect.encoding {
+		case rfbEncodingCursor:
+			if err := discardRFBCursor(server, rect, format); err != nil {
+				return err
+			}
+		case rfbEncodingXCursor:
+			if err := discardRFBXCursor(server, rect); err != nil {
+				return err
+			}
+		case rfbEncodingRaw:
+			payload.Write(rectHeader)
+			if err := copyRFBRectangle(&payload, server, rect, format.bytesPerPixel()); err != nil {
+				return err
+			}
+			outCount++
+		case rfbEncodingCopyRect:
+			payload.Write(rectHeader)
+			if _, err := io.CopyN(&payload, server, 4); err != nil {
+				return fmt.Errorf("proxy copy RFB copyrect payload: %w", err)
+			}
+			outCount++
+		default:
+			return fmt.Errorf("unsupported RFB rectangle encoding %d", rect.encoding)
+		}
+	}
+	outHeader := []byte{0, 0, 0, 0}
+	binary.BigEndian.PutUint16(outHeader[2:4], uint16(outCount))
+	if _, err := client.Write(outHeader); err != nil {
+		return fmt.Errorf("proxy write RFB framebuffer update header: %w", err)
+	}
+	if _, err := client.Write(payload.Bytes()); err != nil {
+		return fmt.Errorf("proxy write RFB framebuffer update payload: %w", err)
+	}
+	return nil
+}
+
+func readRFBRectHeaderBytes(r io.Reader) (rfbRectHeader, []byte, error) {
+	buf := make([]byte, 12)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return rfbRectHeader{}, nil, fmt.Errorf("read RFB rectangle header: %w", err)
+	}
+	return parseRFBRectHeader(buf), buf, nil
+}
+
+func copyRFBRectangle(dst io.Writer, src io.Reader, rect rfbRectHeader, bytesPerPixel int) error {
+	if bytesPerPixel <= 0 {
+		return errors.New("invalid RFB pixel format")
+	}
+	size := int64(rect.width) * int64(rect.height) * int64(bytesPerPixel)
+	if size < 0 || size > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB rectangle payload too large: %d", size)
+	}
+	if _, err := io.CopyN(dst, src, size); err != nil {
+		return fmt.Errorf("proxy copy RFB raw rectangle: %w", err)
+	}
+	return nil
+}
+
+func discardRFBCursor(r io.Reader, rect rfbRectHeader, format rfbPixelFormat) error {
+	bytesPerPixel := format.bytesPerPixel()
+	if bytesPerPixel <= 0 {
+		return errors.New("invalid RFB cursor pixel format")
+	}
+	size := int64(rect.width)*int64(rect.height)*int64(bytesPerPixel) + int64(rfbCursorMaskBytes(rect.width, rect.height))
+	if size < 0 || size > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB cursor payload too large: %d", size)
+	}
+	if _, err := io.CopyN(io.Discard, r, size); err != nil {
+		return fmt.Errorf("discard RFB cursor payload: %w", err)
+	}
+	return nil
+}
+
+func discardRFBXCursor(r io.Reader, rect rfbRectHeader) error {
+	size := int64(6 + rfbCursorMaskBytes(rect.width, rect.height)*2)
+	if size < 0 || size > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB XCursor payload too large: %d", size)
+	}
+	if _, err := io.CopyN(io.Discard, r, size); err != nil {
+		return fmt.Errorf("discard RFB XCursor payload: %w", err)
+	}
+	return nil
 }
 
 func (s *session) forwardRTP() {
@@ -1391,9 +1916,373 @@ func (w processLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+type rfbCursorWatcher struct {
+	conn     net.Conn
+	onCursor func(cursorMetadata)
+}
+
+type rfbServerInit struct {
+	width  uint16
+	height uint16
+	format rfbPixelFormat
+	name   string
+}
+
+type rfbPixelFormat struct {
+	bitsPerPixel uint8
+	depth        uint8
+	bigEndian    bool
+	trueColor    bool
+	redMax       uint16
+	greenMax     uint16
+	blueMax      uint16
+	redShift     uint8
+	greenShift   uint8
+	blueShift    uint8
+}
+
+type rfbRectHeader struct {
+	x        uint16
+	y        uint16
+	width    uint16
+	height   uint16
+	encoding int32
+}
+
+var cursorPixelFormat = rfbPixelFormat{
+	bitsPerPixel: 32,
+	depth:        24,
+	trueColor:    true,
+	redMax:       255,
+	greenMax:     255,
+	blueMax:      255,
+	redShift:     16,
+	greenShift:   8,
+	blueShift:    0,
+}
+
+func (w *rfbCursorWatcher) Run(ctx context.Context) error {
+	if w == nil || w.conn == nil {
+		return errors.New("RFB cursor watcher has no connection")
+	}
+	defer func() { _ = w.conn.Close() }()
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = w.conn.Close()
+		case <-done:
+		}
+	}()
+	defer close(done)
+
+	init, err := handshakeRFBNoneSecurityServerInit(w.conn, true)
+	if err != nil {
+		return err
+	}
+	if init == nil || init.width == 0 || init.height == 0 {
+		return errors.New("RFB server init is missing display size")
+	}
+	if err := writeRFBSetPixelFormat(w.conn, cursorPixelFormat); err != nil {
+		return fmt.Errorf("write RFB cursor pixel format: %w", err)
+	}
+	if err := writeRFBSetEncodings(w.conn, []int32{rfbEncodingCursor, rfbEncodingXCursor, rfbEncodingRaw, rfbEncodingCopyRect}); err != nil {
+		return fmt.Errorf("write RFB cursor encodings: %w", err)
+	}
+
+	incremental := false
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := writeRFBFramebufferUpdateRequest(w.conn, incremental, 0, 0, init.width, init.height); err != nil {
+			return fmt.Errorf("request RFB cursor update: %w", err)
+		}
+		incremental = true
+		if err := w.readServerMessage(); err != nil {
+			return err
+		}
+	}
+}
+
+func (w *rfbCursorWatcher) readServerMessage() error {
+	msgType := []byte{0}
+	if _, err := io.ReadFull(w.conn, msgType); err != nil {
+		return fmt.Errorf("read RFB server message type: %w", err)
+	}
+	switch msgType[0] {
+	case 0:
+		return w.readFramebufferUpdate()
+	case 2:
+		return nil
+	case 3:
+		return skipRFBCutText(w.conn)
+	default:
+		return fmt.Errorf("unsupported RFB server message type %d", msgType[0])
+	}
+}
+
+func (w *rfbCursorWatcher) readFramebufferUpdate() error {
+	header := make([]byte, 3)
+	if _, err := io.ReadFull(w.conn, header); err != nil {
+		return fmt.Errorf("read RFB framebuffer update header: %w", err)
+	}
+	count := int(binary.BigEndian.Uint16(header[1:3]))
+	for i := 0; i < count; i++ {
+		rect, err := readRFBRectHeader(w.conn)
+		if err != nil {
+			return err
+		}
+		switch rect.encoding {
+		case rfbEncodingCursor:
+			cursor, err := readRFBRichCursor(w.conn, rect, cursorPixelFormat)
+			if err != nil {
+				return err
+			}
+			if w.onCursor != nil {
+				w.onCursor(cursor)
+			}
+		case rfbEncodingXCursor:
+			cursor, err := readRFBXCursor(w.conn, rect)
+			if err != nil {
+				return err
+			}
+			if w.onCursor != nil {
+				w.onCursor(cursor)
+			}
+		case rfbEncodingRaw:
+			if err := skipRFBRectangle(w.conn, rect, cursorPixelFormat.bytesPerPixel()); err != nil {
+				return err
+			}
+		case rfbEncodingCopyRect:
+			if _, err := io.CopyN(io.Discard, w.conn, 4); err != nil {
+				return fmt.Errorf("skip RFB copyrect payload: %w", err)
+			}
+		default:
+			return fmt.Errorf("unsupported RFB rectangle encoding %d", rect.encoding)
+		}
+	}
+	return nil
+}
+
+func readRFBRectHeader(r io.Reader) (rfbRectHeader, error) {
+	buf := make([]byte, 12)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return rfbRectHeader{}, fmt.Errorf("read RFB rectangle header: %w", err)
+	}
+	return parseRFBRectHeader(buf), nil
+}
+
+func parseRFBRectHeader(buf []byte) rfbRectHeader {
+	if len(buf) < 12 {
+		return rfbRectHeader{}
+	}
+	return rfbRectHeader{
+		x:        binary.BigEndian.Uint16(buf[0:2]),
+		y:        binary.BigEndian.Uint16(buf[2:4]),
+		width:    binary.BigEndian.Uint16(buf[4:6]),
+		height:   binary.BigEndian.Uint16(buf[6:8]),
+		encoding: int32(binary.BigEndian.Uint32(buf[8:12])), //nolint:gosec // RFB encodings are signed 32-bit values on the wire.
+	}
+}
+
+func readRFBRichCursor(r io.Reader, rect rfbRectHeader, format rfbPixelFormat) (cursorMetadata, error) {
+	if rect.width == 0 || rect.height == 0 {
+		return cursorMetadata{Type: "cursor", Source: "rfb", Hidden: true}, nil
+	}
+	if rect.width > maxCursorDimension || rect.height > maxCursorDimension {
+		return cursorMetadata{}, fmt.Errorf("RFB cursor is too large: %dx%d", rect.width, rect.height)
+	}
+	bytesPerPixel := format.bytesPerPixel()
+	pixelBytes := int(rect.width) * int(rect.height) * bytesPerPixel
+	maskBytes := rfbCursorMaskBytes(rect.width, rect.height)
+	pixels := make([]byte, pixelBytes)
+	if _, err := io.ReadFull(r, pixels); err != nil {
+		return cursorMetadata{}, fmt.Errorf("read RFB cursor pixels: %w", err)
+	}
+	mask := make([]byte, maskBytes)
+	if _, err := io.ReadFull(r, mask); err != nil {
+		return cursorMetadata{}, fmt.Errorf("read RFB cursor mask: %w", err)
+	}
+	return richCursorMetadata(rect, pixels, mask, format)
+}
+
+func readRFBXCursor(r io.Reader, rect rfbRectHeader) (cursorMetadata, error) {
+	if rect.width == 0 || rect.height == 0 {
+		return cursorMetadata{Type: "cursor", Source: "rfb", Hidden: true}, nil
+	}
+	if rect.width > maxCursorDimension || rect.height > maxCursorDimension {
+		return cursorMetadata{}, fmt.Errorf("RFB XCursor is too large: %dx%d", rect.width, rect.height)
+	}
+	maskBytes := rfbCursorMaskBytes(rect.width, rect.height)
+	payload := make([]byte, 6+maskBytes*2)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return cursorMetadata{}, fmt.Errorf("read RFB XCursor payload: %w", err)
+	}
+	return cursorMetadataFromGeometry(rect), nil
+}
+
+func richCursorMetadata(rect rfbRectHeader, pixels, mask []byte, format rfbPixelFormat) (cursorMetadata, error) {
+	if rect.width == 0 || rect.height == 0 {
+		return cursorMetadata{Type: "cursor", Source: "rfb", Hidden: true}, nil
+	}
+	bytesPerPixel := format.bytesPerPixel()
+	expectedPixels := int(rect.width) * int(rect.height) * bytesPerPixel
+	expectedMask := rfbCursorMaskBytes(rect.width, rect.height)
+	if len(pixels) != expectedPixels {
+		return cursorMetadata{}, fmt.Errorf("RFB cursor pixel length = %d, want %d", len(pixels), expectedPixels)
+	}
+	if len(mask) != expectedMask {
+		return cursorMetadata{}, fmt.Errorf("RFB cursor mask length = %d, want %d", len(mask), expectedMask)
+	}
+	return cursorMetadataFromGeometry(rect), nil
+}
+
+func cursorMetadataFromGeometry(rect rfbRectHeader) cursorMetadata {
+	return cursorMetadata{
+		Type:   "cursor",
+		Source: "rfb",
+		Cursor: nativeCursorType(rect),
+		Width:  int(rect.width),
+		Height: int(rect.height),
+		HotX:   int(rect.x),
+		HotY:   int(rect.y),
+	}
+}
+
+func nativeCursorType(rect rfbRectHeader) string {
+	width := int(rect.width)
+	height := int(rect.height)
+	hotX := int(rect.x)
+	hotY := int(rect.y)
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	centerX := width / 2
+	centerY := height / 2
+	if width <= 18 && height >= 18 && absInt(hotX-centerX) <= 3 && absInt(hotY-centerY) <= 4 {
+		return "text"
+	}
+	if width >= height*2 && absInt(hotY-centerY) <= 4 {
+		return "ew-resize"
+	}
+	if height >= width*2 && absInt(hotX-centerX) <= 4 {
+		return "ns-resize"
+	}
+	if width >= 18 && height >= 18 && absInt(hotX-centerX) <= 4 && absInt(hotY-centerY) <= 4 {
+		return "move"
+	}
+	if width >= 16 && height >= 16 && hotX > 3 && hotY <= 5 {
+		return "pointer"
+	}
+	return "default"
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func (f rfbPixelFormat) bytesPerPixel() int {
+	if f.bitsPerPixel == 0 {
+		return 0
+	}
+	return int(f.bitsPerPixel+7) / 8
+}
+
+func rfbCursorMaskBytes(width, height uint16) int {
+	return int((width+7)/8) * int(height)
+}
+
+func writeRFBSetPixelFormat(w io.Writer, format rfbPixelFormat) error {
+	msg := make([]byte, 20)
+	msg[0] = 0
+	msg[4] = format.bitsPerPixel
+	msg[5] = format.depth
+	if format.bigEndian {
+		msg[6] = 1
+	}
+	if format.trueColor {
+		msg[7] = 1
+	}
+	binary.BigEndian.PutUint16(msg[8:10], format.redMax)
+	binary.BigEndian.PutUint16(msg[10:12], format.greenMax)
+	binary.BigEndian.PutUint16(msg[12:14], format.blueMax)
+	msg[14] = format.redShift
+	msg[15] = format.greenShift
+	msg[16] = format.blueShift
+	_, err := w.Write(msg)
+	return err
+}
+
+func writeRFBSetEncodings(w io.Writer, encodings []int32) error {
+	if len(encodings) > 0xffff {
+		return fmt.Errorf("too many RFB encodings: %d", len(encodings))
+	}
+	msg := make([]byte, 4+len(encodings)*4)
+	msg[0] = 2
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(encodings))) //nolint:gosec // Length is range-checked above.
+	offset := 4
+	for _, encoding := range encodings {
+		binary.BigEndian.PutUint32(msg[offset:offset+4], uint32(encoding))
+		offset += 4
+	}
+	_, err := w.Write(msg)
+	return err
+}
+
+func writeRFBFramebufferUpdateRequest(w io.Writer, incremental bool, x, y, width, height uint16) error {
+	msg := make([]byte, 10)
+	msg[0] = 3
+	if incremental {
+		msg[1] = 1
+	}
+	binary.BigEndian.PutUint16(msg[2:4], x)
+	binary.BigEndian.PutUint16(msg[4:6], y)
+	binary.BigEndian.PutUint16(msg[6:8], width)
+	binary.BigEndian.PutUint16(msg[8:10], height)
+	_, err := w.Write(msg)
+	return err
+}
+
+func skipRFBRectangle(r io.Reader, rect rfbRectHeader, bytesPerPixel int) error {
+	if bytesPerPixel <= 0 {
+		return errors.New("invalid RFB pixel format")
+	}
+	size := int64(rect.width) * int64(rect.height) * int64(bytesPerPixel)
+	if size < 0 || size > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB rectangle payload too large: %d", size)
+	}
+	if _, err := io.CopyN(io.Discard, r, size); err != nil {
+		return fmt.Errorf("skip RFB raw rectangle: %w", err)
+	}
+	return nil
+}
+
+func skipRFBCutText(r io.Reader) error {
+	header := make([]byte, 7)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return fmt.Errorf("read RFB cut text header: %w", err)
+	}
+	length := binary.BigEndian.Uint32(header[3:7])
+	if length > maxRFBDiscardBytes {
+		return fmt.Errorf("RFB cut text too large: %d", length)
+	}
+	if _, err := io.CopyN(io.Discard, r, int64(length)); err != nil {
+		return fmt.Errorf("skip RFB cut text: %w", err)
+	}
+	return nil
+}
+
 type rfbInputClient struct {
-	mu   sync.Mutex
-	conn net.Conn
+	mu             sync.Mutex
+	conn           net.Conn
+	lastX          int
+	lastY          int
+	lastButtonMask uint8
+	hasPointer     bool
 }
 
 func newRFBInputClient(conn net.Conn) (*rfbInputClient, error) {
@@ -1422,6 +2311,14 @@ func (c *rfbInputClient) Pointer(x, y int, buttonMask uint8) error {
 	if c.conn == nil {
 		return net.ErrClosed
 	}
+	c.lastX = x
+	c.lastY = y
+	c.lastButtonMask = buttonMask
+	c.hasPointer = true
+	return c.writePointerLocked(x, y, buttonMask)
+}
+
+func (c *rfbInputClient) writePointerLocked(x, y int, buttonMask uint8) error {
 	msg := []byte{5, buttonMask, 0, 0, 0, 0}
 	binary.BigEndian.PutUint16(msg[2:4], clampUint16(x))
 	binary.BigEndian.PutUint16(msg[4:6], clampUint16(y))
@@ -1440,8 +2337,23 @@ func (c *rfbInputClient) Key(keysym uint32, down bool) error {
 		msg[1] = 1
 	}
 	binary.BigEndian.PutUint32(msg[4:8], keysym)
+	if c.hasPointer {
+		jitterX := c.lastX - 1
+		if jitterX < 0 {
+			jitterX = c.lastX + 1
+		}
+		msg = append(msg, pointerEventBytes(jitterX, c.lastY, c.lastButtonMask)...)
+		msg = append(msg, pointerEventBytes(c.lastX, c.lastY, c.lastButtonMask)...)
+	}
 	_, err := c.conn.Write(msg)
 	return err
+}
+
+func pointerEventBytes(x, y int, buttonMask uint8) []byte {
+	msg := []byte{5, buttonMask, 0, 0, 0, 0}
+	binary.BigEndian.PutUint16(msg[2:4], clampUint16(x))
+	binary.BigEndian.PutUint16(msg[4:6], clampUint16(y))
+	return msg
 }
 
 func (c *rfbInputClient) handshake() error {
@@ -1454,69 +2366,102 @@ func probeRFBNoneSecurity(conn net.Conn) error {
 }
 
 func handshakeRFBNoneSecurity(conn net.Conn, clientInit bool) error {
+	_, err := handshakeRFBNoneSecurityServerInit(conn, clientInit)
+	return err
+}
+
+func handshakeRFBNoneSecurityServerInit(conn net.Conn, clientInit bool) (*rfbServerInit, error) {
 	if err := conn.SetDeadline(time.Now().Add(displayProbePeriod)); err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = conn.SetDeadline(time.Time{}) }()
 
 	version := make([]byte, 12)
 	if _, err := io.ReadFull(conn, version); err != nil {
-		return fmt.Errorf("read RFB version: %w", err)
+		return nil, fmt.Errorf("read RFB version: %w", err)
 	}
 	if _, err := conn.Write(version); err != nil {
-		return fmt.Errorf("write RFB version: %w", err)
+		return nil, fmt.Errorf("write RFB version: %w", err)
 	}
 
 	count := []byte{0}
 	if _, err := io.ReadFull(conn, count); err != nil {
-		return fmt.Errorf("read RFB security types: %w", err)
+		return nil, fmt.Errorf("read RFB security types: %w", err)
 	}
 	if count[0] == 0 {
 		reason, err := readRFBString(conn)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return fmt.Errorf("RFB security negotiation failed: %s", reason)
+		return nil, fmt.Errorf("RFB security negotiation failed: %s", reason)
 	}
 	types := make([]byte, int(count[0]))
 	if _, err := io.ReadFull(conn, types); err != nil {
-		return fmt.Errorf("read RFB security type list: %w", err)
+		return nil, fmt.Errorf("read RFB security type list: %w", err)
 	}
 	if !containsByte(types, 1) {
-		return errors.New("RFB server does not allow None security")
+		return nil, errors.New("RFB server does not allow None security")
 	}
 	if _, err := conn.Write([]byte{1}); err != nil {
-		return fmt.Errorf("write RFB security type: %w", err)
+		return nil, fmt.Errorf("write RFB security type: %w", err)
 	}
 	result := make([]byte, 4)
 	if _, err := io.ReadFull(conn, result); err != nil {
-		return fmt.Errorf("read RFB security result: %w", err)
+		return nil, fmt.Errorf("read RFB security result: %w", err)
 	}
 	if binary.BigEndian.Uint32(result) != 0 {
 		reason, err := readRFBString(conn)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return fmt.Errorf("RFB security rejected: %s", reason)
+		return nil, fmt.Errorf("RFB security rejected: %s", reason)
 	}
 	if !clientInit {
-		return nil
+		return nil, nil
 	}
 
 	if _, err := conn.Write([]byte{1}); err != nil {
-		return fmt.Errorf("write RFB client init: %w", err)
+		return nil, fmt.Errorf("write RFB client init: %w", err)
 	}
 	header := make([]byte, 24)
 	if _, err := io.ReadFull(conn, header); err != nil {
-		return fmt.Errorf("read RFB server init: %w", err)
+		return nil, fmt.Errorf("read RFB server init: %w", err)
+	}
+	init := &rfbServerInit{
+		width:  binary.BigEndian.Uint16(header[0:2]),
+		height: binary.BigEndian.Uint16(header[2:4]),
+		format: parseRFBPixelFormat(header[4:20]),
 	}
 	nameLen := binary.BigEndian.Uint32(header[20:24])
 	if nameLen > 0 {
-		if _, err := io.CopyN(io.Discard, conn, int64(nameLen)); err != nil {
-			return fmt.Errorf("read RFB server name: %w", err)
+		if nameLen > 4096 {
+			return nil, fmt.Errorf("RFB desktop name too large: %d", nameLen)
 		}
+		name := make([]byte, nameLen)
+		if _, err := io.ReadFull(conn, name); err != nil {
+			return nil, fmt.Errorf("read RFB server name: %w", err)
+		}
+		init.name = string(name)
 	}
-	return nil
+	return init, nil
+}
+
+func parseRFBPixelFormat(data []byte) rfbPixelFormat {
+	if len(data) < 16 {
+		return rfbPixelFormat{}
+	}
+	return rfbPixelFormat{
+		bitsPerPixel: data[0],
+		depth:        data[1],
+		bigEndian:    data[2] != 0,
+		trueColor:    data[3] != 0,
+		redMax:       binary.BigEndian.Uint16(data[4:6]),
+		greenMax:     binary.BigEndian.Uint16(data[6:8]),
+		blueMax:      binary.BigEndian.Uint16(data[8:10]),
+		redShift:     data[10],
+		greenShift:   data[11],
+		blueShift:    data[12],
+	}
 }
 
 func readRFBString(r io.Reader) (string, error) {

--- a/internal/display/service_test.go
+++ b/internal/display/service_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -216,6 +217,134 @@ func TestGStreamerScreenshotArgsCapturesComputerUseJPEG(t *testing.T) {
 	}
 }
 
+func TestRFBInputKeyJittersLastPointerToWakeDisplayRefresh(t *testing.T) {
+	conn := &recordingConn{}
+	input := &rfbInputClient{conn: conn}
+
+	if err := input.Pointer(320, 240, 1); err != nil {
+		t.Fatalf("Pointer returned error: %v", err)
+	}
+	if err := input.Key(0x61, true); err != nil {
+		t.Fatalf("Key returned error: %v", err)
+	}
+
+	got := conn.Bytes()
+	want := []byte{
+		5, 1, 0x01, 0x40, 0x00, 0xf0,
+		4, 1, 0, 0, 0, 0, 0, 0x61,
+		5, 1, 0x01, 0x3f, 0x00, 0xf0,
+		5, 1, 0x01, 0x40, 0x00, 0xf0,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("input bytes = %v, want %v", got, want)
+	}
+}
+
+func TestRFBInputKeyWithoutPointerDoesNotMoveCursor(t *testing.T) {
+	conn := &recordingConn{}
+	input := &rfbInputClient{conn: conn}
+
+	if err := input.Key(0xff0d, true); err != nil {
+		t.Fatalf("Key returned error: %v", err)
+	}
+
+	got := conn.Bytes()
+	want := []byte{4, 1, 0, 0, 0, 0, 0xff, 0x0d}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("input bytes = %v, want %v", got, want)
+	}
+}
+
+func TestRFBSetEncodingsRequestsCursorPseudoEncoding(t *testing.T) {
+	var conn recordingConn
+
+	if err := writeRFBSetEncodings(&conn, []int32{rfbEncodingCursor, rfbEncodingXCursor, rfbEncodingRaw}); err != nil {
+		t.Fatalf("writeRFBSetEncodings returned error: %v", err)
+	}
+
+	got := conn.Bytes()
+	want := []byte{
+		2, 0, 0, 3,
+		0xff, 0xff, 0xff, 0x11,
+		0xff, 0xff, 0xff, 0x10,
+		0, 0, 0, 0,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("set encodings bytes = %v, want %v", got, want)
+	}
+}
+
+func TestProxyRFBSetEncodingsInjectsCursorAndRestrictsUnsupportedEncodings(t *testing.T) {
+	client := bytes.NewBuffer([]byte{
+		0, 0, 3,
+		0, 0, 0, 5,
+		0, 0, 0, 1,
+		0, 0, 0, 0,
+	})
+	var server recordingConn
+
+	if err := proxyRFBSetEncodingsWithCursor(client, &server); err != nil {
+		t.Fatalf("proxyRFBSetEncodingsWithCursor returned error: %v", err)
+	}
+
+	got := server.Bytes()
+	want := []byte{
+		2, 0, 0, 4,
+		0xff, 0xff, 0xff, 0x11,
+		0xff, 0xff, 0xff, 0x10,
+		0, 0, 0, 1,
+		0, 0, 0, 0,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("proxied encodings = %v, want %v", got, want)
+	}
+}
+
+func TestProxyRFBFramebufferUpdateFiltersCursorRectangles(t *testing.T) {
+	server := bytes.NewBuffer([]byte{
+		0, 0, 2,
+		0, 1, 0, 1, 0, 1, 0, 1, 0xff, 0xff, 0xff, 0x11,
+		0x00, 0x00, 0xff, 0x00, 0x80,
+		0, 2, 0, 2, 0, 2, 0, 1, 0, 0, 0, 0,
+		1, 2, 3, 4, 5, 6, 7, 8,
+	})
+	var client recordingConn
+
+	if err := proxyRFBFramebufferUpdateWithoutCursor(&client, server, cursorPixelFormat); err != nil {
+		t.Fatalf("proxyRFBFramebufferUpdateWithoutCursor returned error: %v", err)
+	}
+
+	got := client.Bytes()
+	want := []byte{
+		0, 0, 0, 1,
+		0, 2, 0, 2, 0, 2, 0, 1, 0, 0, 0, 0,
+		1, 2, 3, 4, 5, 6, 7, 8,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("filtered framebuffer update = %v, want %v", got, want)
+	}
+}
+
+func TestRichCursorMetadataUsesNativeCursorType(t *testing.T) {
+	rect := rfbRectHeader{x: 6, y: 11, width: 13, height: 23, encoding: rfbEncodingCursor}
+	pixels := bytes.Repeat([]byte{0x00, 0x00, 0xff, 0x00}, int(rect.width*rect.height))
+	mask := bytes.Repeat([]byte{0xff, 0xf8}, int(rect.height))
+
+	cursor, err := richCursorMetadata(rect, pixels, mask, cursorPixelFormat)
+	if err != nil {
+		t.Fatalf("richCursorMetadata returned error: %v", err)
+	}
+	if cursor.Type != "cursor" || cursor.Source != "rfb" {
+		t.Fatalf("unexpected cursor metadata type/source: %#v", cursor)
+	}
+	if cursor.Width != 13 || cursor.Height != 23 || cursor.HotX != 6 || cursor.HotY != 11 {
+		t.Fatalf("unexpected cursor geometry: %#v", cursor)
+	}
+	if cursor.Cursor != "text" {
+		t.Fatalf("cursor type = %q, want text", cursor.Cursor)
+	}
+}
+
 func TestLimitJPEGSizeRecompressesOversizedImage(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 1280, 800))
 	for y := 0; y < img.Bounds().Dy(); y++ {
@@ -360,4 +489,36 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+type recordingConn struct {
+	bytes.Buffer
+}
+
+func (*recordingConn) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (*recordingConn) Close() error {
+	return nil
+}
+
+func (*recordingConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (*recordingConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (*recordingConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (*recordingConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (*recordingConn) SetWriteDeadline(_ time.Time) error {
+	return nil
 }

--- a/internal/handlers/display.go
+++ b/internal/handlers/display.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -163,6 +164,8 @@ func (h *ContainerdHandler) HandleDisplayWebRTCOffer(c echo.Context) error {
 		}
 		return echo.NewHTTPError(status, err.Error())
 	}
+
+	h.applyDisplayStyleAsync(c.Request().Context(), botID)
 
 	return c.JSON(http.StatusOK, displayWebRTCOfferResponse{
 		Type:      answer.Type,
@@ -412,6 +415,10 @@ func displayPrepareCommand() string {
 ` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
 MEMOH_DESKTOP_INSTALL
 chmod 0755 /tmp/memoh-desktop-install.sh
+cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
+` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
+MEMOH_DESKTOP_STYLE
+chmod 0755 /tmp/memoh-desktop-style.sh
 ` + displayPrepareMainCommand
 }
 
@@ -420,6 +427,96 @@ func displayPrepareInstallScript() string {
 		return string(data)
 	}
 	return scriptassets.DesktopInstall
+}
+
+func displayPrepareStyleScript() string {
+	if data, err := os.ReadFile("scripts/desktop-style.sh"); err == nil {
+		return string(data)
+	}
+	return scriptassets.DesktopStyle
+}
+
+func displayApplyStyleCommand() string {
+	return `cat >/tmp/memoh-desktop-install.sh <<'MEMOH_DESKTOP_INSTALL'
+` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
+MEMOH_DESKTOP_INSTALL
+chmod 0755 /tmp/memoh-desktop-install.sh
+cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
+` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
+MEMOH_DESKTOP_STYLE
+chmod 0755 /tmp/memoh-desktop-style.sh
+cat >/tmp/memoh-desktop-apply-style.sh <<'MEMOH_DESKTOP_APPLY_STYLE'
+#!/bin/sh
+
+progress() { :; }
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+os_like() {
+  if [ -r /etc/os-release ]; then
+    . /etc/os-release
+    printf '%s %s\n' "${ID:-}" "${ID_LIKE:-}"
+    return
+  fi
+  printf unknown
+}
+is_debian_like() {
+  case " $(os_like) " in
+    *" debian "*|*" ubuntu "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+is_alpine() {
+  case " $(os_like) " in
+    *" alpine "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+. /tmp/memoh-desktop-install.sh
+
+style_lock=/tmp/memoh-desktop-style.lock
+if mkdir "$style_lock" 2>/dev/null; then
+  trap 'rmdir "$style_lock" 2>/dev/null || true' EXIT INT TERM
+else
+  exit 0
+fi
+
+install_style_extras_for_current_os
+/bin/sh /tmp/memoh-desktop-style.sh
+MEMOH_DESKTOP_APPLY_STYLE
+chmod 0755 /tmp/memoh-desktop-apply-style.sh
+/bin/sh /tmp/memoh-desktop-apply-style.sh`
+}
+
+func (h *ContainerdHandler) applyDisplayStyleAsync(ctx context.Context, botID string) {
+	if h == nil || h.manager == nil {
+		return
+	}
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+		defer cancel()
+		client, err := h.manager.MCPClient(runCtx, botID)
+		if err != nil || client == nil {
+			if err != nil && h.logger != nil {
+				h.logger.Warn("display desktop style skipped", slog.String("bot_id", botID), slog.Any("error", err))
+			}
+			return
+		}
+		result, err := client.Exec(runCtx, displayApplyStyleCommand(), "/", 540)
+		if err != nil {
+			if h.logger != nil {
+				h.logger.Warn("display desktop style failed", slog.String("bot_id", botID), slog.Any("error", err))
+			}
+			return
+		}
+		if result != nil && result.ExitCode != 0 && h.logger != nil {
+			h.logger.Warn(
+				"display desktop style exited non-zero",
+				slog.String("bot_id", botID),
+				slog.Int("exit_code", int(result.ExitCode)),
+				slog.String("stderr", strings.TrimSpace(result.Stderr)),
+			)
+		}
+	}()
 }
 
 const displayPrepareMainCommand = `cat >/tmp/memoh-display-prepare.sh <<'MEMOH_DISPLAY_PREPARE'
@@ -501,6 +598,7 @@ is_alpine() {
 }
 RFB_PORT=5999
 XVNC_GEOMETRY="${MEMOH_DISPLAY_GEOMETRY:-1280x960}"
+XVNC_CURSOR_ARG=-nocursor
 X_SOCKET=/tmp/.X11-unix/X99
 X_LOCK=/tmp/.X99-lock
 xvnc_pids() {
@@ -516,6 +614,18 @@ xvnc_pids() {
 }
 xvnc_running() {
   [ -n "$(xvnc_pids)" ]
+}
+xvnc_missing_arg() {
+  required="$1"
+  [ -n "$required" ] || return 1
+  for proc_dir in /proc/[0-9]*; do
+    [ -d "$proc_dir" ] || continue
+    cmdline="$(tr '\000' '\n' <"$proc_dir/cmdline" 2>/dev/null || true)"
+    printf '%s\n' "$cmdline" | grep -Eq '(^|/)Xvnc$' || continue
+    printf '%s\n' "$cmdline" | grep -Fxq ':99' || continue
+    printf '%s\n' "$cmdline" | grep -Fxq -- "$required" || return 0
+  done
+  return 1
 }
 browser_pids() {
   for proc_dir in /proc/[0-9]*; do
@@ -565,6 +675,77 @@ stop_browsers() {
     kill -9 "$pid" 2>/dev/null || true
   done
 }
+process_pids_by_name() {
+  for proc_dir in /proc/[0-9]*; do
+    [ -d "$proc_dir" ] || continue
+    pid="${proc_dir#/proc/}"
+    cmdline="$(tr '\000' '\n' <"$proc_dir/cmdline" 2>/dev/null || true)"
+    found=0
+    old_ifs="$IFS"
+    IFS='
+'
+    for arg in $cmdline; do
+      base="${arg##*/}"
+      for target in "$@"; do
+        [ "$base" = "$target" ] && found=1
+      done
+    done
+    IFS="$old_ifs"
+    [ "$found" = 1 ] && printf '%s\n' "$pid"
+  done
+  return 0
+}
+xfce_session_pids() {
+  process_pids_by_name startxfce4 xfce4-session xfdesktop
+}
+xfwm4_pids() {
+  process_pids_by_name xfwm4
+}
+fallback_wm_pids() {
+  process_pids_by_name twm
+}
+stop_fallback_wm() {
+  pids="$(fallback_wm_pids)"
+  [ -n "$pids" ] || return 0
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  pids="$(fallback_wm_pids)"
+  for pid in $pids; do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+}
+start_xfwm4() {
+  has_cmd xfwm4 || return 1
+  [ -n "$(xfwm4_pids)" ] && return 0
+  stop_fallback_wm
+  nohup xfwm4 --replace >/tmp/memoh-xfwm4.log 2>&1 &
+  return 0
+}
+start_desktop_session() {
+  if has_cmd startxfce4; then
+    if [ -n "$(xfce_session_pids)" ]; then
+      start_xfwm4
+      return 0
+    fi
+    stop_fallback_wm
+    nohup startxfce4 >/tmp/memoh-xfce.log 2>&1 &
+  elif has_cmd xfce4-session; then
+    if [ -n "$(xfce_session_pids)" ]; then
+      start_xfwm4
+      return 0
+    fi
+    stop_fallback_wm
+    nohup xfce4-session >/tmp/memoh-xfce.log 2>&1 &
+  elif has_cmd xfwm4; then
+    start_xfwm4
+  elif [ -n "$(fallback_wm_pids)" ]; then
+    return 0
+  elif [ -x /opt/memoh/toolkit/display/bin/twm ]; then
+    nohup /opt/memoh/toolkit/display/bin/twm >/tmp/memoh-twm.log 2>&1 &
+  fi
+}
 display_socket_ready() {
   xvnc_running && [ -S "$X_SOCKET" ] && awk -v port="$(printf '%04X' "$RFB_PORT")" 'toupper($2) ~ ":" port "$" && $4 == "0A" { found = 1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6 2>/dev/null
 }
@@ -613,6 +794,7 @@ else
     exit 1
   fi
 fi
+install_style_extras_for_current_os
 
 XVNC="$(find_xvnc || true)"
 BROWSER="$(find_browser || true)"
@@ -640,6 +822,12 @@ cleanup_stale_display() {
   rm -f "$X_SOCKET" "$X_LOCK"
 }
 
+if xvnc_missing_arg "$XVNC_CURSOR_ARG"; then
+  progress 76 starting "Restarting VNC display without remote cursor"
+  stop_xvnc
+  cleanup_stale_display
+fi
+
 if ! display_socket_ready; then
   progress 78 starting "Starting VNC display"
   if xvnc_running; then
@@ -648,7 +836,7 @@ if ! display_socket_ready; then
   if ! display_socket_ready; then
     stop_xvnc
     cleanup_stale_display
-    nohup "$XVNC" :99 -geometry "$XVNC_GEOMETRY" -depth 24 -SecurityTypes None -localhost -rfbport "$RFB_PORT" >/tmp/memoh-xvnc.log 2>&1 &
+    nohup "$XVNC" :99 -geometry "$XVNC_GEOMETRY" -depth 24 -SecurityTypes None "$XVNC_CURSOR_ARG" -localhost -rfbport "$RFB_PORT" >/tmp/memoh-xvnc.log 2>&1 &
     wait_i=0
     while [ "$wait_i" -lt 25 ]; do
       display_socket_ready && break
@@ -672,22 +860,15 @@ if command -v fc-cache >/dev/null 2>&1; then
 fi
 if [ -S "$X_SOCKET" ]; then
   if command -v xsetroot >/dev/null 2>&1; then
-    run_quick xsetroot -solid '#315f7d'
+    run_quick xsetroot -solid "${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+    run_quick xsetroot -cursor_name left_ptr
   elif [ -x /opt/memoh/toolkit/display/bin/xsetroot ]; then
-    run_quick /opt/memoh/toolkit/display/bin/xsetroot -solid '#315f7d'
+    run_quick /opt/memoh/toolkit/display/bin/xsetroot -solid "${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+    run_quick /opt/memoh/toolkit/display/bin/xsetroot -cursor_name left_ptr
   fi
 fi
-if ! ps -ef 2>/dev/null | grep -E 'xfce4-session|xfwm4|twm' | grep -v grep >/dev/null 2>&1; then
-  if has_cmd startxfce4; then
-    nohup startxfce4 >/tmp/memoh-xfce.log 2>&1 &
-  elif has_cmd xfce4-session; then
-    nohup xfce4-session >/tmp/memoh-xfce.log 2>&1 &
-  elif has_cmd xfwm4; then
-    nohup xfwm4 >/tmp/memoh-xfwm4.log 2>&1 &
-  elif [ -x /opt/memoh/toolkit/display/bin/twm ]; then
-    nohup /opt/memoh/toolkit/display/bin/twm >/tmp/memoh-twm.log 2>&1 &
-  fi
-fi
+start_desktop_session
+nohup /bin/sh /tmp/memoh-desktop-style.sh >/tmp/memoh-desktop-style.log 2>&1 &
 
 progress 94 browser "Launching browser"
 if ! browser_cdp_running; then

--- a/internal/handlers/display_test.go
+++ b/internal/handlers/display_test.go
@@ -48,11 +48,59 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-install.sh") {
 		t.Fatal("display prepare command must inject the install script")
 	}
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-style.sh") {
+		t.Fatal("display prepare command must inject the desktop style script")
+	}
 	if !strings.Contains(cmd, ". /tmp/memoh-desktop-install.sh") {
 		t.Fatal("display prepare command must source the injected install script")
 	}
 	if !strings.Contains(cmd, "install_debian()") || !strings.Contains(cmd, "install_alpine()") {
 		t.Fatal("injected install script must define Debian and Alpine installers")
+	}
+	if !strings.Contains(cmd, "configure_plank()") || !strings.Contains(cmd, "WhiteSur-Dark") {
+		t.Fatal("injected style script must define macOS-like desktop styling")
+	}
+	if !strings.Contains(cmd, "configure_topbar()") || !strings.Contains(cmd, "windowck-plugin") || !strings.Contains(cmd, "appmenu") {
+		t.Fatal("injected style script must define macOS-like topbar styling")
+	}
+	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
+		t.Fatal("injected style script must use the white Memoh logo for the topbar menu icon")
+	}
+	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
+		t.Fatal("injected style script must remove the default Xfce bottom panel")
+	}
+	if !strings.Contains(cmd, "xsetroot -cursor_name left_ptr") || !strings.Contains(cmd, "nohup xfwm4 --replace") {
+		t.Fatal("injected style script must restore the Xfce window manager and pointer cursor")
+	}
+	if !strings.Contains(cmd, "hide_remote_cursor()") ||
+		!strings.Contains(cmd, `MEMOH_DISPLAY_HIDE_REMOTE_CURSOR:-0`) ||
+		!strings.Contains(cmd, "unclutter") {
+		t.Fatal("injected style script must clean up legacy X cursor hiders while keeping X cursor metadata enabled by default")
+	}
+	if !strings.Contains(cmd, "plugin-ids 101 102 103 104 105 106 107 108") ||
+		!strings.Contains(cmd, "xfconf_reset xfce4-panel /plugins/plugin-109") ||
+		strings.Contains(cmd, "plugin-109 string actions") {
+		t.Fatal("injected style script must omit the Xfce actions menu with logout and power options")
+	}
+	if !strings.Contains(cmd, `write_chromium_wrapper "$browser"`) ||
+		!strings.Contains(cmd, `write_desktop_file "$file" "Chromium" "chromium" "$wrapper"`) ||
+		!strings.Contains(cmd, `--user-data-dir="\$profile"`) ||
+		!strings.Contains(cmd, `rm -f "\$profile"/SingletonLock`) ||
+		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
+		t.Fatal("injected style script must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
+	}
+	if !strings.Contains(cmd, "install_style_extras_for_current_os") {
+		t.Fatal("display prepare must install styling assets even when core display packages already exist")
+	}
+	if !strings.Contains(cmd, "SUDO_USER") || !strings.Contains(cmd, "sudo git unzip bash") {
+		t.Fatal("display prepare must support WhiteSur's installer in non-login root containers")
+	}
+	if !strings.Contains(cmd, "install_debian_cursor_tools()") ||
+		!strings.Contains(cmd, "install_debian_optional unclutter unclutter-xfixes") {
+		t.Fatal("display prepare must install remote cursor hiding tools when available")
+	}
+	if !strings.Contains(cmd, "xfce4-appmenu-plugin") || !strings.Contains(cmd, "xfce4-windowck-plugin") || !strings.Contains(cmd, "appmenu-gtk3-module") {
+		t.Fatal("display prepare must install macOS-like topbar plugins when available")
 	}
 	if strings.Contains(displayPrepareMainCommand, "apt-get install") || strings.Contains(displayPrepareMainCommand, "apk add") {
 		t.Fatal("package installation details should stay in scripts/desktop-install.sh")
@@ -69,13 +117,31 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	if !strings.Contains(displayPrepareMainCommand, "grep -Eq '^--type=' && continue") {
 		t.Fatal("CDP readiness detection must ignore Chromium child processes")
 	}
+	if !strings.Contains(displayPrepareMainCommand, "start_desktop_session()") ||
+		!strings.Contains(displayPrepareMainCommand, "stop_fallback_wm") ||
+		!strings.Contains(displayPrepareMainCommand, "start_xfwm4()") ||
+		!strings.Contains(displayPrepareMainCommand, "process_pids_by_name startxfce4 xfce4-session xfdesktop") ||
+		!strings.Contains(displayPrepareMainCommand, "process_pids_by_name xfwm4") {
+		t.Fatal("display prepare must prefer Xfce over the fallback window manager")
+	}
+	if strings.Contains(displayPrepareMainCommand, "grep -E 'xfce4-session|xfwm4|twm'") {
+		t.Fatal("display prepare must not treat twm as a healthy Xfce desktop session")
+	}
+	if !strings.Contains(displayPrepareMainCommand, "xsetroot -cursor_name left_ptr") {
+		t.Fatal("display prepare must replace the default X root cursor")
+	}
+	if !strings.Contains(displayPrepareMainCommand, "XVNC_CURSOR_ARG=-nocursor") ||
+		!strings.Contains(displayPrepareMainCommand, "xvnc_missing_arg()") ||
+		!strings.Contains(displayPrepareMainCommand, `xvnc_missing_arg "$XVNC_CURSOR_ARG"`) {
+		t.Fatal("display prepare must restart old Xvnc processes without remote cursor hiding")
+	}
 	if !strings.Contains(displayPrepareMainCommand, "SingletonLock") {
 		t.Fatal("display prepare must clean stale Chromium profile locks before starting the browser")
 	}
 	if strings.Contains(displayPrepareMainCommand, "rfbunixpath") || strings.Contains(displayPrepareMainCommand, "RFB_SOCKET") {
 		t.Fatal("display prepare should use loopback TCP VNC instead of a bind-mounted Unix RFB socket")
 	}
-	if !strings.Contains(displayPrepareMainCommand, "-localhost -rfbport \"$RFB_PORT\"") {
+	if !strings.Contains(displayPrepareMainCommand, "\"$XVNC_CURSOR_ARG\" -localhost -rfbport \"$RFB_PORT\"") {
 		t.Fatal("display prepare must keep VNC on container loopback")
 	}
 	if !strings.Contains(displayPrepareMainCommand, `XVNC_GEOMETRY="${MEMOH_DISPLAY_GEOMETRY:-1280x960}"`) {
@@ -83,5 +149,55 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	}
 	if !strings.Contains(displayPrepareMainCommand, `-geometry "$XVNC_GEOMETRY"`) {
 		t.Fatal("display prepare must pass the configured geometry to Xvnc")
+	}
+}
+
+func TestDisplayApplyStyleCommandInjectsStyleScript(t *testing.T) {
+	t.Parallel()
+
+	cmd := displayApplyStyleCommand()
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-install.sh") {
+		t.Fatal("display style command must inject the install script for existing desktops")
+	}
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-style.sh") {
+		t.Fatal("display style command must inject the desktop style script")
+	}
+	if !strings.Contains(cmd, "install_style_extras_for_current_os") {
+		t.Fatal("display style command must install missing macOS styling assets")
+	}
+	if !strings.Contains(cmd, "/bin/sh /tmp/memoh-desktop-style.sh") {
+		t.Fatal("display style command must run the desktop style script")
+	}
+	if !strings.Contains(cmd, "configure_plank()") || !strings.Contains(cmd, "WhiteSur-Dark") {
+		t.Fatal("display style command must include macOS-like desktop styling")
+	}
+	if !strings.Contains(cmd, "configure_topbar()") || !strings.Contains(cmd, "windowck-plugin") || !strings.Contains(cmd, "appmenu") {
+		t.Fatal("display style command must include macOS-like topbar styling")
+	}
+	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
+		t.Fatal("display style command must use the white Memoh logo for the topbar menu icon")
+	}
+	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
+		t.Fatal("display style command must remove the default Xfce bottom panel")
+	}
+	if !strings.Contains(cmd, "xsetroot -cursor_name left_ptr") || !strings.Contains(cmd, "nohup xfwm4 --replace") {
+		t.Fatal("display style command must restore the Xfce window manager and pointer cursor")
+	}
+	if !strings.Contains(cmd, "hide_remote_cursor()") ||
+		!strings.Contains(cmd, `MEMOH_DISPLAY_HIDE_REMOTE_CURSOR:-0`) ||
+		!strings.Contains(cmd, "unclutter") {
+		t.Fatal("display style command must clean up legacy X cursor hiders while keeping X cursor metadata enabled by default")
+	}
+	if !strings.Contains(cmd, "plugin-ids 101 102 103 104 105 106 107 108") ||
+		!strings.Contains(cmd, "xfconf_reset xfce4-panel /plugins/plugin-109") ||
+		strings.Contains(cmd, "plugin-109 string actions") {
+		t.Fatal("display style command must omit the Xfce actions menu with logout and power options")
+	}
+	if !strings.Contains(cmd, `write_chromium_wrapper "$browser"`) ||
+		!strings.Contains(cmd, `write_desktop_file "$file" "Chromium" "chromium" "$wrapper"`) ||
+		!strings.Contains(cmd, `--user-data-dir="\$profile"`) ||
+		!strings.Contains(cmd, `rm -f "\$profile"/SingletonLock`) ||
+		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
+		t.Fatal("display style command must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
 	}
 }

--- a/scripts/desktop-install.sh
+++ b/scripts/desktop-install.sh
@@ -1,19 +1,191 @@
 #!/bin/sh
 
+apt_get() {
+  timeout_seconds="${MEMOH_APT_COMMAND_TIMEOUT:-300}"
+  if has_cmd timeout; then
+    timeout "$timeout_seconds" apt-get \
+      -o "Acquire::Retries=${MEMOH_APT_RETRIES:-2}" \
+      -o "Acquire::Connect::Timeout=${MEMOH_APT_CONNECT_TIMEOUT:-20}" \
+      -o "Acquire::http::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+      -o "Acquire::https::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+      "$@"
+    return $?
+  fi
+  apt-get \
+    -o "Acquire::Retries=${MEMOH_APT_RETRIES:-2}" \
+    -o "Acquire::Connect::Timeout=${MEMOH_APT_CONNECT_TIMEOUT:-20}" \
+    -o "Acquire::http::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+    -o "Acquire::https::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+    "$@"
+}
+
+run_limited() {
+  timeout_seconds="${1:-180}"
+  shift
+  if has_cmd timeout; then
+    timeout "$timeout_seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+install_debian_optional() {
+  optional_packages=""
+  for package in "$@"; do
+    if apt-cache show "$package" >/dev/null 2>&1; then
+      optional_packages="$optional_packages $package"
+    fi
+  done
+  [ -n "$optional_packages" ] || return 0
+  # Optional styling packages should never block display setup.
+  apt_get install -y --no-install-recommends $optional_packages || true
+}
+
+install_alpine_optional() {
+  for package in "$@"; do
+    apk add --no-cache "$package" >/dev/null 2>&1 || true
+  done
+}
+
+install_debian_cursor_tools() {
+  install_debian_optional unclutter unclutter-xfixes
+}
+
+install_alpine_cursor_tools() {
+  install_alpine_optional unclutter unclutter-xfixes
+}
+
+display_style_enabled() {
+  style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+  case "$style" in
+    ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+has_macos_theme_assets() {
+  { [ -d "$HOME/.themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.themes/WhiteSur-Dark" ] || [ -d "$HOME/.themes/WhiteSur-Dark-solid" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-solid" ]; } &&
+    { [ -d "$HOME/.local/share/icons/WhiteSur" ] || [ -d "$HOME/.icons/WhiteSur" ] || [ -d "$HOME/.local/share/icons/WhiteSur-dark" ] || [ -d "$HOME/.icons/WhiteSur-dark" ]; } &&
+    { [ -d "$HOME/.local/share/plank/themes/macOS Dark" ] || [ -d "$HOME/.local/share/plank/themes/Big Sur Dark" ]; } &&
+    find "$HOME/.local/share/backgrounds/WhiteSur" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -q .
+}
+
+clone_or_update_theme_repo() {
+  url="$1"
+  dest="$2"
+  [ -n "$url" ] && [ -n "$dest" ] || return 1
+  if [ -d "$dest/.git" ]; then
+    run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git -C "$dest" fetch --depth=1 origin >/dev/null 2>&1 || return 1
+    run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git -C "$dest" reset --hard origin/HEAD >/dev/null 2>&1 || return 1
+    return 0
+  fi
+  rm -rf "$dest"
+  run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git clone --depth=1 "$url" "$dest" >/dev/null 2>&1
+}
+
+install_macos_theme_assets() {
+  display_style_enabled || return 0
+  has_macos_theme_assets && return 0
+  has_cmd git || return 0
+  has_cmd bash || return 0
+
+  theme_cache="${XDG_CACHE_HOME:-$HOME/.cache}/memoh-display-themes"
+  mkdir -p "$theme_cache" "$HOME/.themes" "$HOME/.icons" "$HOME/.local/share/icons" "$HOME/.local/share/plank/themes" "$HOME/.local/share/backgrounds/WhiteSur"
+
+  progress 58 desktop "Installing macOS desktop theme"
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-gtk-theme.git "$theme_cache/WhiteSur-gtk-theme"; then
+    (
+      cd "$theme_cache/WhiteSur-gtk-theme"
+      export SUDO_USER="${SUDO_USER:-root}"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-240}" ./install.sh \
+        -d "$HOME/.themes" \
+        -n WhiteSur \
+        -c dark \
+        -o normal \
+        -t default \
+        -a alt \
+        -m \
+        --silent-mode
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-icon-theme.git "$theme_cache/WhiteSur-icon-theme"; then
+    (
+      cd "$theme_cache/WhiteSur-icon-theme"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-180}" ./install.sh \
+        -d "$HOME/.local/share/icons" \
+        -n WhiteSur \
+        -t default \
+        -a
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-cursors.git "$theme_cache/WhiteSur-cursors"; then
+    (
+      cd "$theme_cache/WhiteSur-cursors"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-120}" ./install.sh
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/x64Bits/plank-themes.git "$theme_cache/plank-themes"; then
+    find "$theme_cache/plank-themes" -mindepth 1 -maxdepth 1 -type d ! -name .git -exec cp -a {} "$HOME/.local/share/plank/themes/" \; 2>/dev/null || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-wallpapers.git "$theme_cache/WhiteSur-wallpapers"; then
+    find "$theme_cache/WhiteSur-wallpapers" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) -exec cp -a {} "$HOME/.local/share/backgrounds/WhiteSur/" \; 2>/dev/null || true
+  fi
+}
+
+install_debian_style_extras() {
+  display_style_enabled || return 0
+  if [ "${MEMOH_APT_INDEX_UPDATED:-0}" != "1" ]; then
+    apt_get update && MEMOH_APT_INDEX_UPDATED=1 || true
+  fi
+  install_debian_cursor_tools
+  has_macos_theme_assets && return 0
+  progress 54 desktop "Installing macOS desktop theme dependencies"
+  install_debian_optional sudo git unzip bash sassc libglib2.0-bin libglib2.0-dev-bin libglib2.0-dev libxml2-utils gtk2-engines-murrine gtk2-engines-pixbuf plank papirus-icon-theme arc-theme fonts-inter gnome-themes-extra bibata-cursor-theme xfce4-appmenu-plugin xfce4-windowck-plugin appmenu-gtk2-module appmenu-gtk3-module appmenu-registrar
+  install_macos_theme_assets
+}
+
+install_alpine_style_extras() {
+  display_style_enabled || return 0
+  install_alpine_cursor_tools
+  has_macos_theme_assets && return 0
+  install_alpine_optional sudo git unzip bash sassc glib-dev libxml2-utils plank papirus-icon-theme arc-theme font-inter
+  install_macos_theme_assets
+}
+
+install_style_extras_for_current_os() {
+  display_style_enabled || return 0
+  if is_debian_like; then
+    install_debian_style_extras
+  elif is_alpine; then
+    install_alpine_style_extras
+  else
+    install_macos_theme_assets
+  fi
+}
+
 install_debian() {
   has_cmd apt-get || { echo "This image looks Debian-like but apt-get is unavailable. Install the Memoh workspace toolkit or use a Debian/Alpine image." >&2; exit 1; }
   export DEBIAN_FRONTEND=noninteractive
+  export APT_LISTCHANGES_FRONTEND=none
   progress 18 system "Detected Debian workspace"
   progress 24 installing "Updating package index"
-  apt-get update
+  apt_get update
+  MEMOH_APT_INDEX_UPDATED=1
   if ! has_cmd apt-extracttemplates; then
-    apt-get install -y --no-install-recommends apt-utils
+    apt_get install -y --no-install-recommends apt-utils
   fi
   progress 42 installing "Installing VNC, desktop, accessibility, and CJK fonts"
-  apt-get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core
+  apt_get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core
+  install_debian_cursor_tools
+  install_debian_style_extras
   if ! find_browser >/dev/null 2>&1; then
     progress 66 browser "Installing browser"
-    if apt-get install -y --no-install-recommends chromium || apt-get install -y --no-install-recommends chromium-browser; then
+    if apt_get install -y --no-install-recommends chromium || apt_get install -y --no-install-recommends chromium-browser; then
       return 0
     fi
     arch="$(dpkg --print-architecture)"
@@ -22,8 +194,8 @@ install_debian() {
     rm -f /etc/apt/keyrings/google-chrome.gpg
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --batch --yes --dearmor -o /etc/apt/keyrings/google-chrome.gpg
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >/etc/apt/sources.list.d/google-chrome.list
-    apt-get update
-    apt-get install -y --no-install-recommends google-chrome-stable
+    apt_get update
+    apt_get install -y --no-install-recommends google-chrome-stable
   fi
 }
 
@@ -32,4 +204,6 @@ install_alpine() {
   progress 18 system "Detected Alpine workspace"
   progress 42 installing "Installing VNC, desktop, browser, accessibility, and CJK fonts"
   apk add --no-cache tigervnc xkeyboard-config xfce4 xfce4-terminal dbus-x11 xterm chromium fontconfig ttf-dejavu font-noto-cjk font-noto-emoji at-spi2-core
+  install_alpine_cursor_tools
+  install_alpine_style_extras
 }

--- a/scripts/desktop-style.sh
+++ b/scripts/desktop-style.sh
@@ -1,0 +1,636 @@
+#!/bin/sh
+
+style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+case "$style" in
+  ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE)
+    exit 0
+    ;;
+esac
+
+DISPLAY="${DISPLAY:-:99}"
+GTK_A11Y="${GTK_A11Y:-1}"
+export DISPLAY GTK_A11Y
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+theme_path() {
+  name="$1"
+  for dir in "$HOME/.themes" "$HOME/.local/share/themes" /usr/local/share/themes /usr/share/themes; do
+    [ -d "$dir/$name" ] || continue
+    printf '%s\n' "$dir/$name"
+    return 0
+  done
+  return 1
+}
+
+icon_theme_path() {
+  name="$1"
+  for dir in "$HOME/.icons" "$HOME/.local/share/icons" /usr/local/share/icons /usr/share/icons; do
+    [ -d "$dir/$name" ] || continue
+    printf '%s\n' "$dir/$name"
+    return 0
+  done
+  return 1
+}
+
+first_theme() {
+  for name in "$@"; do
+    theme_path "$name" >/dev/null 2>&1 || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_xfwm_theme() {
+  for name in "$@"; do
+    path="$(theme_path "$name" 2>/dev/null || true)"
+    [ -n "$path" ] && [ -d "$path/xfwm4" ] || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_icon_theme() {
+  for name in "$@"; do
+    icon_theme_path "$name" >/dev/null 2>&1 || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_plank_theme() {
+  for name in "$@"; do
+    for dir in "$HOME/.local/share/plank/themes" "$HOME/.config/plank/themes" /usr/local/share/plank/themes /usr/share/plank/themes; do
+      [ -d "$dir/$name" ] || continue
+      printf '%s\n' "$name"
+      return 0
+    done
+  done
+  return 1
+}
+
+font_available() {
+  has_cmd fc-match || return 1
+  fc-match "$1" 2>/dev/null | grep -qi "$1"
+}
+
+first_font() {
+  for name in "$@"; do
+    if font_available "$name"; then
+      printf '%s 10\n' "$name"
+      return 0
+    fi
+  done
+  printf 'Sans 10\n'
+}
+
+run_xsetroot() {
+  color="${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+  if has_cmd xsetroot; then
+    xsetroot -solid "$color" >/dev/null 2>&1 || true
+    xsetroot -cursor_name left_ptr >/dev/null 2>&1 || true
+  elif [ -x /opt/memoh/toolkit/display/bin/xsetroot ]; then
+    /opt/memoh/toolkit/display/bin/xsetroot -solid "$color" >/dev/null 2>&1 || true
+    /opt/memoh/toolkit/display/bin/xsetroot -cursor_name left_ptr >/dev/null 2>&1 || true
+  fi
+}
+
+transparent_root_cursor() {
+  cursor_dir="$HOME/.cache/memoh-display-cursor"
+  cursor_bitmap="$cursor_dir/empty.xbm"
+  mkdir -p "$cursor_dir"
+  cat >"$cursor_bitmap" <<'EOF'
+#define empty_width 1
+#define empty_height 1
+static unsigned char empty_bits[] = { 0x00 };
+EOF
+  if has_cmd xsetroot; then
+    xsetroot -cursor "$cursor_bitmap" "$cursor_bitmap" >/dev/null 2>&1 || true
+  elif [ -x /opt/memoh/toolkit/display/bin/xsetroot ]; then
+    /opt/memoh/toolkit/display/bin/xsetroot -cursor "$cursor_bitmap" "$cursor_bitmap" >/dev/null 2>&1 || true
+  fi
+}
+
+hide_remote_cursor() {
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /](unclutter|unclutter-xfixes)($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  case "${MEMOH_DISPLAY_HIDE_REMOTE_CURSOR:-0}" in
+    1|true|True|TRUE|on|On|ON|yes|Yes|YES) ;;
+    *) return 0 ;;
+  esac
+  transparent_root_cursor
+
+  cursor_hider="$(command -v unclutter 2>/dev/null || command -v unclutter-xfixes 2>/dev/null || true)"
+  [ -n "$cursor_hider" ] || return 0
+
+  if "$cursor_hider" --help 2>&1 | grep -q -- '--timeout'; then
+    nohup "$cursor_hider" --timeout 0 --jitter 0 --ignore-scrolling --start-hidden >/tmp/memoh-unclutter.log 2>&1 &
+  else
+    nohup "$cursor_hider" -idle 0 -root >/tmp/memoh-unclutter.log 2>&1 &
+  fi
+}
+
+wait_for_xfconf() {
+  has_cmd xfconf-query || return 1
+  i=0
+  while [ "$i" -lt 24 ]; do
+    xfconf-query -c xsettings -l >/dev/null 2>&1 && return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+xfconf_set() {
+  channel="$1"
+  property="$2"
+  value_type="$3"
+  value="$4"
+  xfconf-query -c "$channel" -p "$property" -s "$value" >/dev/null 2>&1 && return 0
+  xfconf-query -c "$channel" -p "$property" -n -t "$value_type" -s "$value" >/dev/null 2>&1 || true
+}
+
+xfconf_reset() {
+  channel="$1"
+  property="$2"
+  xfconf-query -c "$channel" -p "$property" -r -R >/dev/null 2>&1 || true
+}
+
+xfconf_set_int_array() {
+  channel="$1"
+  property="$2"
+  shift 2
+  xfconf_reset "$channel" "$property"
+  command="xfconf-query -c \"$channel\" -p \"$property\" -n -a"
+  for value in "$@"; do
+    command="$command -t int -s \"$value\""
+  done
+  eval "$command" >/dev/null 2>&1 || true
+}
+
+xfconf_replace_int_array() {
+  channel="$1"
+  property="$2"
+  shift 2
+  command="xfconf-query -c \"$channel\" -p \"$property\" -a"
+  for value in "$@"; do
+    command="$command -t int -s \"$value\""
+  done
+  eval "$command" >/dev/null 2>&1 && return 0
+  xfconf_set_int_array "$channel" "$property" "$@"
+}
+
+panel_plugin_available() {
+  [ -f "/usr/share/xfce4/panel/plugins/$1.desktop" ]
+}
+
+start_appmenu_registrar() {
+  registrar="$(command -v appmenu-registrar 2>/dev/null || true)"
+  [ -n "$registrar" ] || registrar="/usr/libexec/vala-panel/appmenu-registrar"
+  [ -x "$registrar" ] || return 0
+  ps -ef 2>/dev/null | grep -E '[ /]appmenu-registrar($| )' | grep -v grep >/dev/null 2>&1 && return 0
+  nohup "$registrar" >/tmp/memoh-appmenu-registrar.log 2>&1 &
+}
+
+install_topbar_menu_icon() {
+  icon_dir="$HOME/.local/share/icons/hicolor/scalable/apps"
+  mkdir -p "$icon_dir"
+  cat >"$icon_dir/memoh-logo-white.svg" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 454.08 399.96">
+  <path fill="#f5f5f7" d="M249.55,307.07c-63.11,20.61-155.69,25.5-182.38,6.68-34.57-24.37-19.05-137.12,7.42-173.36,32.66-44.71,114.75-54.31,152.82-55.97,44.88-1.96,50.44-30.49,50.44-30.49-15.46,14.29-17.33,16.35-64.32,18.23-33.97,1.36-87.49,3.88-130.26,27.67l-2.72-56.39c-.4-8.24-7.4-14.59-15.63-14.2-8.24.4-14.59,7.4-14.2,15.63l3.68,76.38c-4.98,4.93-9.62,10.35-13.82,16.35C3.89,189.99-1.8,249.58.42,297.41c.81,17.44,2.49,31.96,6.82,44.21,0,0,0,.01.01.03.6,1.19,22.35,43.42,104.6,34.64,83.45-8.9,172.88-57.76,208.36-119.64-13.8,23.41-35.2,38.86-70.67,50.43Z"/>
+  <path fill="#f5f5f7" d="M429.45,110.2c-23.96-30.8-56.39-44.77-79.74-51.1l13.35-39.38c2.65-7.81-1.54-16.29-9.35-18.93h0c-7.81-2.65-16.29,1.54-18.93,9.35l-14.85,43.78c-8.49,25.06-53.64,36.67-53.64,36.67,0,0,11.72-1.65,40.22,7.62,28.5,9.29,34.21,37.45,31.07,93.85-1.36,24.71-6.6,46.33-17.36,64.57-35.48,61.88-124.9,110.75-208.36,119.64-82.26,8.78-104-33.45-104.6-34.64,2.24,6.32,5.18,12.03,9.07,17.2,13.1,17.4,32.05,24.78,47.08,28.94,81.61,22.55,233.81,7.12,244.66,5.97,24.35-2.57,51.97-5.92,79.03-25.32,5.4-3.87,22.47-18.21,39.94-46.21,25.47-40.82,44.25-158.22,2.42-212.01Z"/>
+  <path fill="#f5f5f7" d="M163.41,238.79c.37.09,2.75.63,6.52,1.04,11.65,1.27,36.5,1.31,55.49-17.2,3.11-3.04,3.18-8.02.14-11.13-3.04-3.11-8.02-3.18-11.13-.14-18.85,18.38-47.15,12.17-47.44,12.11-4.23-.99-8.45,1.64-9.44,5.86-1,4.23,1.63,8.47,5.86,9.47Z"/>
+  <path fill="#f5f5f7" d="M118.67,218.27c12.32-.73,22.48-9.91,24.45-22.09l2-12.31c1.56-9.59-6.18-18.15-15.87-17.57h0c-12.32.73-22.48,9.91-24.45,22.09l-2,12.31c-1.56,9.59,6.18,18.15,15.87,17.57Z"/>
+  <path fill="#f5f5f7" d="M249.71,207.88h0c12.32-.73,22.48-9.91,24.45-22.09l2-12.31c1.56-9.59-6.18-18.15-15.87-17.57h0c-12.32.73-22.48,9.91-24.45,22.09l-2,12.31c-1.56,9.59,6.18,18.15,15.87,17.57Z"/>
+</svg>
+EOF
+  if has_cmd gtk-update-icon-cache; then
+    gtk-update-icon-cache -q "$HOME/.local/share/icons/hicolor" >/dev/null 2>&1 || true
+  fi
+}
+
+write_panel_css() {
+  mkdir -p "$HOME/.config/gtk-3.0"
+  cat >"$HOME/.config/gtk-3.0/gtk.css" <<'EOF'
+#XfcePanelWindow,
+#XfcePanelWindow.background,
+.xfce4-panel {
+  background-color: rgba(28, 31, 36, 0.92);
+  color: #f5f5f7;
+  font-weight: 600;
+}
+
+#XfcePanelWindow button,
+#XfcePanelWindow .flat,
+#XfcePanelWindow menuitem {
+  min-height: 22px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #f5f5f7;
+  box-shadow: none;
+}
+
+#XfcePanelWindow button:hover {
+  background-color: rgba(255, 255, 255, 0.14);
+}
+EOF
+}
+
+write_gtk_settings() {
+  theme="$1"
+  icons="$2"
+  cursor="$3"
+  font="$4"
+
+  mkdir -p "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"
+  cat >"$HOME/.config/gtk-3.0/settings.ini" <<EOF
+[Settings]
+gtk-theme-name=${theme}
+gtk-icon-theme-name=${icons}
+gtk-cursor-theme-name=${cursor}
+gtk-font-name=${font}
+gtk-application-prefer-dark-theme=1
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-button-images=1
+gtk-menu-images=1
+EOF
+  cp "$HOME/.config/gtk-3.0/settings.ini" "$HOME/.config/gtk-4.0/settings.ini" 2>/dev/null || true
+}
+
+configure_topbar() {
+  wait_for_xfconf || return 0
+
+  appmenu_plugin="separator"
+  panel_title_plugin="separator"
+  if panel_plugin_available appmenu; then
+    appmenu_plugin="appmenu"
+    xfconf_set xsettings /Gtk/ShellShowsMenubar bool true
+    xfconf_set xsettings /Gtk/ShellShowsAppmenu bool true
+    xfconf_set xsettings /Gtk/Modules string "appmenu-gtk-module"
+    start_appmenu_registrar
+  fi
+  if panel_plugin_available windowck-plugin; then
+    panel_title_plugin="windowck-plugin"
+  elif panel_plugin_available windowmenu; then
+    panel_title_plugin="windowmenu"
+  fi
+
+  xfconf_replace_int_array xfce4-panel /panels 1
+  xfconf_reset xfce4-panel /panels/panel-2
+  xfconf_set_int_array xfce4-panel /panels/panel-1/plugin-ids 101 102 103 104 105 106 107 108
+  xfconf_reset xfce4-panel /plugins
+  xfconf_reset xfce4-panel /plugins/plugin-109
+
+  xfconf_set xfce4-panel /plugins/plugin-101 string applicationsmenu
+  install_topbar_menu_icon
+  xfconf_set xfce4-panel /plugins/plugin-101/show-button-title bool false
+  xfconf_set xfce4-panel /plugins/plugin-101/button-icon string "memoh-logo-white"
+  xfconf_set xfce4-panel /plugins/plugin-101/show-menu-icons bool true
+  xfconf_set xfce4-panel /plugins/plugin-101/show-generic-names bool false
+  xfconf_set xfce4-panel /plugins/plugin-101/small bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-102 string "$panel_title_plugin"
+  xfconf_set xfce4-panel /plugins/plugin-102/active_window bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/only_maximized bool false
+  xfconf_set xfce4-panel /plugins/plugin-102/show_on_desktop bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/sync_wm_font bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/full_name bool false
+  xfconf_set xfce4-panel /plugins/plugin-102/title_padding int 6
+  xfconf_set xfce4-panel /plugins/plugin-102/title_size int 28
+  xfconf_set xfce4-panel /plugins/plugin-102/title_alignment int 0
+
+  xfconf_set xfce4-panel /plugins/plugin-103 string "$appmenu_plugin"
+  xfconf_set xfce4-panel /plugins/plugin-103/compact-mode bool false
+  xfconf_set xfce4-panel /plugins/plugin-103/bold-application-name bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-104 string separator
+  xfconf_set xfce4-panel /plugins/plugin-104/expand bool true
+  xfconf_set xfce4-panel /plugins/plugin-104/style int 0
+
+  xfconf_set xfce4-panel /plugins/plugin-105 string systray
+  xfconf_set xfce4-panel /plugins/plugin-105/square-icons bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-106 string pulseaudio
+  xfconf_set xfce4-panel /plugins/plugin-106/enable-keyboard-shortcuts bool true
+  xfconf_set xfce4-panel /plugins/plugin-106/show-notifications bool false
+
+  xfconf_set xfce4-panel /plugins/plugin-107 string notification-plugin
+
+  xfconf_set xfce4-panel /plugins/plugin-108 string clock
+  xfconf_set xfce4-panel /plugins/plugin-108/mode int 2
+  xfconf_set xfce4-panel /plugins/plugin-108/digital-layout int 3
+  xfconf_set xfce4-panel /plugins/plugin-108/digital-time-format string "%a %b %-d  %H:%M"
+  xfconf_set xfce4-panel /plugins/plugin-108/tooltip-format string "%A, %B %-d, %Y"
+}
+
+first_wallpaper() {
+  for file in \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Monterey-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Ventura-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Sonoma-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur-light.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Monterey.jpg"; do
+    [ -f "$file" ] || continue
+    printf '%s\n' "$file"
+    return 0
+  done
+
+  for dir in \
+    "$HOME/.local/share/backgrounds/WhiteSur" \
+    "$HOME/.local/share/backgrounds/whitesur" \
+    "$HOME/.local/share/backgrounds" \
+    /usr/local/share/backgrounds \
+    /usr/share/backgrounds; do
+    [ -d "$dir" ] || continue
+    found="$(find "$dir" -maxdepth 2 -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -Ei 'WhiteSur|Big[ -]?Sur|Monterey|Ventura|macOS|Mojave' | sort | head -n 1 || true)"
+    [ -n "$found" ] && { printf '%s\n' "$found"; return 0; }
+  done
+  return 1
+}
+
+configure_wallpaper() {
+  wallpaper="$(first_wallpaper 2>/dev/null || true)"
+  [ -n "$wallpaper" ] || return 0
+  wait_for_xfconf || return 0
+
+  props="$(xfconf-query -c xfce4-desktop -l 2>/dev/null | grep '/last-image$' || true)"
+  if [ -z "$props" ]; then
+    props="/backdrop/screen0/monitor0/workspace0/last-image
+/backdrop/screen0/monitorVNC-0/workspace0/last-image
+/backdrop/screen0/monitorVirtual1/workspace0/last-image
+/backdrop/screen0/monitordefault/workspace0/last-image"
+  fi
+
+  printf '%s\n' "$props" | while IFS= read -r prop; do
+    [ -n "$prop" ] || continue
+    base="${prop%/last-image}"
+    xfconf_set xfce4-desktop "$prop" string "$wallpaper"
+    xfconf_set xfce4-desktop "$base/image-style" int 5
+    xfconf_set xfce4-desktop "$base/color-style" int 0
+  done
+}
+
+configure_xfce() {
+  wait_for_xfconf || return 0
+
+  gtk_theme="${MEMOH_DISPLAY_GTK_THEME:-$(first_theme WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
+  xfwm_theme="${MEMOH_DISPLAY_XFWM_THEME:-$(first_xfwm_theme "$gtk_theme" WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
+  icons="${MEMOH_DISPLAY_ICON_THEME:-$(first_icon_theme WhiteSur-dark WhiteSur-Dark WhiteSur WhiteSur-light WhiteSur-Light Cupertino McMojave-circle-dark McMojave-circle Papirus-Dark Papirus Adwaita 2>/dev/null || true)}"
+  cursor="${MEMOH_DISPLAY_CURSOR_THEME:-$(first_icon_theme WhiteSur-cursors WhiteSur Bibata-Modern-Classic Bibata-Modern-Ice Adwaita 2>/dev/null || true)}"
+  font="$(first_font Inter 'SF Pro Display' 'Noto Sans' Cantarell Sans)"
+
+  [ -n "$gtk_theme" ] && xfconf_set xsettings /Net/ThemeName string "$gtk_theme"
+  [ -n "$xfwm_theme" ] && xfconf_set xfwm4 /general/theme string "$xfwm_theme"
+  [ -n "$icons" ] && xfconf_set xsettings /Net/IconThemeName string "$icons"
+  [ -n "$cursor" ] && xfconf_set xsettings /Gtk/CursorThemeName string "$cursor"
+
+  xfconf_set xsettings /Gtk/FontName string "$font"
+  xfconf_set xsettings /Gtk/MonospaceFontName string "Monospace 10"
+  xfconf_set xsettings /Gtk/ToolbarStyle string "icons"
+  xfconf_set xsettings /Gtk/MenuImages bool true
+  xfconf_set xsettings /Gtk/ButtonImages bool true
+  [ -n "$gtk_theme" ] && [ -n "$icons" ] && [ -n "$cursor" ] && write_gtk_settings "$gtk_theme" "$icons" "$cursor" "$font"
+  write_panel_css
+
+  # macOS order: close, minimize, maximize on the left; the WhiteSur xfwm4
+  # assets render these as traffic-light buttons.
+  xfconf_set xfwm4 /general/button_layout string "CHM|"
+  xfconf_set xfwm4 /general/title_alignment string "center"
+  xfconf_set xfwm4 /general/workspace_count int 1
+  xfconf_set xfwm4 /general/use_compositing bool true
+  xfconf_set xfwm4 /general/frame_opacity int 100
+  xfconf_set xfwm4 /general/inactive_opacity int 94
+  xfconf_set xfwm4 /general/title_font string "$font"
+
+  xfconf_set xfce4-desktop /desktop-icons/style int 0
+
+  xfconf_set xfce4-panel /panels/panel-1/mode int 0
+  xfconf_set xfce4-panel /panels/panel-1/position string "p=6;x=0;y=0"
+  xfconf_set xfce4-panel /panels/panel-1/position-locked bool true
+  xfconf_set xfce4-panel /panels/panel-1/size int 26
+  xfconf_set xfce4-panel /panels/panel-1/length int 100
+  xfconf_set xfce4-panel /panels/panel-1/length-adjust bool false
+  xfconf_set xfce4-panel /panels/panel-1/autohide-behavior int 0
+  configure_topbar
+}
+
+write_desktop_file() {
+  file="$1"
+  name="$2"
+  icon="$3"
+  exec_cmd="$4"
+  [ -n "$exec_cmd" ] || return 1
+  mkdir -p "$(dirname "$file")"
+  cat >"$file" <<EOF
+[Desktop Entry]
+Type=Application
+Name=${name}
+Icon=${icon}
+Exec=${exec_cmd}
+Terminal=false
+Categories=Utility;
+EOF
+}
+
+first_existing_file() {
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    printf '%s\n' "$file"
+    return 0
+  done
+  return 1
+}
+
+write_chromium_wrapper() {
+  browser="$1"
+  [ -n "$browser" ] || return 1
+
+  wrapper="$HOME/.local/bin/memoh-chromium"
+  mkdir -p "$(dirname "$wrapper")"
+  cat >"$wrapper" <<EOF
+#!/bin/sh
+browser="${browser}"
+profile="\${MEMOH_DISPLAY_CHROMIUM_PROFILE:-/tmp/memoh-display-browser}"
+
+if [ "\$#" -eq 0 ]; then
+  set -- about:blank
+fi
+
+mkdir -p "\$profile"
+if ! ps -ef 2>/dev/null | grep -F -- "--user-data-dir=\$profile" | grep -v grep >/dev/null 2>&1; then
+  rm -f "\$profile"/SingletonLock "\$profile"/SingletonSocket "\$profile"/SingletonCookie
+fi
+
+exec "\$browser" \\
+  --no-sandbox \\
+  --disable-dev-shm-usage \\
+  --disable-gpu \\
+  --no-first-run \\
+  --no-default-browser-check \\
+  --force-renderer-accessibility \\
+  --remote-debugging-address=127.0.0.1 \\
+  --remote-debugging-port=9222 \\
+  --remote-allow-origins='*' \\
+  --user-data-dir="\$profile" \\
+  "\$@"
+EOF
+  chmod 0755 "$wrapper" 2>/dev/null || true
+  printf '%s\n' "$wrapper"
+}
+
+browser_desktop_file() {
+  browser="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || true)"
+  if [ -n "$browser" ]; then
+    wrapper="$(write_chromium_wrapper "$browser" 2>/dev/null || true)"
+    [ -n "$wrapper" ] || wrapper="$browser"
+    file="$HOME/.local/share/applications/memoh-chromium.desktop"
+    write_desktop_file "$file" "Chromium" "chromium" "$wrapper"
+    printf '%s\n' "$file"
+    return 0
+  fi
+
+  first_existing_file \
+    /usr/share/applications/chromium.desktop \
+    /usr/share/applications/chromium-browser.desktop \
+    /usr/local/share/applications/chromium.desktop \
+    /usr/local/share/applications/chromium-browser.desktop
+}
+
+terminal_desktop_file() {
+  first_existing_file \
+    /usr/share/applications/xfce4-terminal.desktop \
+    /usr/share/applications/org.xfce.terminal.desktop \
+    /usr/share/applications/debian-xterm.desktop \
+    /usr/local/share/applications/xfce4-terminal.desktop && return 0
+
+  terminal="$(command -v xfce4-terminal 2>/dev/null || command -v xterm 2>/dev/null || true)"
+  [ -n "$terminal" ] || return 1
+  file="$HOME/.local/share/applications/memoh-terminal.desktop"
+  write_desktop_file "$file" "Terminal" "utilities-terminal" "$terminal"
+  printf '%s\n' "$file"
+}
+
+files_desktop_file() {
+  first_existing_file \
+    /usr/share/applications/thunar.desktop \
+    /usr/share/applications/org.xfce.Thunar.desktop \
+    /usr/local/share/applications/thunar.desktop && return 0
+  return 1
+}
+
+write_dockitem() {
+  name="$1"
+  launcher="$2"
+  [ -n "$launcher" ] && [ -f "$launcher" ] || return 0
+  mkdir -p "$HOME/.config/plank/dock1/launchers"
+  cat >"$HOME/.config/plank/dock1/launchers/$name.dockitem" <<EOF
+[PlankDockItemPreferences]
+Launcher=file://${launcher}
+EOF
+}
+
+gsettings_set_plank() {
+  has_cmd gsettings || return 0
+  key="$1"
+  shift
+  gsettings set net.launchpad.plank.dock.settings:/net/launchpad/plank/docks/dock1/ "$key" "$@" >/dev/null 2>&1 || true
+}
+
+configure_plank() {
+  has_cmd plank || return 0
+
+  dock_theme="${MEMOH_DISPLAY_DOCK_THEME:-$(first_plank_theme 'macOS Dark' 'Big Sur Dark' 'Mojave Dark' 'macOS Night Owl' 'macOS Light' 'Big Sur Light' Default 2>/dev/null || true)}"
+  [ -n "$dock_theme" ] || dock_theme="Default"
+
+  browser_file="$(browser_desktop_file 2>/dev/null || true)"
+  terminal_file="$(terminal_desktop_file 2>/dev/null || true)"
+  files_file="$(files_desktop_file 2>/dev/null || true)"
+
+  rm -rf "$HOME/.config/plank/dock1/launchers"
+  write_dockitem 01-browser "$browser_file"
+  write_dockitem 02-terminal "$terminal_file"
+  write_dockitem 03-files "$files_file"
+
+  mkdir -p "$HOME/.config/plank/dock1"
+  cat >"$HOME/.config/plank/dock1/settings" <<EOF
+[PlankDockPreferences]
+CurrentWorkspaceOnly=false
+IconSize=56
+HideMode=1
+UnhideDelay=0
+Monitor=
+DockItems=01-browser.dockitem;02-terminal.dockitem;03-files.dockitem;
+Position=3
+Offset=0
+Theme=${dock_theme}
+Alignment=3
+ItemsAlignment=3
+LockItems=false
+PressureReveal=false
+PinnedOnly=false
+ZoomEnabled=true
+ZoomPercent=150
+EOF
+
+  gsettings_set_plank theme "$dock_theme"
+  gsettings_set_plank icon-size 56
+  gsettings_set_plank position "'bottom'"
+  gsettings_set_plank alignment "'center'"
+  gsettings_set_plank items-alignment "'center'"
+  gsettings_set_plank hide-mode "'intelligent'"
+  gsettings_set_plank zoom-enabled true
+  gsettings_set_plank zoom-percent 150
+}
+
+restart_plank() {
+  has_cmd plank || return 0
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]plank($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  [ -n "$pids" ] && sleep 1
+  nohup plank >/tmp/memoh-plank.log 2>&1 &
+}
+
+restart_xfce_panel() {
+  has_cmd xfce4-panel || return 0
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]xfce4-panel($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  [ -n "$pids" ] && sleep 1
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]xfce4-panel($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  nohup xfce4-panel >/tmp/memoh-xfce-panel.log 2>&1 &
+}
+
+reload_xfce_components() {
+  if has_cmd xfwm4; then
+    nohup xfwm4 --replace >/tmp/memoh-xfwm4-replace.log 2>&1 &
+  fi
+  restart_xfce_panel
+}
+
+run_xsetroot
+hide_remote_cursor
+configure_xfce
+configure_wallpaper
+configure_plank
+restart_plank
+reload_xfce_components
+hide_remote_cursor
+
+exit 0

--- a/scripts/embed.go
+++ b/scripts/embed.go
@@ -6,3 +6,8 @@ import _ "embed"
 //
 //go:embed desktop-install.sh
 var DesktopInstall string
+
+// DesktopStyle is the fallback desktop styling script bundled into the binary.
+//
+//go:embed desktop-style.sh
+var DesktopStyle string


### PR DESCRIPTION
## Summary

- add a bundled desktop styling script for macOS-like XFCE sessions, including top bar, Dock/Plank, theme, icon, wallpaper, and launcher defaults
- make Xvnc hide the remote cursor at the source with `-nocursor` and restart old display servers that lack the flag
- keep the browser/system cursor native while carrying lightweight cursor metadata over the display data channel
- improve desktop session recovery so XFCE does not fall back to twm after logout/session loss

## Root Cause

- desktop preparation did not apply the full styling path consistently across new and existing bot workspaces
- hiding cursor state was split between the remote X server and frontend CSS, which could accidentally expose the remote cursor or hide/replace the local system cursor
- stale or partial desktop sessions could survive without a healthy XFCE session/window manager

## Validation

- `go test ./internal/display ./cmd/bridge ./internal/handlers`
- `pnpm exec eslint apps/web/src/pages/home/components/display-pane.vue`
- `sh -n scripts/desktop-style.sh && sh -n scripts/desktop-install.sh && git diff --check && git diff --cached --check`
- pre-commit hook: full Go test and Go lint passed during commit
